### PR TITLE
[Build] Upgrade Apache parent pom version to 23

### DIFF
--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
-    <version>18</version>
+    <version>23</version>
   </parent>
 
   <groupId>org.apache.pulsar</groupId>
@@ -33,6 +33,11 @@
   <version>2.8.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Pulsar Build Tools</name>
+
+  <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
 
   <dependencies>
     <dependency>
@@ -72,13 +77,6 @@
           <mapping>
             <java>JAVADOC_STYLE</java>
           </mapping>
-        </configuration>
-      </plugin>
-      <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
         </configuration>
       </plugin>
     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
-    <version>18</version>
+    <version>23</version>
   </parent>
 
   <groupId>org.apache.pulsar</groupId>
@@ -77,6 +77,9 @@ flexible messaging model and an intuitive client API.</description>
   </issueManagement>
 
   <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+
     <!--config keys to congiure test selection -->
     <include>*</include>
     <exclude/>
@@ -211,7 +214,9 @@ flexible messaging model and an intuitive client API.</description>
     <license-maven-plugin.version>4.0.rc2</license-maven-plugin.version>
     <directory-maven-plugin.version>0.3.1</directory-maven-plugin.version>
     <maven-enforcer-plugin.version>3.0.0-M2</maven-enforcer-plugin.version>
-    <maven-surefire-plugin.version>3.0.0-M3</maven-surefire-plugin.version>
+    <!-- surefire.version is defined in apache parent pom -->
+    <!-- it is used for surefire, failsafe and surefire-report plugins -->
+    <surefire.version>3.0.0-M5</surefire.version>
     <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
     <maven-dependency-plugin.version>3.1.2</maven-dependency-plugin.version>
     <maven-clean-plugin.version>2.4.1</maven-clean-plugin.version>
@@ -1129,8 +1134,6 @@ flexible messaging model and an intuitive client API.</description>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
           <encoding>UTF-8</encoding>
           <showDeprecation>true</showDeprecation>
           <showWarnings>true</showWarnings>
@@ -1510,7 +1513,6 @@ flexible messaging model and an intuitive client API.</description>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>${maven-surefire-plugin.version}</version>
           <configuration>
             <includes>
                 <include>${include}</include>

--- a/pulsar-sql/presto-distribution/pom.xml
+++ b/pulsar-sql/presto-distribution/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.apache</groupId>
         <artifactId>apache</artifactId>
-        <version>18</version>
+        <version>23</version>
     </parent>
 
     <groupId>org.apache.pulsar</groupId>
@@ -34,7 +34,9 @@
     <version>2.8.0-SNAPSHOT</version>
 
     <properties>
-        <jersey.version>2.31</jersey.version>
+      <maven.compiler.source>1.8</maven.compiler.source>
+      <maven.compiler.target>1.8</maven.compiler.target>
+      <jersey.version>2.31</jersey.version>
         <presto.version>332</presto.version>
         <airlift.version>0.170</airlift.version>
         <objenesis.version>2.6</objenesis.version>
@@ -322,13 +324,6 @@
                 <mapping>
                   <java>JAVADOC_STYLE</java>
                 </mapping>
-              </configuration>
-            </plugin>
-            <plugin>
-              <artifactId>maven-compiler-plugin</artifactId>
-              <configuration>
-                <source>1.8</source>
-                <target>1.8</target>
               </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
- previous version 18 is from May 2016
- use surefire.version to set surefire version, since that's the way
  the parent pom supports
- use maven.compiler.source / maven.compiler.target properties since that's
  what the parent pom supports
