### PR TITLE
lh fix flaky ManagedLedgerImpl shutdown

### DIFF
--- a/bouncy-castle/bcfips-include-test/src/test/resources/authentication/tls/broker-cert.pem
+++ b/bouncy-castle/bcfips-include-test/src/test/resources/authentication/tls/broker-cert.pem
@@ -1,18 +1,18 @@
 Certificate:
     Data:
-        Version: 3 (0x2)
+        Version: 1 (0x0)
         Serial Number:
-            88:08:98:b3:13:d8:00:97
-        Signature Algorithm: sha1WithRSAEncryption
-        Issuer: C=US, ST=CA, O=Apache, OU=Pulsar Incubator, CN=localhost
+            0c:26:15:df:8f:71:1d:6a:31:d0:da:af:64:ef:80:de:ac:9a:46:76
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = CARoot
         Validity
-            Not Before: Feb 17 02:06:21 2018 GMT
-            Not After : Nov 16 00:00:00 2030 GMT
-        Subject: C=US, ST=CA, O=Apache, OU=Apache Pulsar, CN=localhost
+            Not Before: Apr 23 17:08:51 2021 GMT
+            Not After : Apr 21 17:08:51 2031 GMT
+        Subject: C = US, ST = CA, O = Apache, OU = Apache Pulsar, CN = localhost
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
-            RSA Public Key: (2048 bit)
-                Modulus (2048 bit):
+                RSA Public-Key: (2048 bit)
+                Modulus:
                     00:af:bf:b7:2d:98:ad:9d:f6:da:a3:13:d4:62:0f:
                     98:be:1c:a2:89:22:ba:6f:d5:fd:1f:67:e3:91:03:
                     98:80:81:0e:ed:d8:f6:70:7f:2c:36:68:3d:53:ea:
@@ -32,42 +32,37 @@ Certificate:
                     a0:1a:81:9d:d2:e1:66:dd:c4:cc:fc:63:04:ac:ec:
                     a7:35
                 Exponent: 65537 (0x10001)
-        X509v3 extensions:
-            X509v3 Basic Constraints: 
-                CA:FALSE
-            Netscape Comment: 
-                OpenSSL Generated Certificate
-            X509v3 Subject Key Identifier: 
-                D3:F3:19:AE:74:B1:AF:E7:AF:08:7B:16:72:78:29:87:79:ED:30:8C
-            X509v3 Authority Key Identifier: 
-                keyid:D4:7A:CD:0F:44:1B:16:29:25:14:ED:A2:EF:13:0F:A7:46:09:78:F6
-
-    Signature Algorithm: sha1WithRSAEncryption
-        0f:04:f3:91:f2:87:19:fe:9d:f8:34:5a:24:4a:00:d1:58:bf:
-        1e:b2:77:67:07:bc:78:b5:4b:9a:4b:fd:a1:e5:dc:0e:09:84:
-        9e:59:c4:dd:cf:f7:2e:bf:da:f3:31:36:6b:81:6e:a2:88:76:
-        e4:2e:0b:36:44:82:36:8f:80:93:f4:9e:fc:ed:85:d0:97:da:
-        0f:fb:c9:b9:8b:da:ae:07:3d:4f:82:b7:0c:25:22:63:12:6b:
-        0a:e9:c4:12:a4:5c:ed:11:12:cc:fe:b0:2e:d4:c1:ec:79:01:
-        60:ea:cc:cc:e5:66:cc:57:f6:55:a9:09:4c:63:01:e9:b4:2e:
-        73:a5
+    Signature Algorithm: sha256WithRSAEncryption
+         3a:38:c8:85:48:ed:84:c9:f4:bc:ef:b4:4b:a1:46:9c:97:9b:
+         5f:7e:1a:ff:9b:dc:93:0e:7e:ab:de:09:21:30:1f:7f:2a:f7:
+         94:d1:b3:07:3d:b1:71:4f:72:90:1f:41:3d:fe:34:14:ac:5a:
+         39:02:f1:a4:8a:d1:d3:c0:48:da:6f:37:dc:b5:1d:60:29:e6:
+         c5:b0:ce:b4:52:8d:f6:6b:59:0b:e4:c8:f1:1a:40:3a:4f:bd:
+         e2:dd:32:2f:21:3c:33:d7:61:5f:86:cd:94:31:31:f1:ff:c6:
+         08:9e:67:bc:8f:9d:bf:38:a8:8c:ff:3f:1f:fb:24:ab:bb:7c:
+         fb:1b:c3:1b:62:b4:dd:21:d3:7b:19:92:16:b7:7d:f6:95:ee:
+         14:a0:83:de:c5:05:d8:af:44:1d:f7:eb:32:e2:03:ac:c9:12:
+         df:11:b6:af:f8:b9:24:ae:55:3e:25:ae:2a:b2:d3:b6:6a:e9:
+         f9:28:e6:e0:46:98:66:2c:0d:a3:fe:c7:82:48:13:80:f2:b2:
+         d1:5c:7d:bb:11:1c:60:62:1b:f7:1a:11:e1:ee:29:70:f1:95:
+         c1:67:c4:f1:e2:d5:f4:24:49:0d:6e:2f:65:7b:48:cd:40:f9:
+         c9:26:a3:c7:41:20:d1:6e:2c:38:8e:1b:bc:93:fa:22:39:3d:
+         2a:f6:ba:77
 -----BEGIN CERTIFICATE-----
-MIIDLjCCApegAwIBAgIJAIgImLMT2ACXMA0GCSqGSIb3DQEBBQUAMFoxCzAJBgNV
-BAYTAlVTMQswCQYDVQQIEwJDQTEPMA0GA1UEChMGQXBhY2hlMRkwFwYDVQQLExBQ
-dWxzYXIgSW5jdWJhdG9yMRIwEAYDVQQDEwlsb2NhbGhvc3QwHhcNMTgwMjE3MDIw
-NjIxWhcNMzAxMTE2MDAwMDAwWjBXMQswCQYDVQQGEwJVUzELMAkGA1UECBMCQ0Ex
-DzANBgNVBAoTBkFwYWNoZTEWMBQGA1UECxMNQXBhY2hlIFB1bHNhcjESMBAGA1UE
-AxMJbG9jYWxob3N0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAr7+3
-LZitnfbaoxPUYg+YvhyiiSK6b9X9H2fjkQOYgIEO7dj2cH8sNmg9U+pYOqbViWZL
-vR5XcRNtSxHlQKV2hCSSQFiAlskfLMRV66N5c3BcN5qJ7S+6a+OCfGlKAlSLgV48
-v0yKy+osXoPntxAIX4JYo4nR2pK6KijuMCg/W64QcZbH4RLFsBqtRG9EOhFKmjwP
-jQaAezTvP2z0XsVEVB7I3ceAhYDZaObGUwN34f4YYQd3BUztWbxdQThq712hsmCY
-1EgolQKKDv3PexvSEcwQDFBz18w4bIPdeSaqkMibhIa8WeliafSYG8SAeH6gGoGd
-0uFm3cTM/GMErOynNQIDAQABo3sweTAJBgNVHRMEAjAAMCwGCWCGSAGG+EIBDQQf
-Fh1PcGVuU1NMIEdlbmVyYXRlZCBDZXJ0aWZpY2F0ZTAdBgNVHQ4EFgQU0/MZrnSx
-r+evCHsWcngph3ntMIwwHwYDVR0jBBgwFoAU1HrND0QbFiklFO2i7xMPp0YJePYw
-DQYJKoZIhvcNAQEFBQADgYEADwTzkfKHGf6d+DRaJEoA0Vi/HrJ3Zwe8eLVLmkv9
-oeXcDgmEnlnE3c/3Lr/a8zE2a4Fuooh25C4LNkSCNo+Ak/Se/O2F0JfaD/vJuYva
-rgc9T4K3DCUiYxJrCunEEqRc7RESzP6wLtTB7HkBYOrMzOVmzFf2VakJTGMB6bQu
-c6U=
+MIIC7zCCAdcCFAwmFd+PcR1qMdDar2TvgN6smkZ2MA0GCSqGSIb3DQEBCwUAMBEx
+DzANBgNVBAMMBkNBUm9vdDAeFw0yMTA0MjMxNzA4NTFaFw0zMTA0MjExNzA4NTFa
+MFcxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJDQTEPMA0GA1UEChMGQXBhY2hlMRYw
+FAYDVQQLEw1BcGFjaGUgUHVsc2FyMRIwEAYDVQQDEwlsb2NhbGhvc3QwggEiMA0G
+CSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCvv7ctmK2d9tqjE9RiD5i+HKKJIrpv
+1f0fZ+ORA5iAgQ7t2PZwfyw2aD1T6lg6ptWJZku9HldxE21LEeVApXaEJJJAWICW
+yR8sxFXro3lzcFw3montL7pr44J8aUoCVIuBXjy/TIrL6ixeg+e3EAhfglijidHa
+kroqKO4wKD9brhBxlsfhEsWwGq1Eb0Q6EUqaPA+NBoB7NO8/bPRexURUHsjdx4CF
+gNlo5sZTA3fh/hhhB3cFTO1ZvF1BOGrvXaGyYJjUSCiVAooO/c97G9IRzBAMUHPX
+zDhsg915JqqQyJuEhrxZ6WJp9JgbxIB4fqAagZ3S4WbdxMz8YwSs7Kc1AgMBAAEw
+DQYJKoZIhvcNAQELBQADggEBADo4yIVI7YTJ9LzvtEuhRpyXm19+Gv+b3JMOfqve
+CSEwH38q95TRswc9sXFPcpAfQT3+NBSsWjkC8aSK0dPASNpvN9y1HWAp5sWwzrRS
+jfZrWQvkyPEaQDpPveLdMi8hPDPXYV+GzZQxMfH/xgieZ7yPnb84qIz/Px/7JKu7
+fPsbwxtitN0h03sZkha3ffaV7hSgg97FBdivRB336zLiA6zJEt8Rtq/4uSSuVT4l
+riqy07Zq6fko5uBGmGYsDaP+x4JIE4DystFcfbsRHGBiG/caEeHuKXDxlcFnxPHi
+1fQkSQ1uL2V7SM1A+ckmo8dBINFuLDiOG7yT+iI5PSr2unc=
 -----END CERTIFICATE-----

--- a/bouncy-castle/bcfips-include-test/src/test/resources/authentication/tls/cacert.pem
+++ b/bouncy-castle/bcfips-include-test/src/test/resources/authentication/tls/cacert.pem
@@ -2,61 +2,76 @@ Certificate:
     Data:
         Version: 3 (0x2)
         Serial Number:
-            88:08:98:b3:13:d8:00:94
-        Signature Algorithm: sha1WithRSAEncryption
-        Issuer: C=US, ST=CA, O=Apache, OU=Pulsar Incubator, CN=localhost
+            10:50:a0:5c:8e:cf:88:33:b6:b5:d2:1e:38:bf:78:56:2a:f1:09:22
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = CARoot
         Validity
-            Not Before: Feb 17 01:37:33 2018 GMT
-            Not After : Feb 16 01:37:33 2021 GMT
-        Subject: C=US, ST=CA, O=Apache, OU=Pulsar Incubator, CN=localhost
+            Not Before: Apr 23 17:08:51 2021 GMT
+            Not After : Apr 21 17:08:51 2031 GMT
+        Subject: CN = CARoot
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
-            RSA Public Key: (1024 bit)
-                Modulus (1024 bit):
-                    00:ea:16:8d:a5:b1:19:61:34:54:07:02:60:4e:6d:
-                    54:92:08:fd:fb:23:79:9c:05:bf:14:f7:bc:aa:db:
-                    2b:42:a4:35:74:86:e3:00:ad:8b:18:79:73:7d:f2:
-                    d1:74:dd:74:bc:b8:a2:4c:80:c9:f3:80:ce:bf:f8:
-                    6d:97:f5:05:4f:f4:b2:99:50:e8:d8:b0:c4:57:a0:
-                    e7:dc:82:57:75:2a:a2:02:21:76:f7:37:c2:dc:7c:
-                    4c:36:a6:73:6f:dc:75:48:72:ad:fa:98:02:70:b2:
-                    5e:a2:83:cc:c3:8d:20:a7:1e:bc:d7:1e:c1:d1:7e:
-                    39:35:4b:f5:be:6b:c1:0f:f9
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:c4:92:ca:40:ce:8d:71:dd:e9:2b:e3:3b:b7:17:
+                    1d:25:bf:12:66:c0:cb:32:18:32:3e:24:ea:e1:26:
+                    1a:97:e8:85:4b:19:8e:c0:0a:da:a6:57:ec:31:a6:
+                    a8:68:d9:8e:5c:a2:00:54:30:11:47:a6:0e:84:0d:
+                    6d:e3:48:a8:a6:e3:42:63:97:ef:91:c0:3a:bc:db:
+                    77:77:3b:d0:45:fc:c5:a8:3a:74:dc:82:4e:83:ed:
+                    f9:9d:a0:30:11:0c:d9:20:7b:a6:04:60:a1:9c:41:
+                    33:c6:04:d2:a7:e8:b1:46:e6:35:5e:fd:ca:2e:42:
+                    2f:f4:0c:f7:6e:8d:60:f5:cf:82:7a:e3:eb:ed:d0:
+                    a1:51:a9:78:8d:14:2d:ca:ea:cc:fa:ae:a9:f9:6c:
+                    df:5c:cb:83:4a:42:22:5c:48:3e:a6:63:70:43:63:
+                    ff:3f:d8:1f:88:e1:91:7b:49:b9:67:10:8a:60:51:
+                    24:68:db:68:24:5f:10:a5:a2:b3:95:83:7e:3c:88:
+                    9c:1c:52:6a:2c:03:52:aa:90:90:85:21:78:a7:20:
+                    b0:e2:dc:79:b4:b7:57:f0:be:df:3b:fc:21:23:ee:
+                    ff:63:5d:0b:0d:3d:ab:61:54:8c:2d:96:44:7b:42:
+                    10:60:3b:1d:a8:ab:33:01:e7:96:74:08:a6:f9:9d:
+                    ba:cf
                 Exponent: 65537 (0x10001)
         X509v3 extensions:
             X509v3 Subject Key Identifier: 
-                D4:7A:CD:0F:44:1B:16:29:25:14:ED:A2:EF:13:0F:A7:46:09:78:F6
+                C6:91:71:A0:C9:1F:A9:5A:87:7B:E5:10:FB:9A:2A:12:90:44:7D:A0
             X509v3 Authority Key Identifier: 
-                keyid:D4:7A:CD:0F:44:1B:16:29:25:14:ED:A2:EF:13:0F:A7:46:09:78:F6
-                DirName:/C=US/ST=CA/O=Apache/OU=Pulsar Incubator/CN=localhost
-                serial:88:08:98:B3:13:D8:00:94
+                keyid:C6:91:71:A0:C9:1F:A9:5A:87:7B:E5:10:FB:9A:2A:12:90:44:7D:A0
 
-            X509v3 Basic Constraints: 
+            X509v3 Basic Constraints: critical
                 CA:TRUE
-    Signature Algorithm: sha1WithRSAEncryption
-        5e:30:c5:7b:30:3e:1e:16:cd:ba:66:f1:2a:19:13:8a:1a:00:
-        08:f4:1e:8c:e4:3d:57:13:65:96:bf:07:58:55:52:37:3e:aa:
-        2c:19:de:ee:c3:92:6e:79:f3:06:0e:9a:7b:e0:02:50:c3:ef:
-        3b:84:ea:8f:e0:f0:16:a6:a6:67:8b:be:73:0e:5d:f7:88:39:
-        d3:d4:df:85:ad:7c:c1:4f:fa:55:55:6f:c2:48:4e:8e:82:fa:
-        72:3b:8e:9d:dc:f7:2e:9d:47:8e:e5:c9:a2:ee:b1:76:94:15:
-        7c:7a:62:bc:06:45:fa:61:2e:33:8c:18:3e:e9:d5:90:a5:a6:
-        80:5a
+    Signature Algorithm: sha256WithRSAEncryption
+         5d:c2:68:9e:66:fb:67:39:fc:5e:2f:ba:4c:f0:20:3f:f9:4a:
+         e2:b9:05:56:d6:5e:da:01:c7:8b:1a:70:e6:67:61:84:71:67:
+         a8:11:bc:7c:4d:58:d0:52:44:71:19:47:87:60:cb:16:12:25:
+         b2:b0:95:13:ff:52:00:36:78:2d:d3:ce:4e:c6:7d:1b:e5:8e:
+         37:23:8a:ef:c2:44:88:e2:bc:47:c4:ef:23:f5:8b:6d:fc:39:
+         3c:cb:7e:70:7c:60:51:33:5a:38:3a:fd:cc:8f:2c:08:d5:07:
+         06:f9:89:77:96:8e:60:21:e5:05:98:37:d6:c4:b7:a3:43:9e:
+         87:13:9d:12:c4:8f:6a:ad:a9:67:c4:3a:7e:14:77:c3:75:72:
+         95:e6:25:a2:14:e7:77:4d:8f:dd:45:ae:f0:f6:f3:fe:2b:cf:
+         ea:0e:f8:61:66:45:db:9f:6b:e4:5e:b8:d4:04:41:68:e9:7c:
+         a4:7e:c8:1c:4d:ec:49:49:57:a4:46:95:e8:0f:55:ea:08:2e:
+         b9:7a:62:e2:be:05:00:d5:81:5f:60:60:58:4e:19:bc:24:ee:
+         0e:17:63:da:fd:40:44:c2:5f:7d:e9:26:b4:80:4d:db:88:4f:
+         31:a4:16:93:fd:a8:70:94:50:f1:23:92:20:fb:26:c3:9a:71:
+         b1:9c:c9:db
 -----BEGIN CERTIFICATE-----
-MIIC8jCCAlugAwIBAgIJAIgImLMT2ACUMA0GCSqGSIb3DQEBBQUAMFoxCzAJBgNV
-BAYTAlVTMQswCQYDVQQIEwJDQTEPMA0GA1UEChMGQXBhY2hlMRkwFwYDVQQLExBQ
-dWxzYXIgSW5jdWJhdG9yMRIwEAYDVQQDEwlsb2NhbGhvc3QwHhcNMTgwMjE3MDEz
-NzMzWhcNMjEwMjE2MDEzNzMzWjBaMQswCQYDVQQGEwJVUzELMAkGA1UECBMCQ0Ex
-DzANBgNVBAoTBkFwYWNoZTEZMBcGA1UECxMQUHVsc2FyIEluY3ViYXRvcjESMBAG
-A1UEAxMJbG9jYWxob3N0MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDqFo2l
-sRlhNFQHAmBObVSSCP37I3mcBb8U97yq2ytCpDV0huMArYsYeXN98tF03XS8uKJM
-gMnzgM6/+G2X9QVP9LKZUOjYsMRXoOfcgld1KqICIXb3N8LcfEw2pnNv3HVIcq36
-mAJwsl6ig8zDjSCnHrzXHsHRfjk1S/W+a8EP+QIDAQABo4G/MIG8MB0GA1UdDgQW
-BBTUes0PRBsWKSUU7aLvEw+nRgl49jCBjAYDVR0jBIGEMIGBgBTUes0PRBsWKSUU
-7aLvEw+nRgl49qFepFwwWjELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAkNBMQ8wDQYD
-VQQKEwZBcGFjaGUxGTAXBgNVBAsTEFB1bHNhciBJbmN1YmF0b3IxEjAQBgNVBAMT
-CWxvY2FsaG9zdIIJAIgImLMT2ACUMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEF
-BQADgYEAXjDFezA+HhbNumbxKhkTihoACPQejOQ9VxNllr8HWFVSNz6qLBne7sOS
-bnnzBg6ae+ACUMPvO4Tqj+DwFqamZ4u+cw5d94g509Tfha18wU/6VVVvwkhOjoL6
-cjuOndz3Lp1HjuXJou6xdpQVfHpivAZF+mEuM4wYPunVkKWmgFo=
+MIIDAzCCAeugAwIBAgIUEFCgXI7PiDO2tdIeOL94VirxCSIwDQYJKoZIhvcNAQEL
+BQAwETEPMA0GA1UEAwwGQ0FSb290MB4XDTIxMDQyMzE3MDg1MVoXDTMxMDQyMTE3
+MDg1MVowETEPMA0GA1UEAwwGQ0FSb290MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A
+MIIBCgKCAQEAxJLKQM6Ncd3pK+M7txcdJb8SZsDLMhgyPiTq4SYal+iFSxmOwAra
+plfsMaaoaNmOXKIAVDARR6YOhA1t40iopuNCY5fvkcA6vNt3dzvQRfzFqDp03IJO
+g+35naAwEQzZIHumBGChnEEzxgTSp+ixRuY1Xv3KLkIv9Az3bo1g9c+CeuPr7dCh
+Ual4jRQtyurM+q6p+WzfXMuDSkIiXEg+pmNwQ2P/P9gfiOGRe0m5ZxCKYFEkaNto
+JF8QpaKzlYN+PIicHFJqLANSqpCQhSF4pyCw4tx5tLdX8L7fO/whI+7/Y10LDT2r
+YVSMLZZEe0IQYDsdqKszAeeWdAim+Z26zwIDAQABo1MwUTAdBgNVHQ4EFgQUxpFx
+oMkfqVqHe+UQ+5oqEpBEfaAwHwYDVR0jBBgwFoAUxpFxoMkfqVqHe+UQ+5oqEpBE
+faAwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAXcJonmb7Zzn8
+Xi+6TPAgP/lK4rkFVtZe2gHHixpw5mdhhHFnqBG8fE1Y0FJEcRlHh2DLFhIlsrCV
+E/9SADZ4LdPOTsZ9G+WONyOK78JEiOK8R8TvI/WLbfw5PMt+cHxgUTNaODr9zI8s
+CNUHBvmJd5aOYCHlBZg31sS3o0OehxOdEsSPaq2pZ8Q6fhR3w3VyleYlohTnd02P
+3UWu8Pbz/ivP6g74YWZF259r5F641ARBaOl8pH7IHE3sSUlXpEaV6A9V6gguuXpi
+4r4FANWBX2BgWE4ZvCTuDhdj2v1ARMJffekmtIBN24hPMaQWk/2ocJRQ8SOSIPsm
+w5pxsZzJ2w==
 -----END CERTIFICATE-----

--- a/bouncy-castle/bcfips-include-test/src/test/resources/authentication/tls/client-cert.pem
+++ b/bouncy-castle/bcfips-include-test/src/test/resources/authentication/tls/client-cert.pem
@@ -1,18 +1,18 @@
 Certificate:
     Data:
-        Version: 3 (0x2)
+        Version: 1 (0x0)
         Serial Number:
-            88:08:98:b3:13:d8:00:99
-        Signature Algorithm: sha1WithRSAEncryption
-        Issuer: C=US, ST=CA, O=Apache, OU=Pulsar Incubator, CN=localhost
+            0c:26:15:df:8f:71:1d:6a:31:d0:da:af:64:ef:80:de:ac:9a:46:77
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = CARoot
         Validity
-            Not Before: Feb 17 02:50:05 2018 GMT
-            Not After : Nov 16 00:00:00 2030 GMT
-        Subject: C=US, ST=CA, O=Apache, OU=Apache Pulsar, CN=superUser
+            Not Before: Apr 23 17:08:51 2021 GMT
+            Not After : Apr 21 17:08:51 2031 GMT
+        Subject: C = US, ST = CA, O = Apache, OU = Apache Pulsar, CN = superUser
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
-            RSA Public Key: (2048 bit)
-                Modulus (2048 bit):
+                RSA Public-Key: (2048 bit)
+                Modulus:
                     00:cd:43:7d:98:40:f9:b0:5b:bc:ae:db:c0:0b:ad:
                     26:90:96:e0:62:38:ed:68:b1:70:46:3b:de:44:f9:
                     14:51:86:10:eb:ca:90:e7:88:e8:f9:91:85:e0:dd:
@@ -32,42 +32,37 @@ Certificate:
                     b6:98:ef:dd:03:82:58:a3:32:dc:90:a1:b6:a6:1e:
                     e1:0b
                 Exponent: 65537 (0x10001)
-        X509v3 extensions:
-            X509v3 Basic Constraints: 
-                CA:FALSE
-            Netscape Comment: 
-                OpenSSL Generated Certificate
-            X509v3 Subject Key Identifier: 
-                53:7C:D5:D1:52:97:9A:D6:D5:EA:EC:B6:0C:9B:43:39:19:73:F6:2C
-            X509v3 Authority Key Identifier: 
-                keyid:D4:7A:CD:0F:44:1B:16:29:25:14:ED:A2:EF:13:0F:A7:46:09:78:F6
-
-    Signature Algorithm: sha1WithRSAEncryption
-        e4:03:82:ff:be:df:7c:73:2a:c5:8f:7d:87:ab:95:b1:2b:e5:
-        f7:41:22:4f:28:54:84:7a:cc:fe:70:89:0f:48:e5:8a:17:e1:
-        44:ad:12:e9:a1:3a:c7:84:55:f0:7c:29:52:0a:a1:ab:cc:5b:
-        31:e5:b2:37:73:3a:8d:f2:f1:fb:e8:f6:a2:b9:ef:11:10:f8:
-        31:43:8f:af:ce:09:f4:cb:96:0e:d4:58:42:6e:86:ab:b9:03:
-        19:8b:4a:6e:ef:50:c0:7e:c9:0b:1d:2b:42:bf:eb:d0:06:05:
-        84:ea:5a:8a:22:5c:56:fa:da:2a:9f:8a:b2:90:66:8c:5e:01:
-        87:45
+    Signature Algorithm: sha256WithRSAEncryption
+         6f:c2:2f:41:a4:a0:45:10:33:61:20:27:d2:74:40:f9:80:3b:
+         06:88:91:c3:b8:4d:1a:c4:fd:39:9e:3a:c8:41:de:31:4e:ef:
+         8b:06:ce:17:e2:8e:b5:ee:43:92:0a:44:3d:55:e9:85:81:49:
+         c9:19:44:15:f1:bd:ec:1e:cb:34:44:b1:01:c0:96:49:30:a4:
+         5a:64:44:6e:59:d9:b1:17:bf:01:13:b7:45:53:8c:8d:a7:79:
+         fc:19:b4:a9:b5:9b:6f:16:8e:b3:de:5e:2a:db:01:f2:3e:b0:
+         8f:23:4f:8f:49:ee:d5:b7:98:54:6e:b5:be:8b:fc:05:87:e3:
+         8b:2e:70:28:2c:75:75:c3:76:a4:0d:5e:71:67:30:ec:69:cc:
+         2b:43:69:3b:e8:78:89:51:98:07:cb:21:e9:7a:76:a9:b3:e8:
+         e6:19:e7:32:ae:3a:b8:24:c4:20:d8:c2:dc:91:99:d1:9b:8f:
+         77:3c:e7:a8:53:ee:91:fe:ed:2b:86:18:0a:55:44:46:78:a1:
+         78:41:a5:e9:fe:8b:db:bb:10:2e:72:52:b7:54:81:84:8b:f7:
+         29:f3:86:29:7f:f8:e2:d8:51:d8:b2:3c:c2:78:7c:a4:11:9c:
+         0a:42:64:1b:13:cc:91:1a:08:d9:ed:f1:23:5f:fd:b3:89:bb:
+         7a:cc:96:8d
 -----BEGIN CERTIFICATE-----
-MIIDLjCCApegAwIBAgIJAIgImLMT2ACZMA0GCSqGSIb3DQEBBQUAMFoxCzAJBgNV
-BAYTAlVTMQswCQYDVQQIEwJDQTEPMA0GA1UEChMGQXBhY2hlMRkwFwYDVQQLExBQ
-dWxzYXIgSW5jdWJhdG9yMRIwEAYDVQQDEwlsb2NhbGhvc3QwHhcNMTgwMjE3MDI1
-MDA1WhcNMzAxMTE2MDAwMDAwWjBXMQswCQYDVQQGEwJVUzELMAkGA1UECBMCQ0Ex
-DzANBgNVBAoTBkFwYWNoZTEWMBQGA1UECxMNQXBhY2hlIFB1bHNhcjESMBAGA1UE
-AxMJc3VwZXJVc2VyMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzUN9
-mED5sFu8rtvAC60mkJbgYjjtaLFwRjveRPkUUYYQ68qQ54jo+ZGF4N21tBS5eOOG
-1VRtaOwUkrT4IlsFPe0xJWUIBYTK5gwhElgyxxpgo0/SSp4oGXxFhACMidzeiuVP
-iJHMpPGBRUx9wv/iwYnGEnOV4ja9266LWmhqkFHeK4hfqmf0qONj3L4Zgsydf+aN
-+4K+IgE9VhM7WwS06MUY5i4N+rpKjejGWqFRmkpi16/dtPzi1c2umWxcYVYL1wwa
-d1z1OmpUtZ4zrKl1KJp2r9B6VwAbkRMx/UKIIUcFEAEvWbvHOtnhWEwbbHG2mO/d
-A4JYozLckKG2ph7hCwIDAQABo3sweTAJBgNVHRMEAjAAMCwGCWCGSAGG+EIBDQQf
-Fh1PcGVuU1NMIEdlbmVyYXRlZCBDZXJ0aWZpY2F0ZTAdBgNVHQ4EFgQUU3zV0VKX
-mtbV6uy2DJtDORlz9iwwHwYDVR0jBBgwFoAU1HrND0QbFiklFO2i7xMPp0YJePYw
-DQYJKoZIhvcNAQEFBQADgYEA5AOC/77ffHMqxY99h6uVsSvl90EiTyhUhHrM/nCJ
-D0jlihfhRK0S6aE6x4RV8HwpUgqhq8xbMeWyN3M6jfLx++j2ornvERD4MUOPr84J
-9MuWDtRYQm6Gq7kDGYtKbu9QwH7JCx0rQr/r0AYFhOpaiiJcVvraKp+KspBmjF4B
-h0U=
+MIIC7zCCAdcCFAwmFd+PcR1qMdDar2TvgN6smkZ3MA0GCSqGSIb3DQEBCwUAMBEx
+DzANBgNVBAMMBkNBUm9vdDAeFw0yMTA0MjMxNzA4NTFaFw0zMTA0MjExNzA4NTFa
+MFcxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJDQTEPMA0GA1UEChMGQXBhY2hlMRYw
+FAYDVQQLEw1BcGFjaGUgUHVsc2FyMRIwEAYDVQQDEwlzdXBlclVzZXIwggEiMA0G
+CSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDNQ32YQPmwW7yu28ALrSaQluBiOO1o
+sXBGO95E+RRRhhDrypDniOj5kYXg3bW0FLl444bVVG1o7BSStPgiWwU97TElZQgF
+hMrmDCESWDLHGmCjT9JKnigZfEWEAIyJ3N6K5U+Ikcyk8YFFTH3C/+LBicYSc5Xi
+Nr3brotaaGqQUd4riF+qZ/So42PcvhmCzJ1/5o37gr4iAT1WEztbBLToxRjmLg36
+ukqN6MZaoVGaSmLXr920/OLVza6ZbFxhVgvXDBp3XPU6alS1njOsqXUomnav0HpX
+ABuREzH9QoghRwUQAS9Zu8c62eFYTBtscbaY790DglijMtyQobamHuELAgMBAAEw
+DQYJKoZIhvcNAQELBQADggEBAG/CL0GkoEUQM2EgJ9J0QPmAOwaIkcO4TRrE/Tme
+OshB3jFO74sGzhfijrXuQ5IKRD1V6YWBSckZRBXxveweyzREsQHAlkkwpFpkRG5Z
+2bEXvwETt0VTjI2nefwZtKm1m28WjrPeXirbAfI+sI8jT49J7tW3mFRutb6L/AWH
+44sucCgsdXXDdqQNXnFnMOxpzCtDaTvoeIlRmAfLIel6dqmz6OYZ5zKuOrgkxCDY
+wtyRmdGbj3c856hT7pH+7SuGGApVREZ4oXhBpen+i9u7EC5yUrdUgYSL9ynzhil/
++OLYUdiyPMJ4fKQRnApCZBsTzJEaCNnt8SNf/bOJu3rMlo0=
 -----END CERTIFICATE-----

--- a/build/regenerate_certs_for_tests.sh
+++ b/build/regenerate_certs_for_tests.sh
@@ -1,0 +1,73 @@
+#!/bin/bash -xe
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. >/dev/null 2>&1 && pwd)"
+
+cd /tmp
+mkdir keygendir$$
+cd keygendir$$
+
+# create CA key and cert
+function generate_ca() {
+  openssl req -x509 -nodes -newkey rsa:2048 -keyout ca-key -outform pem -text -out ca-cert.pem -days 3650 -sha256 \
+    -subj "/CN=CARoot" -extensions v3_ca
+}
+
+function reissue_certificate() {
+  keyfile=$1
+  certfile=$2
+  openssl x509 -x509toreq -in $certfile -signkey $keyfile -out ${certfile}.csr
+  openssl x509 -req -CA ca-cert.pem -CAkey ca-key -in ${certfile}.csr -text -outform pem -out $certfile -days 3650 -CAcreateserial
+}
+
+generate_ca
+cp ca-cert.pem $ROOT_DIR/pulsar-proxy/src/test/resources/authentication/tls/cacert.pem
+reissue_certificate $ROOT_DIR/pulsar-proxy/src/test/resources/authentication/tls/client-key.pem \
+  $ROOT_DIR/pulsar-proxy/src/test/resources/authentication/tls/client-cert.pem
+reissue_certificate $ROOT_DIR/pulsar-proxy/src/test/resources/authentication/tls/server-key.pem \
+  $ROOT_DIR/pulsar-proxy/src/test/resources/authentication/tls/server-cert.pem
+
+generate_ca
+cp ca-cert.pem $ROOT_DIR/bouncy-castle/bcfips-include-test/src/test/resources/authentication/tls/cacert.pem
+reissue_certificate $ROOT_DIR/bouncy-castle/bcfips-include-test/src/test/resources/authentication/tls/broker-key.pem \
+  $ROOT_DIR/bouncy-castle/bcfips-include-test/src/test/resources/authentication/tls/broker-cert.pem
+reissue_certificate $ROOT_DIR/bouncy-castle/bcfips-include-test/src/test/resources/authentication/tls/client-key.pem \
+  $ROOT_DIR/bouncy-castle/bcfips-include-test/src/test/resources/authentication/tls/client-cert.pem
+
+generate_ca
+cp ca-cert.pem $ROOT_DIR/pulsar-proxy/src/test/resources/authentication/tls/ProxyWithAuthorizationTest/broker-cacert.pem
+reissue_certificate $ROOT_DIR/pulsar-proxy/src/test/resources/authentication/tls/ProxyWithAuthorizationTest/broker-key.pem \
+  $ROOT_DIR/pulsar-proxy/src/test/resources/authentication/tls/ProxyWithAuthorizationTest/broker-cert.pem
+
+generate_ca
+cp ca-cert.pem $ROOT_DIR/pulsar-proxy/src/test/resources/authentication/tls/ProxyWithAuthorizationTest/client-cacert.pem
+reissue_certificate $ROOT_DIR/pulsar-proxy/src/test/resources/authentication/tls/ProxyWithAuthorizationTest/client-key.pem \
+  $ROOT_DIR/pulsar-proxy/src/test/resources/authentication/tls/ProxyWithAuthorizationTest/client-cert.pem
+
+generate_ca
+cp ca-cert.pem $ROOT_DIR/pulsar-proxy/src/test/resources/authentication/tls/ProxyWithAuthorizationTest/proxy-cacert.pem
+reissue_certificate $ROOT_DIR/pulsar-proxy/src/test/resources/authentication/tls/ProxyWithAuthorizationTest/proxy-key.pem \
+  $ROOT_DIR/pulsar-proxy/src/test/resources/authentication/tls/ProxyWithAuthorizationTest/proxy-cert.pem
+
+
+
+
+cd $ROOT_DIR
+rm -rf /tmp/keygendir$$

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
@@ -20,12 +20,9 @@ package org.apache.bookkeeper.mledger.impl;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static org.apache.bookkeeper.mledger.ManagedLedgerException.getManagedLedgerException;
-
 import com.google.common.base.Predicates;
 import com.google.common.collect.Maps;
-
 import io.netty.util.concurrent.DefaultThreadFactory;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -41,7 +38,6 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.common.util.OrderedExecutor;
@@ -78,8 +74,8 @@ import org.apache.bookkeeper.mledger.util.Futures;
 import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.apache.bookkeeper.stats.StatsLogger;
 import org.apache.bookkeeper.zookeeper.ZooKeeperClient;
-import org.apache.pulsar.common.util.DateFormatter;
 import org.apache.pulsar.common.policies.data.EnsemblePlacementPolicyConfig;
+import org.apache.pulsar.common.util.DateFormatter;
 import org.apache.pulsar.metadata.api.MetadataStore;
 import org.apache.pulsar.metadata.api.Stat;
 import org.apache.pulsar.metadata.impl.ZKMetadataStore;
@@ -498,11 +494,13 @@ public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
         statsTask.cancel(true);
         flushCursorsTask.cancel(true);
 
+        // take a snapshot of ledgers currently in the map to prevent race conditions
+        List<CompletableFuture<ManagedLedgerImpl>> ledgers = new ArrayList<>(this.ledgers.values());
         int numLedgers = ledgers.size();
         final CountDownLatch latch = new CountDownLatch(numLedgers);
         log.info("Closing {} ledgers", numLedgers);
 
-        for (CompletableFuture<ManagedLedgerImpl> ledgerFuture : ledgers.values()) {
+        for (CompletableFuture<ManagedLedgerImpl> ledgerFuture : ledgers) {
             ManagedLedgerImpl ledger = ledgerFuture.getNow(null);
             if (ledger == null) {
                 latch.countDown();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -371,6 +371,13 @@ public class PulsarService implements AutoCloseable {
                                                     * getConfiguration()
                                                     .getBrokerShutdownTimeoutMs())));
 
+            // shutdown loadmanager before shutting down the broker
+            executorServicesShutdown.shutdown(loadManagerExecutor);
+            LoadManager loadManager = this.loadManager.get();
+            if (loadManager != null) {
+                loadManager.stop();
+            }
+
             List<CompletableFuture<Void>> asyncCloseFutures = new ArrayList<>();
             if (this.brokerService != null) {
                 asyncCloseFutures.add(this.brokerService.closeAsync());
@@ -391,8 +398,6 @@ public class PulsarService implements AutoCloseable {
                 this.leaderElectionService.close();
                 this.leaderElectionService = null;
             }
-
-            executorServicesShutdown.shutdown(loadManagerExecutor);
 
             if (globalZkCache != null) {
                 globalZkCache.close();
@@ -434,10 +439,7 @@ public class PulsarService implements AutoCloseable {
             executorServicesShutdown.shutdown(orderedExecutor);
             executorServicesShutdown.shutdown(cacheExecutor);
 
-            LoadManager loadManager = this.loadManager.get();
-            if (loadManager != null) {
-                loadManager.stop();
-            }
+
 
             if (schemaRegistryService != null) {
                 schemaRegistryService.close();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -1172,7 +1172,8 @@ public class PersistentTopic extends AbstractTopic
         return closeFuture;
     }
 
-    private CompletableFuture<Void> checkReplicationAndRetryOnFailure() {
+    @VisibleForTesting
+    CompletableFuture<Void> checkReplicationAndRetryOnFailure() {
         CompletableFuture<Void> result = new CompletableFuture<Void>();
         checkReplication().thenAccept(res -> {
             log.info("[{}] Policies updated successfully", topic);
@@ -2182,6 +2183,10 @@ public class PersistentTopic extends AbstractTopic
         if (log.isDebugEnabled()) {
             log.debug("[{}] isEncryptionRequired changes: {} -> {}", topic, isEncryptionRequired,
                     data.encryption_required);
+        }
+        if (data.deleted) {
+            log.debug("Ignore the update because it has been deleted : {}", data);
+            return CompletableFuture.completedFuture(null);
         }
         isEncryptionRequired = data.encryption_required;
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicTest.java
@@ -23,15 +23,18 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
-import static org.testng.Assert.assertEquals;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 
 import java.lang.reflect.Field;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 
+import com.google.common.collect.Sets;
 import org.apache.bookkeeper.client.LedgerHandle;
 import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.pulsar.broker.service.BrokerTestBase;
@@ -43,6 +46,8 @@ import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.common.naming.NamespaceBundle;
 import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.policies.data.Policies;
+import org.awaitility.Awaitility;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -155,5 +160,31 @@ public class PersistentTopicTest extends BrokerTestBase {
         assertNotNull(msg);
         msg = consumer2.receive(5, TimeUnit.SECONDS);
         assertNotNull(msg);
+    }
+
+    @Test
+    public void testDeleteNamespaceInfiniteRetry() throws Exception {
+        //init namespace
+        final String myNamespace = "prop/ns" + UUID.randomUUID();
+        admin.namespaces().createNamespace(myNamespace, Sets.newHashSet("test"));
+        final String topic = "persistent://" + myNamespace + "/testDeleteNamespaceInfiniteRetry";
+        conf.setForceDeleteNamespaceAllowed(true);
+        //init topic and policies
+        pulsarClient.newProducer().topic(topic).create().close();
+        admin.namespaces().setMaxConsumersPerTopic(myNamespace, 0);
+        Awaitility.await().atMost(3, TimeUnit.SECONDS).until(()
+                -> admin.namespaces().getMaxConsumersPerTopic(myNamespace) == 0);
+
+        PersistentTopic persistentTopic =
+                spy((PersistentTopic) pulsar.getBrokerService().getTopicIfExists(topic).get().get());
+
+        Policies policies = new Policies();
+        policies.deleted = true;
+        persistentTopic.onPoliciesUpdate(policies);
+        verify(persistentTopic, times(0)).checkReplicationAndRetryOnFailure();
+
+        policies.deleted = false;
+        persistentTopic.onPoliciesUpdate(policies);
+        verify(persistentTopic, times(1)).checkReplicationAndRetryOnFailure();
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MultiTopicsReaderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MultiTopicsReaderTest.java
@@ -31,7 +31,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.Future;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import lombok.Cleanup;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
@@ -50,6 +50,7 @@ import org.apache.pulsar.common.policies.data.PersistentTopicInternalStats;
 import org.apache.pulsar.common.policies.data.Policies;
 import org.apache.pulsar.common.policies.data.RetentionPolicies;
 import org.apache.pulsar.common.policies.data.TenantInfo;
+import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.common.util.Murmur3_32Hash;
 import org.awaitility.Awaitility;
 import org.testng.Assert;
@@ -91,9 +92,9 @@ public class MultiTopicsReaderTest extends MockedPulsarServiceBaseTest {
         testReadMessages(topic, false);
     }
 
-    @Test(timeOut = 10000, groups = "quarantine")
+    @Test(timeOut = 20000)
     public void testReadMessageWithoutBatchingWithMessageInclusive() throws Exception {
-        String topic = "persistent://my-property/my-ns/my-reader-topic-inclusive";
+        String topic = "persistent://my-property/my-ns/my-reader-topic-inclusive" + UUID.randomUUID();
         int topicNum = 3;
         admin.topics().createPartitionedTopic(topic, topicNum);
         Set<String> keys = publishMessages(topic, 10, false);
@@ -102,11 +103,13 @@ public class MultiTopicsReaderTest extends MockedPulsarServiceBaseTest {
                 .startMessageIdInclusive().readerName(subscription).create();
         int count = 0;
         while (reader.hasMessageAvailable()) {
-            Assert.assertTrue(keys.remove(reader.readNext(1, TimeUnit.SECONDS).getKey()));
-            count++;
+            if (keys.remove(reader.readNext(5, TimeUnit.SECONDS).getKey())) {
+                count++;
+            }
         }
         Assert.assertEquals(count, topicNum);
         Assert.assertFalse(reader.hasMessageAvailable());
+        reader.close();
     }
 
     @Test(timeOut = 10000)
@@ -116,9 +119,9 @@ public class MultiTopicsReaderTest extends MockedPulsarServiceBaseTest {
         testReadMessages(topic, true);
     }
 
-    @Test(timeOut = 10000, groups = "quarantine")
+    @Test(timeOut = 10000)
     public void testReadMessageWithBatchingWithMessageInclusive() throws Exception {
-        String topic = "persistent://my-property/my-ns/my-reader-topic-with-batching-inclusive";
+        String topic = "persistent://my-property/my-ns/my-reader-topic-with-batching-inclusive" + UUID.randomUUID();
         int topicNum = 3;
         int msgNum = 15;
         admin.topics().createPartitionedTopic(topic, topicNum);
@@ -128,7 +131,7 @@ public class MultiTopicsReaderTest extends MockedPulsarServiceBaseTest {
                 .startMessageIdInclusive().readerName(subscription).create();
 
         while (reader.hasMessageAvailable()) {
-            Assert.assertTrue(keys.remove(reader.readNext(2, TimeUnit.SECONDS).getKey()));
+            keys.remove(reader.readNext(2, TimeUnit.SECONDS).getKey());
         }
         // start from latest with start message inclusive should only read the last 3 message from 3 partition
         Assert.assertEquals(keys.size(), msgNum - topicNum);
@@ -136,12 +139,13 @@ public class MultiTopicsReaderTest extends MockedPulsarServiceBaseTest {
         Assert.assertFalse(keys.contains("key13"));
         Assert.assertFalse(keys.contains("key12"));
         Assert.assertFalse(reader.hasMessageAvailable());
+        reader.close();
     }
 
     @Test(timeOut = 10000)
     public void testReaderWithTimeLong() throws Exception {
         String ns = "my-property/my-ns";
-        String topic = "persistent://" + ns + "/testReadFromPartition";
+        String topic = "persistent://" + ns + "/testReadFromPartition" + UUID.randomUUID();
         admin.topics().createPartitionedTopic(topic, 3);
         RetentionPolicies retention = new RetentionPolicies(-1, -1);
         admin.namespaces().setRetention(ns, retention);
@@ -161,6 +165,7 @@ public class MultiTopicsReaderTest extends MockedPulsarServiceBaseTest {
                 .setSequenceId(i)
                 .setProducerName(producer.getProducerName())
                 .setReplicatedFrom("us-west1");
+            msg.send();
         }
 
         // (2) Publish 10 messages with publish-time 1 HOUR back
@@ -199,6 +204,9 @@ public class MultiTopicsReaderTest extends MockedPulsarServiceBaseTest {
         restartBroker();
 
         assertFalse(reader.hasMessageAvailable());
+
+        reader.close();
+        producer.close();
     }
 
     @Test(timeOut = 10000)
@@ -274,8 +282,7 @@ public class MultiTopicsReaderTest extends MockedPulsarServiceBaseTest {
         }
         // receive messages
         while (reader.hasMessageAvailable()) {
-            Message<String> message = reader.readNext();
-            assertTrue(messages.remove(message.getValue()));
+            messages.remove(reader.readNext(5, TimeUnit.SECONDS).getValue());
         }
         assertEquals(messages.size(), 0);
         assertEquals(client.consumersCount(), 1);
@@ -378,8 +385,7 @@ public class MultiTopicsReaderTest extends MockedPulsarServiceBaseTest {
                 .create();
 
         while (reader.hasMessageAvailable()) {
-            Message<byte[]> message = reader.readNext();
-            Assert.assertTrue(keys.remove(message.getKey()));
+            keys.remove(reader.readNext(5, TimeUnit.SECONDS).getKey());
         }
         Assert.assertEquals(keys.size(), 0);
 
@@ -392,7 +398,6 @@ public class MultiTopicsReaderTest extends MockedPulsarServiceBaseTest {
         Set<String> keys = new HashSet<>();
         ProducerBuilder<byte[]> builder = pulsarClient.newProducer();
         builder.messageRoutingMode(MessageRoutingMode.RoundRobinPartition);
-        builder.maxPendingMessages(count);
         // disable periodical flushing
         builder.batchingMaxPublishDelay(1, TimeUnit.DAYS);
         builder.topic(topic);
@@ -401,17 +406,22 @@ public class MultiTopicsReaderTest extends MockedPulsarServiceBaseTest {
             builder.batchingMaxMessages(count);
         } else {
             builder.enableBatching(false);
+            builder.maxPendingMessages(1);
         }
         try (Producer<byte[]> producer = builder.create()) {
-            Future<?> lastFuture = null;
+            List<CompletableFuture<MessageId>> list = new ArrayList<>();
             for (int i = 0; i < count; i++) {
-                String key = "key"+i;
+                String key = "key" + i;
                 byte[] data = ("my-message-" + i).getBytes();
-                lastFuture = producer.newMessage().key(key).value(data).sendAsync();
+                if (enableBatch) {
+                    list.add(producer.newMessage().key(key).value(data).sendAsync());
+                } else {
+                    producer.newMessage().key(key).value(data).send();
+                }
                 keys.add(key);
             }
             producer.flush();
-            lastFuture.get();
+            FutureUtil.waitForAll(list).get();
         }
         return keys;
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/RetryUtilTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/RetryUtilTest.java
@@ -1,0 +1,81 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import org.apache.pulsar.client.util.RetryUtil;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+@Test(groups = "utils")
+public class RetryUtilTest {
+
+
+    @Test
+    public void testFailAndRetry() throws Exception {
+        ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+        CompletableFuture<Boolean> callback = new CompletableFuture<>();
+        AtomicInteger atomicInteger = new AtomicInteger(0);
+        Backoff backoff = new BackoffBuilder()
+                .setInitialTime(100, TimeUnit.MILLISECONDS)
+                .setMax(2000, TimeUnit.MILLISECONDS)
+                .setMandatoryStop(5000, TimeUnit.MILLISECONDS)
+                .create();
+        RetryUtil.retryAsynchronously(() -> {
+            atomicInteger.incrementAndGet();
+            if (atomicInteger.get() < 5) {
+                throw new RuntimeException("fail");
+            }
+            return true;
+        }, backoff, executor, callback);
+        assertTrue(callback.get());
+        assertEquals(atomicInteger.get(), 5);
+        executor.shutdownNow();
+    }
+
+    @Test
+    public void testFail() throws Exception {
+        ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+        CompletableFuture<Boolean> callback = new CompletableFuture<>();
+        Backoff backoff = new BackoffBuilder()
+                .setInitialTime(500, TimeUnit.MILLISECONDS)
+                .setMax(2000, TimeUnit.MILLISECONDS)
+                .setMandatoryStop(5000, TimeUnit.MILLISECONDS)
+                .create();
+        long start = System.currentTimeMillis();
+        RetryUtil.retryAsynchronously(() -> {
+            throw new RuntimeException("fail");
+        }, backoff, executor, callback);
+        try {
+            callback.get();
+        } catch (Exception e) {
+            assertTrue(e.getMessage().contains("fail"));
+        }
+        long time = System.currentTimeMillis() - start;
+        assertTrue(time >= 5000 - 2000, "Duration:" + time);
+        executor.shutdownNow();
+    }
+}

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdBrokerStats.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdBrokerStats.java
@@ -120,7 +120,7 @@ public class CmdBrokerStats extends CmdBase {
 
     @Parameters(commandDescription = "dump allocator stats")
     private class CmdAllocatorStats extends CliCommand {
-        @Parameter(description = "allocator-name\n", required = true)
+        @Parameter(description = "allocator-name", required = true)
         private List<String> params;
 
         @Override

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdBrokers.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdBrokers.java
@@ -30,7 +30,7 @@ public class CmdBrokers extends CmdBase {
 
     @Parameters(commandDescription = "List active brokers of the cluster")
     private class List extends CliCommand {
-        @Parameter(description = "cluster-name\n", required = true)
+        @Parameter(description = "cluster-name", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -51,9 +51,9 @@ public class CmdBrokers extends CmdBase {
 
     @Parameters(commandDescription = "List namespaces owned by the broker")
     private class Namespaces extends CliCommand {
-        @Parameter(description = "cluster-name\n", required = true)
+        @Parameter(description = "cluster-name", required = true)
         private java.util.List<String> params;
-        @Parameter(names = "--url", description = "broker-url\n", required = true)
+        @Parameter(names = "--url", description = "broker-url", required = true)
         private String brokerUrl;
 
         @Override

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdClusters.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdClusters.java
@@ -45,7 +45,7 @@ public class CmdClusters extends CmdBase {
 
     @Parameters(commandDescription = "Get the configuration data for the specified cluster")
     private class Get extends CliCommand {
-        @Parameter(description = "cluster-name\n", required = true)
+        @Parameter(description = "cluster-name", required = true)
         private java.util.List<String> params;
 
         void run() throws PulsarAdminException {
@@ -56,7 +56,7 @@ public class CmdClusters extends CmdBase {
 
     @Parameters(commandDescription = "Provisions a new cluster. This operation requires Pulsar super-user privileges")
     private class Create extends CliCommand {
-        @Parameter(description = "cluster-name\n", required = true)
+        @Parameter(description = "cluster-name", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = "--url", description = "service-url", required = false)
@@ -87,7 +87,7 @@ public class CmdClusters extends CmdBase {
 
     @Parameters(commandDescription = "Update the configuration for a cluster")
     private class Update extends CliCommand {
-        @Parameter(description = "cluster-name\n", required = true)
+        @Parameter(description = "cluster-name", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = "--url", description = "service-url", required = false)
@@ -117,10 +117,10 @@ public class CmdClusters extends CmdBase {
 
     @Parameters(commandDescription = "Deletes an existing cluster")
     private class Delete extends CliCommand {
-        @Parameter(description = "cluster-name\n", required = true)
+        @Parameter(description = "cluster-name", required = true)
         private java.util.List<String> params;
 
-        @Parameter(names = { "-a", "--all" }, description = "Delete all data (tenants) of the cluster\n", required = false)
+        @Parameter(names = { "-a", "--all" }, description = "Delete all data (tenants) of the cluster", required = false)
         private boolean deleteAll = false;
 
         void run() throws PulsarAdminException {
@@ -148,7 +148,7 @@ public class CmdClusters extends CmdBase {
 
     @Parameters(commandDescription = "Update peer cluster names")
     private class UpdatePeerClusters extends CliCommand {
-        @Parameter(description = "cluster-name\n", required = true)
+        @Parameter(description = "cluster-name", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = "--peer-clusters", description = "Comma separated peer-cluster names [Pass empty string \"\" to delete list]", required = true)
@@ -165,7 +165,7 @@ public class CmdClusters extends CmdBase {
     @Parameters(commandDescription = "Get list of peer-clusters")
     private class GetPeerClusters extends CliCommand {
         
-        @Parameter(description = "cluster-name\n", required = true)
+        @Parameter(description = "cluster-name", required = true)
         private java.util.List<String> params;
         
         void run() throws PulsarAdminException {
@@ -177,7 +177,7 @@ public class CmdClusters extends CmdBase {
     
     @Parameters(commandDescription = "Create a new failure-domain for a cluster. updates it if already created.")
     private class CreateFailureDomain extends CliCommand {
-        @Parameter(description = "cluster-name\n", required = true)
+        @Parameter(description = "cluster-name", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = "--domain-name", description = "domain-name", required = true)
@@ -196,7 +196,7 @@ public class CmdClusters extends CmdBase {
 
     @Parameters(commandDescription = "Update failure-domain for a cluster. Creates a new one if not exist.")
     private class UpdateFailureDomain extends CliCommand {
-        @Parameter(description = "cluster-name\n", required = true)
+        @Parameter(description = "cluster-name", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = "--domain-name", description = "domain-name", required = true)
@@ -215,7 +215,7 @@ public class CmdClusters extends CmdBase {
     
     @Parameters(commandDescription = "Deletes an existing failure-domain")
     private class DeleteFailureDomain extends CliCommand {
-        @Parameter(description = "cluster-name\n", required = true)
+        @Parameter(description = "cluster-name", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = "--domain-name", description = "domain-name", required = true)
@@ -230,7 +230,7 @@ public class CmdClusters extends CmdBase {
     @Parameters(commandDescription = "List the existing failure-domains for a cluster")
     private class ListFailureDomains extends CliCommand {
         
-        @Parameter(description = "cluster-name\n", required = true)
+        @Parameter(description = "cluster-name", required = true)
         private java.util.List<String> params;
         
         void run() throws PulsarAdminException {
@@ -241,7 +241,7 @@ public class CmdClusters extends CmdBase {
 
     @Parameters(commandDescription = "Get the configuration brokers of a failure-domain")
     private class GetFailureDomain extends CliCommand {
-        @Parameter(description = "cluster-name\n", required = true)
+        @Parameter(description = "cluster-name", required = true)
         private java.util.List<String> params;
         
         @Parameter(names = "--domain-name", description = "domain-name", required = true)

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
@@ -631,14 +631,14 @@ public class CmdFunctions extends CmdBase {
         @Parameter(names = "--client-auth-params", description = "Client authentication param")
         protected String clientAuthParams;
         // for backwards compatibility purposes
-        @Parameter(names = "--use_tls", description = "Use tls connection\n", hidden = true)
+        @Parameter(names = "--use_tls", description = "Use tls connection", hidden = true)
         protected Boolean DEPRECATED_useTls = null;
-        @Parameter(names = "--use-tls", description = "Use tls connection\n")
+        @Parameter(names = "--use-tls", description = "Use tls connection")
         protected boolean useTls;
         // for backwards compatibility purposes
-        @Parameter(names = "--tls_allow_insecure", description = "Allow insecure tls connection\n", hidden = true)
+        @Parameter(names = "--tls_allow_insecure", description = "Allow insecure tls connection", hidden = true)
         protected Boolean DEPRECATED_tlsAllowInsecureConnection = null;
-        @Parameter(names = "--tls-allow-insecure", description = "Allow insecure tls connection\n")
+        @Parameter(names = "--tls-allow-insecure", description = "Allow insecure tls connection")
         protected boolean tlsAllowInsecureConnection;
         // for backwards compatibility purposes
         @Parameter(names = "--hostname_verification_enabled", description = "Enable hostname verification", hidden = true)

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaceIsolationPolicy.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaceIsolationPolicy.java
@@ -40,7 +40,7 @@ import com.beust.jcommander.converters.CommaParameterSplitter;
 public class CmdNamespaceIsolationPolicy extends CmdBase {
     @Parameters(commandDescription = "Create/Update a namespace isolation policy for a cluster. This operation requires Pulsar super-user privileges")
     private class SetPolicy extends CliCommand {
-        @Parameter(description = "cluster-name policy-name\n", required = true)
+        @Parameter(description = "cluster-name policy-name", required = true)
         private List<String> params;
 
         @Parameter(names = "--namespaces", description = "comma separated namespaces-regex list", required = true, splitter = CommaParameterSplitter.class)
@@ -72,7 +72,7 @@ public class CmdNamespaceIsolationPolicy extends CmdBase {
 
     @Parameters(commandDescription = "List all namespace isolation policies of a cluster. This operation requires Pulsar super-user privileges")
     private class GetAllPolicies extends CliCommand {
-        @Parameter(description = "cluster-name\n", required = true)
+        @Parameter(description = "cluster-name", required = true)
         private List<String> params;
 
         void run() throws PulsarAdminException {
@@ -86,7 +86,7 @@ public class CmdNamespaceIsolationPolicy extends CmdBase {
 
     @Parameters(commandDescription = "List all brokers with namespace-isolation policies attached to it. This operation requires Pulsar super-user privileges")
     private class GetAllBrokersWithPolicies extends CliCommand {
-        @Parameter(description = "cluster-name\n", required = true)
+        @Parameter(description = "cluster-name", required = true)
         private List<String> params;
 
         void run() throws PulsarAdminException {
@@ -101,7 +101,7 @@ public class CmdNamespaceIsolationPolicy extends CmdBase {
 
     @Parameters(commandDescription = "Get broker with namespace-isolation policies attached to it. This operation requires Pulsar super-user privileges")
     private class GetBrokerWithPolicies extends CliCommand {
-        @Parameter(description = "cluster-name\n", required = true)
+        @Parameter(description = "cluster-name", required = true)
         private List<String> params;
 
         @Parameter(names = "--broker", description = "Broker-name to get namespace-isolation policies attached to it", required = true)
@@ -119,7 +119,7 @@ public class CmdNamespaceIsolationPolicy extends CmdBase {
 
     @Parameters(commandDescription = "Get namespace isolation policy of a cluster. This operation requires Pulsar super-user privileges")
     private class GetPolicy extends CliCommand {
-        @Parameter(description = "cluster-name policy-name\n", required = true)
+        @Parameter(description = "cluster-name policy-name", required = true)
         private List<String> params;
 
         void run() throws PulsarAdminException {
@@ -135,7 +135,7 @@ public class CmdNamespaceIsolationPolicy extends CmdBase {
 
     @Parameters(commandDescription = "Delete namespace isolation policy of a cluster. This operation requires Pulsar super-user privileges")
     private class DeletePolicy extends CliCommand {
-        @Parameter(description = "cluster-name policy-name\n", required = true)
+        @Parameter(description = "cluster-name policy-name", required = true)
         private List<String> params;
 
         void run() throws PulsarAdminException {

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
@@ -67,7 +67,7 @@ import org.apache.pulsar.common.util.RelativeTimeUtil;
 public class CmdNamespaces extends CmdBase {
     @Parameters(commandDescription = "Get the namespaces for a tenant")
     private class GetNamespacesPerProperty extends CliCommand {
-        @Parameter(description = "tenant-name\n", required = true)
+        @Parameter(description = "tenant-name", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -79,7 +79,7 @@ public class CmdNamespaces extends CmdBase {
 
     @Parameters(commandDescription = "Get the namespaces for a tenant in a cluster", hidden = true)
     private class GetNamespacesPerCluster extends CliCommand {
-        @Parameter(description = "tenant/cluster\n", required = true)
+        @Parameter(description = "tenant/cluster", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -91,7 +91,7 @@ public class CmdNamespaces extends CmdBase {
 
     @Parameters(commandDescription = "Get the list of topics for a namespace")
     private class GetTopics extends CliCommand {
-        @Parameter(description = "tenant/namespace\n", required = true)
+        @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -103,7 +103,7 @@ public class CmdNamespaces extends CmdBase {
 
     @Parameters(commandDescription = "Get the list of bundles for a namespace")
     private class GetBundles extends CliCommand {
-        @Parameter(description = "tenant/namespace\n", required = true)
+        @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -115,7 +115,7 @@ public class CmdNamespaces extends CmdBase {
 
     @Parameters(commandDescription = "Get the list of destinations for a namespace", hidden = true)
     private class GetDestinations extends CliCommand {
-        @Parameter(description = "tenant/namespace\n", required = true)
+        @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -127,7 +127,7 @@ public class CmdNamespaces extends CmdBase {
 
     @Parameters(commandDescription = "Get the configuration policies of a namespace")
     private class GetPolicies extends CliCommand {
-        @Parameter(description = "tenant/namespace\n", required = true)
+        @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -139,7 +139,7 @@ public class CmdNamespaces extends CmdBase {
 
     @Parameters(commandDescription = "Creates a new namespace")
     private class Create extends CliCommand {
-        @Parameter(description = "tenant/namespace\n", required = true)
+        @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = { "--clusters", "-c" }, description = "List of clusters this namespace will be assigned", required = false)
@@ -184,7 +184,7 @@ public class CmdNamespaces extends CmdBase {
 
     @Parameters(commandDescription = "Deletes a namespace.")
     private class Delete extends CliCommand {
-        @Parameter(description = "tenant/namespace\n", required = true)
+        @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = { "-f",
@@ -269,7 +269,7 @@ public class CmdNamespaces extends CmdBase {
 
     @Parameters(commandDescription = "Get the permissions on a namespace")
     private class Permissions extends CliCommand {
-        @Parameter(description = "tenant/namespace\n", required = true)
+        @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -298,7 +298,7 @@ public class CmdNamespaces extends CmdBase {
 
     @Parameters(commandDescription = "Get replication clusters for a namespace")
     private class GetReplicationClusters extends CliCommand {
-        @Parameter(description = "tenant/namespace\n", required = true)
+        @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -328,7 +328,7 @@ public class CmdNamespaces extends CmdBase {
 
     @Parameters(commandDescription = "Get subscription types enabled for a namespace")
     private class GetSubscriptionTypesEnabled extends CliCommand {
-        @Parameter(description = "tenant/namespace\n", required = true)
+        @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -367,7 +367,7 @@ public class CmdNamespaces extends CmdBase {
 
     @Parameters(commandDescription = "Get max subscriptions per topic for a namespace")
     private class GetMaxSubscriptionsPerTopic extends CliCommand {
-        @Parameter(description = "tenant/namespace\n", required = true)
+        @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -437,7 +437,7 @@ public class CmdNamespaces extends CmdBase {
 
     @Parameters(commandDescription = "Get Anti-affinity group name for a namespace")
     private class GetAntiAffinityGroup extends CliCommand {
-        @Parameter(description = "tenant/namespace\n", required = true)
+        @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -468,7 +468,7 @@ public class CmdNamespaces extends CmdBase {
 
     @Parameters(commandDescription = "Remove Anti-affinity group name for a namespace")
     private class DeleteAntiAffinityGroup extends CliCommand {
-        @Parameter(description = "tenant/namespace\n", required = true)
+        @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -480,7 +480,7 @@ public class CmdNamespaces extends CmdBase {
 
     @Parameters(commandDescription = "Get Deduplication for a namespace")
     private class GetDeduplication extends CliCommand {
-        @Parameter(description = "tenant/namespace\n", required = true)
+        @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -492,7 +492,7 @@ public class CmdNamespaces extends CmdBase {
 
     @Parameters(commandDescription = "Remove Deduplication for a namespace")
     private class RemoveDeduplication extends CliCommand {
-        @Parameter(description = "tenant/namespace\n", required = true)
+        @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -656,7 +656,7 @@ public class CmdNamespaces extends CmdBase {
 
     @Parameters(commandDescription = "Get the retention policy for a namespace")
     private class GetRetention extends CliCommand {
-        @Parameter(description = "tenant/namespace\n", required = true)
+        @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -701,7 +701,7 @@ public class CmdNamespaces extends CmdBase {
 
     @Parameters(commandDescription = "Get the bookie-affinity group name")
     private class GetBookieAffinityGroup extends CliCommand {
-        @Parameter(description = "tenant/namespace\n", required = true)
+        @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -713,7 +713,7 @@ public class CmdNamespaces extends CmdBase {
 
     @Parameters(commandDescription = "Get message TTL for a namespace")
     private class GetMessageTTL extends CliCommand {
-        @Parameter(description = "tenant/namespace\n", required = true)
+        @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -725,7 +725,7 @@ public class CmdNamespaces extends CmdBase {
 
     @Parameters(commandDescription = "Get subscription expiration time for a namespace")
     private class GetSubscriptionExpirationTime extends CliCommand {
-        @Parameter(description = "tenant/namespace\n", required = true)
+        @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -737,10 +737,10 @@ public class CmdNamespaces extends CmdBase {
 
     @Parameters(commandDescription = "Unload a namespace from the current serving broker")
     private class Unload extends CliCommand {
-        @Parameter(description = "tenant/namespace\n", required = true)
+        @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
-        @Parameter(names = { "--bundle", "-b" }, description = "{start-boundary}_{end-boundary}\n")
+        @Parameter(names = { "--bundle", "-b" }, description = "{start-boundary}_{end-boundary}")
         private String bundle;
 
         @Override
@@ -756,18 +756,18 @@ public class CmdNamespaces extends CmdBase {
 
     @Parameters(commandDescription = "Split a namespace-bundle from the current serving broker")
     private class SplitBundle extends CliCommand {
-        @Parameter(description = "tenant/namespace\n", required = true)
+        @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
-        @Parameter(names = { "--bundle", "-b" }, description = "{start-boundary}_{end-boundary}\n", required = true)
+        @Parameter(names = { "--bundle", "-b" }, description = "{start-boundary}_{end-boundary}", required = true)
         private String bundle;
 
         @Parameter(names = { "--unload",
                 "-u" }, description = "Unload newly split bundles after splitting old bundle", required = false)
         private boolean unload;
 
-        @Parameter(names = { "--split-algorithm-name", "-san" }, description = "Algorithm name for split namespace bundle.\n" +
-            " Valid options are: [range_equally_divide, topic_count_equally_divide].\n" +
+        @Parameter(names = { "--split-algorithm-name", "-san" }, description = "Algorithm name for split namespace bundle." +
+            " Valid options are: [range_equally_divide, topic_count_equally_divide]." +
             " Use broker side config if absent", required = false)
         private String splitAlgorithmName;
 
@@ -780,23 +780,23 @@ public class CmdNamespaces extends CmdBase {
 
     @Parameters(commandDescription = "Set message-dispatch-rate for all topics of the namespace")
     private class SetDispatchRate extends CliCommand {
-        @Parameter(description = "tenant/namespace\n", required = true)
+        @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = { "--msg-dispatch-rate",
-                "-md" }, description = "message-dispatch-rate (default -1 will be overwrite if not passed)\n", required = false)
+                "-md" }, description = "message-dispatch-rate (default -1 will be overwrite if not passed)", required = false)
         private int msgDispatchRate = -1;
 
         @Parameter(names = { "--byte-dispatch-rate",
-                "-bd" }, description = "byte-dispatch-rate (default -1 will be overwrite if not passed)\n", required = false)
+                "-bd" }, description = "byte-dispatch-rate (default -1 will be overwrite if not passed)", required = false)
         private long byteDispatchRate = -1;
 
         @Parameter(names = { "--dispatch-rate-period",
-                "-dt" }, description = "dispatch-rate-period in second type (default 1 second will be overwrite if not passed)\n", required = false)
+                "-dt" }, description = "dispatch-rate-period in second type (default 1 second will be overwrite if not passed)", required = false)
         private int dispatchRatePeriodSec = 1;
 
         @Parameter(names = { "--relative-to-publish-rate",
-                "-rp" }, description = "dispatch rate relative to publish-rate (if publish-relative flag is enabled then broker will apply throttling value to (publish-rate + dispatch rate))\n", required = false)
+                "-rp" }, description = "dispatch rate relative to publish-rate (if publish-relative flag is enabled then broker will apply throttling value to (publish-rate + dispatch rate))", required = false)
         private boolean relativeToPublishRate = false;
 
         @Override
@@ -809,7 +809,7 @@ public class CmdNamespaces extends CmdBase {
 
     @Parameters(commandDescription = "Remove configured message-dispatch-rate for all topics of the namespace")
     private class RemoveDispatchRate extends CliCommand {
-        @Parameter(description = "tenant/namespace\n", required = true)
+        @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -821,7 +821,7 @@ public class CmdNamespaces extends CmdBase {
 
     @Parameters(commandDescription = "Get configured message-dispatch-rate for all topics of the namespace (Disabled if value < 0)")
     private class GetDispatchRate extends CliCommand {
-        @Parameter(description = "tenant/namespace\n", required = true)
+        @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -834,15 +834,15 @@ public class CmdNamespaces extends CmdBase {
     @Parameters(commandDescription = "Set subscribe-rate per consumer for all topics of the namespace")
     private class SetSubscribeRate extends CliCommand {
 
-        @Parameter(description = "tenant/namespace\n", required = true)
+        @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = { "--subscribe-rate",
-                "-sr" }, description = "subscribe-rate (default -1 will be overwrite if not passed)\n", required = false)
+                "-sr" }, description = "subscribe-rate (default -1 will be overwrite if not passed)", required = false)
         private int subscribeRate = -1;
 
         @Parameter(names = { "--subscribe-rate-period",
-                "-st" }, description = "subscribe-rate-period in second type (default 30 second will be overwrite if not passed)\n", required = false)
+                "-st" }, description = "subscribe-rate-period in second type (default 30 second will be overwrite if not passed)", required = false)
         private int subscribeRatePeriodSec = 30;
 
         @Override
@@ -855,7 +855,7 @@ public class CmdNamespaces extends CmdBase {
 
     @Parameters(commandDescription = "Get configured subscribe-rate per consumer for all topics of the namespace")
     private class GetSubscribeRate extends CliCommand {
-        @Parameter(description = "tenant/namespace\n", required = true)
+        @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -867,7 +867,7 @@ public class CmdNamespaces extends CmdBase {
 
     @Parameters(commandDescription = "Remove configured subscribe-rate per consumer for all topics of the namespace")
     private class RemoveSubscribeRate extends CliCommand {
-        @Parameter(description = "tenant/namespace\n", required = true)
+        @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -880,23 +880,23 @@ public class CmdNamespaces extends CmdBase {
 
     @Parameters(commandDescription = "Set subscription message-dispatch-rate for all subscription of the namespace")
     private class SetSubscriptionDispatchRate extends CliCommand {
-        @Parameter(description = "tenant/namespace\n", required = true)
+        @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = { "--msg-dispatch-rate",
-            "-md" }, description = "message-dispatch-rate (default -1 will be overwrite if not passed)\n", required = false)
+            "-md" }, description = "message-dispatch-rate (default -1 will be overwrite if not passed)", required = false)
         private int msgDispatchRate = -1;
 
         @Parameter(names = { "--byte-dispatch-rate",
-            "-bd" }, description = "byte-dispatch-rate (default -1 will be overwrite if not passed)\n", required = false)
+            "-bd" }, description = "byte-dispatch-rate (default -1 will be overwrite if not passed)", required = false)
         private long byteDispatchRate = -1;
 
         @Parameter(names = { "--dispatch-rate-period",
-            "-dt" }, description = "dispatch-rate-period in second type (default 1 second will be overwrite if not passed)\n", required = false)
+            "-dt" }, description = "dispatch-rate-period in second type (default 1 second will be overwrite if not passed)", required = false)
         private int dispatchRatePeriodSec = 1;
 
         @Parameter(names = { "--relative-to-publish-rate",
-                "-rp" }, description = "dispatch rate relative to publish-rate (if publish-relative flag is enabled then broker will apply throttling value to (publish-rate + dispatch rate))\n", required = false)
+                "-rp" }, description = "dispatch rate relative to publish-rate (if publish-relative flag is enabled then broker will apply throttling value to (publish-rate + dispatch rate))", required = false)
         private boolean relativeToPublishRate = false;
 
         @Override
@@ -910,7 +910,7 @@ public class CmdNamespaces extends CmdBase {
     @Parameters(commandDescription = "Remove subscription configured message-dispatch-rate " +
             "for all topics of the namespace")
     private class RemoveSubscriptionDispatchRate extends CliCommand {
-        @Parameter(description = "tenant/namespace\n", required = true)
+        @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -922,7 +922,7 @@ public class CmdNamespaces extends CmdBase {
 
     @Parameters(commandDescription = "Get subscription configured message-dispatch-rate for all topics of the namespace (Disabled if value < 0)")
     private class GetSubscriptionDispatchRate extends CliCommand {
-        @Parameter(description = "tenant/namespace\n", required = true)
+        @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -934,15 +934,15 @@ public class CmdNamespaces extends CmdBase {
 
     @Parameters(commandDescription = "Set publish-rate for all topics of the namespace")
     private class SetPublishRate extends CliCommand {
-        @Parameter(description = "tenant/namespace\n", required = true)
+        @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
          @Parameter(names = { "--msg-publish-rate",
-            "-m" }, description = "message-publish-rate (default -1 will be overwrite if not passed)\n", required = false)
+            "-m" }, description = "message-publish-rate (default -1 will be overwrite if not passed)", required = false)
         private int msgPublishRate = -1;
 
          @Parameter(names = { "--byte-publish-rate",
-            "-b" }, description = "byte-publish-rate (default -1 will be overwrite if not passed)\n", required = false)
+            "-b" }, description = "byte-publish-rate (default -1 will be overwrite if not passed)", required = false)
         private long bytePublishRate = -1;
 
          @Override
@@ -955,7 +955,7 @@ public class CmdNamespaces extends CmdBase {
 
     @Parameters(commandDescription = "Remove publish-rate for all topics of the namespace")
     private class RemovePublishRate extends CliCommand {
-        @Parameter(description = "tenant/namespace\n", required = true)
+        @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -967,7 +967,7 @@ public class CmdNamespaces extends CmdBase {
 
      @Parameters(commandDescription = "Get configured message-publish-rate for all topics of the namespace (Disabled if value < 0)")
     private class GetPublishRate extends CliCommand {
-        @Parameter(description = "tenant/namespace\n", required = true)
+        @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
          @Override
@@ -979,19 +979,19 @@ public class CmdNamespaces extends CmdBase {
 
     @Parameters(commandDescription = "Set replicator message-dispatch-rate for all topics of the namespace")
     private class SetReplicatorDispatchRate extends CliCommand {
-        @Parameter(description = "tenant/namespace\n", required = true)
+        @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = { "--msg-dispatch-rate",
-            "-md" }, description = "message-dispatch-rate (default -1 will be overwrite if not passed)\n", required = false)
+            "-md" }, description = "message-dispatch-rate (default -1 will be overwrite if not passed)", required = false)
         private int msgDispatchRate = -1;
 
         @Parameter(names = { "--byte-dispatch-rate",
-            "-bd" }, description = "byte-dispatch-rate (default -1 will be overwrite if not passed)\n", required = false)
+            "-bd" }, description = "byte-dispatch-rate (default -1 will be overwrite if not passed)", required = false)
         private long byteDispatchRate = -1;
 
         @Parameter(names = { "--dispatch-rate-period",
-            "-dt" }, description = "dispatch-rate-period in second type (default 1 second will be overwrite if not passed)\n", required = false)
+            "-dt" }, description = "dispatch-rate-period in second type (default 1 second will be overwrite if not passed)", required = false)
         private int dispatchRatePeriodSec = 1;
 
         @Override
@@ -1004,7 +1004,7 @@ public class CmdNamespaces extends CmdBase {
 
     @Parameters(commandDescription = "Get replicator configured message-dispatch-rate for all topics of the namespace (Disabled if value < 0)")
     private class GetReplicatorDispatchRate extends CliCommand {
-        @Parameter(description = "tenant/namespace\n", required = true)
+        @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -1017,7 +1017,7 @@ public class CmdNamespaces extends CmdBase {
     @Parameters(commandDescription = "Remove replicator configured message-dispatch-rate " +
             "for all topics of the namespace")
     private class RemoveReplicatorDispatchRate extends CliCommand {
-        @Parameter(description = "tenant/namespace\n", required = true)
+        @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -1029,7 +1029,7 @@ public class CmdNamespaces extends CmdBase {
 
     @Parameters(commandDescription = "Get the backlog quota policies for a namespace")
     private class GetBacklogQuotaMap extends CliCommand {
-        @Parameter(description = "tenant/namespace\n", required = true)
+        @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -1084,7 +1084,7 @@ public class CmdNamespaces extends CmdBase {
 
     @Parameters(commandDescription = "Get the persistence policies for a namespace")
     private class GetPersistence extends CliCommand {
-        @Parameter(description = "tenant/namespace\n", required = true)
+        @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -1096,7 +1096,7 @@ public class CmdNamespaces extends CmdBase {
 
     @Parameters(commandDescription = "Remove the persistence policies for a namespace")
     private class RemovePersistence extends CliCommand {
-        @Parameter(description = "tenant/namespace\n", required = true)
+        @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -1143,7 +1143,7 @@ public class CmdNamespaces extends CmdBase {
         @Parameter(names = { "--sub", "-s" }, description = "subscription name")
         private String subscription;
 
-        @Parameter(names = { "--bundle", "-b" }, description = "{start-boundary}_{end-boundary}\n")
+        @Parameter(names = { "--bundle", "-b" }, description = "{start-boundary}_{end-boundary}")
         private String bundle;
 
         @Parameter(names = { "--force", "-force" }, description = "Whether to force clear backlog without prompt")
@@ -1179,7 +1179,7 @@ public class CmdNamespaces extends CmdBase {
         @Parameter(names = { "--sub", "-s" }, description = "subscription name", required = true)
         private String subscription;
 
-        @Parameter(names = { "--bundle", "-b" }, description = "{start-boundary}_{end-boundary}\n")
+        @Parameter(names = { "--bundle", "-b" }, description = "{start-boundary}_{end-boundary}")
         private String bundle;
 
         @Override
@@ -1218,7 +1218,7 @@ public class CmdNamespaces extends CmdBase {
 
     @Parameters(commandDescription = "Get the delayed delivery policy for a namespace")
     private class GetDelayedDelivery extends CliCommand {
-        @Parameter(description = "tenant/namespace\n", required = true)
+        @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -1242,7 +1242,7 @@ public class CmdNamespaces extends CmdBase {
 
     @Parameters(commandDescription = "Get the inactive topic policy for a namespace")
     private class GetInactiveTopicPolicies extends CliCommand {
-        @Parameter(description = "tenant/namespace\n", required = true)
+        @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -1347,7 +1347,7 @@ public class CmdNamespaces extends CmdBase {
 
     @Parameters(commandDescription = "Get deduplicationSnapshotInterval for a namespace")
     private class GetDeduplicationSnapshotInterval extends CliCommand {
-        @Parameter(description = "tenant/namespace\n", required = true)
+        @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -1359,7 +1359,7 @@ public class CmdNamespaces extends CmdBase {
 
     @Parameters(commandDescription = "Remove deduplicationSnapshotInterval for a namespace")
     private class RemoveDeduplicationSnapshotInterval extends CliCommand {
-        @Parameter(description = "tenant/namespace\n", required = true)
+        @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -1387,7 +1387,7 @@ public class CmdNamespaces extends CmdBase {
 
     @Parameters(commandDescription = "Get maxProducersPerTopic for a namespace")
     private class GetMaxProducersPerTopic extends CliCommand {
-        @Parameter(description = "tenant/namespace\n", required = true)
+        @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -1426,7 +1426,7 @@ public class CmdNamespaces extends CmdBase {
 
     @Parameters(commandDescription = "Get maxConsumersPerTopic for a namespace")
     private class GetMaxConsumersPerTopic extends CliCommand {
-        @Parameter(description = "tenant/namespace\n", required = true)
+        @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -1465,7 +1465,7 @@ public class CmdNamespaces extends CmdBase {
 
     @Parameters(commandDescription = "Get maxConsumersPerSubscription for a namespace")
     private class GetMaxConsumersPerSubscription extends CliCommand {
-        @Parameter(description = "tenant/namespace\n", required = true)
+        @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -1477,7 +1477,7 @@ public class CmdNamespaces extends CmdBase {
 
     @Parameters(commandDescription = "Remove maxConsumersPerSubscription for a namespace")
     private class RemoveMaxConsumersPerSubscription extends CliCommand {
-        @Parameter(description = "tenant/namespace\n", required = true)
+        @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -1504,7 +1504,7 @@ public class CmdNamespaces extends CmdBase {
 
     @Parameters(commandDescription = "Get maxUnackedMessagesPerConsumer for a namespace")
     private class GetMaxUnackedMessagesPerConsumer extends CliCommand {
-        @Parameter(description = "tenant/namespace\n", required = true)
+        @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -1531,7 +1531,7 @@ public class CmdNamespaces extends CmdBase {
 
     @Parameters(commandDescription = "Get maxUnackedMessagesPerSubscription for a namespace")
     private class GetMaxUnackedMessagesPerSubscription extends CliCommand {
-        @Parameter(description = "tenant/namespace\n", required = true)
+        @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -1570,7 +1570,7 @@ public class CmdNamespaces extends CmdBase {
 
     @Parameters(commandDescription = "Get compactionThreshold for a namespace")
     private class GetCompactionThreshold extends CliCommand {
-        @Parameter(description = "tenant/namespace\n", required = true)
+        @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -1582,7 +1582,7 @@ public class CmdNamespaces extends CmdBase {
 
     @Parameters(commandDescription = "Remove compactionThreshold for a namespace")
     private class RemoveCompactionThreshold extends CliCommand {
-        @Parameter(description = "tenant/namespace\n", required = true)
+        @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -1612,7 +1612,7 @@ public class CmdNamespaces extends CmdBase {
 
     @Parameters(commandDescription = "Get offloadThreshold for a namespace")
     private class GetOffloadThreshold extends CliCommand {
-        @Parameter(description = "tenant/namespace\n", required = true)
+        @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -1645,7 +1645,7 @@ public class CmdNamespaces extends CmdBase {
 
     @Parameters(commandDescription = "Get offloadDeletionLag, in minutes, for a namespace")
     private class GetOffloadDeletionLag extends CliCommand {
-        @Parameter(description = "tenant/namespace\n", required = true)
+        @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -2037,7 +2037,7 @@ public class CmdNamespaces extends CmdBase {
 
     @Parameters(commandDescription = "Get the offload policies for a namespace")
     private class GetOffloadPolicies extends CliCommand {
-        @Parameter(description = "tenant/namespace\n", required = true)
+        @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -2064,7 +2064,7 @@ public class CmdNamespaces extends CmdBase {
 
     @Parameters(commandDescription = "Get max topics per namespace")
     private class GetMaxTopicsPerNamespace extends CliCommand {
-        @Parameter(description = "tenant/namespace\n", required = true)
+        @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -2076,7 +2076,7 @@ public class CmdNamespaces extends CmdBase {
 
     @Parameters(commandDescription = "Remove max topics per namespace")
     private class RemoveMaxTopicsPerNamespace extends CliCommand {
-        @Parameter(description = "tenant/namespace\n", required = true)
+        @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -2088,7 +2088,7 @@ public class CmdNamespaces extends CmdBase {
 
     @Parameters(commandDescription = "Get ResourceGroup for a namespace")
     private class GetResourceGroup extends CliCommand {
-        @Parameter(description = "tenant/namespace\n", required = true)
+        @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
         @Override

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNonPersistentTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNonPersistentTopics.java
@@ -53,7 +53,7 @@ public class CmdNonPersistentTopics extends CmdBase {
 
     @Parameters(commandDescription = "Lookup a topic from the current serving broker")
     private class Lookup extends CliCommand {
-        @Parameter(description = "non-persistent://property/cluster/namespace/topic\n", required = true)
+        @Parameter(description = "non-persistent://property/cluster/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -63,10 +63,10 @@ public class CmdNonPersistentTopics extends CmdBase {
         }
     }
 
-    @Parameters(commandDescription = "Get the stats for the topic and its connected producers and consumers. \n"
-            + "\t       All the rates are computed over a 1 minute window and are relative the last completed 1 minute period.")
+    @Parameters(commandDescription = "Get the stats for the topic and its connected producers and consumers. "
+            + "All the rates are computed over a 1 minute window and are relative the last completed 1 minute period.")
     private class GetStats extends CliCommand {
-        @Parameter(description = "non-persistent://property/cluster/namespace/topic\n", required = true)
+        @Parameter(description = "non-persistent://property/cluster/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -78,7 +78,7 @@ public class CmdNonPersistentTopics extends CmdBase {
 
     @Parameters(commandDescription = "Get the internal stats for the topic")
     private class GetInternalStats extends CliCommand {
-        @Parameter(description = "non-persistent://property/cluster/namespace/topic\n", required = true)
+        @Parameter(description = "non-persistent://property/cluster/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -88,11 +88,11 @@ public class CmdNonPersistentTopics extends CmdBase {
         }
     }
 
-    @Parameters(commandDescription = "Create a partitioned topic. \n"
-            + "\t\tThe partitioned topic has to be created before creating a producer on it.")
+    @Parameters(commandDescription = "Create a partitioned topic. "
+            + "The partitioned topic has to be created before creating a producer on it.")
     private class CreatePartitionedCmd extends CliCommand {
 
-        @Parameter(description = "non-persistent://property/cluster/namespace/topic\n", required = true)
+        @Parameter(description = "non-persistent://property/cluster/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = { "-p",
@@ -106,11 +106,11 @@ public class CmdNonPersistentTopics extends CmdBase {
         }
     }
 
-    @Parameters(commandDescription = "Get the partitioned topic metadata. \n"
-            + "\t\tIf the topic is not created or is a non-partitioned topic, it returns empty topic with 0 partitions")
+    @Parameters(commandDescription = "Get the partitioned topic metadata. "
+            + "If the topic is not created or is a non-partitioned topic, it returns empty topic with 0 partitions")
     private class GetPartitionedTopicMetadataCmd extends CliCommand {
 
-        @Parameter(description = "non-persistent://property/cluster/namespace/topic\n", required = true)
+        @Parameter(description = "non-persistent://property/cluster/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -122,7 +122,7 @@ public class CmdNonPersistentTopics extends CmdBase {
 
     @Parameters(commandDescription = "Get list of non-persistent topics present under a namespace")
     private class GetList extends CliCommand {
-        @Parameter(description = "property/cluster/namespace\n", required = true)
+        @Parameter(description = "property/cluster/namespace", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -134,7 +134,7 @@ public class CmdNonPersistentTopics extends CmdBase {
 
     @Parameters(commandDescription = "Get list of non-persistent topics present under a namespace bundle")
     private class GetListInBundle extends CliCommand {
-        @Parameter(description = "property/cluster/namespace\n", required = true)
+        @Parameter(description = "property/cluster/namespace", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = { "-b",

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdPackages.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdPackages.java
@@ -135,7 +135,7 @@ class CmdPackages extends CmdBase {
 
     @Parameters(commandDescription = "List all versions of the given package")
     private class ListPackageVersionsCmd extends CliCommand {
-        @Parameter(description = "the package name you want to query, don't need to specify the package version.\n" +
+        @Parameter(description = "the package name you want to query, don't need to specify the package version. " +
             "type://tenant/namespace/packageName", required = true)
         private String packageName;
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdPersistentTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdPersistentTopics.java
@@ -94,7 +94,7 @@ public class CmdPersistentTopics extends CmdBase {
 
     @Parameters(commandDescription = "Get the list of topics under a namespace.")
     private class ListCmd extends CliCommand {
-        @Parameter(description = "property/cluster/namespace\n", required = true)
+        @Parameter(description = "property/cluster/namespace", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -106,7 +106,7 @@ public class CmdPersistentTopics extends CmdBase {
 
     @Parameters(commandDescription = "Get the list of partitioned topics under a namespace.")
     private class PartitionedTopicListCmd extends CliCommand {
-        @Parameter(description = "property/cluster/namespace\n", required = true)
+        @Parameter(description = "property/cluster/namespace", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -134,10 +134,10 @@ public class CmdPersistentTopics extends CmdBase {
         }
     }
 
-    @Parameters(commandDescription = "Revoke permissions on a topic \n "
-            + "\t\t\t   Revoke permissions to a client role on a single topic. If the permission \n"
-            + "\t\t\t   was not set at the topic level, but rather at the namespace level, this \n"
-            + "\t\t\t   operation will return an error (HTTP status code 412).")
+    @Parameters(commandDescription = "Revoke permissions on a topic. "
+            + "Revoke permissions to a client role on a single topic. If the permission "
+            + "was not set at the topic level, but rather at the namespace level, this "
+            + "operation will return an error (HTTP status code 412).")
     private class RevokePermissions extends CliCommand {
         @Parameter(description = "persistent://property/cluster/namespace/topic", required = true)
         private java.util.List<String> params;
@@ -152,12 +152,12 @@ public class CmdPersistentTopics extends CmdBase {
         }
     }
 
-    @Parameters(commandDescription = "Get the permissions on a topic\n"
-            + "\t\t     Retrieve the effective permissions for a topic. These permissions are defined \n"
-            + "\t\t     by the permissions set at the namespace level combined (union) with any eventual \n"
-            + "\t\t     specific permission set on the topic.")
+    @Parameters(commandDescription = "Get the permissions on a topic. "
+            + "Retrieve the effective permissions for a topic. These permissions are defined "
+            + "by the permissions set at the namespace level combined (union) with any eventual "
+            + "specific permission set on the topic.")
     private class Permissions extends CliCommand {
-        @Parameter(description = "persistent://property/cluster/namespace/topic\n", required = true)
+        @Parameter(description = "persistent://property/cluster/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -169,7 +169,7 @@ public class CmdPersistentTopics extends CmdBase {
 
     @Parameters(commandDescription = "Lookup a topic from the current serving broker")
     private class Lookup extends CliCommand {
-        @Parameter(description = "persistent://property/cluster/namespace/topic\n", required = true)
+        @Parameter(description = "persistent://property/cluster/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -181,7 +181,7 @@ public class CmdPersistentTopics extends CmdBase {
 
     @Parameters(commandDescription = "Get Namespace bundle range of a topic")
     private class GetBundleRange extends CliCommand {
-        @Parameter(description = "persistent://property/cluster/namespace/topic\n", required = true)
+        @Parameter(description = "persistent://property/cluster/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -191,11 +191,11 @@ public class CmdPersistentTopics extends CmdBase {
         }
     }
 
-    @Parameters(commandDescription = "Create a partitioned topic. \n"
-            + "\t\tThe partitioned topic has to be created before creating a producer on it.")
+    @Parameters(commandDescription = "Create a partitioned topic. "
+            + "The partitioned topic has to be created before creating a producer on it.")
     private class CreatePartitionedCmd extends CliCommand {
 
-        @Parameter(description = "persistent://property/cluster/namespace/topic\n", required = true)
+        @Parameter(description = "persistent://property/cluster/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = { "-p",
@@ -209,11 +209,11 @@ public class CmdPersistentTopics extends CmdBase {
         }
     }
 
-    @Parameters(commandDescription = "Update existing non-global partitioned topic. \n"
-            + "\t\tNew updating number of partitions must be greater than existing number of partitions.")
+    @Parameters(commandDescription = "Update existing non-global partitioned topic. "
+            + "New updating number of partitions must be greater than existing number of partitions.")
     private class UpdatePartitionedCmd extends CliCommand {
 
-        @Parameter(description = "persistent://property/cluster/namespace/topic\n", required = true)
+        @Parameter(description = "persistent://property/cluster/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = { "-p",
@@ -227,11 +227,11 @@ public class CmdPersistentTopics extends CmdBase {
         }
     }
 
-    @Parameters(commandDescription = "Get the partitioned topic metadata. \n"
-            + "\t\tIf the topic is not created or is a non-partitioned topic, it returns empty topic with 0 partitions")
+    @Parameters(commandDescription = "Get the partitioned topic metadata. "
+            + "If the topic is not created or is a non-partitioned topic, it returns empty topic with 0 partitions")
     private class GetPartitionedTopicMetadataCmd extends CliCommand {
 
-        @Parameter(description = "persistent://property/cluster/namespace/topic\n", required = true)
+        @Parameter(description = "persistent://property/cluster/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -241,11 +241,11 @@ public class CmdPersistentTopics extends CmdBase {
         }
     }
 
-    @Parameters(commandDescription = "Delete a partitioned topic. \n"
-            + "\t\tIt will also delete all the partitions of the topic if it exists.")
+    @Parameters(commandDescription = "Delete a partitioned topic. "
+            + "It will also delete all the partitions of the topic if it exists.")
     private class DeletePartitionedCmd extends CliCommand {
 
-        @Parameter(description = "persistent://property/cluster/namespace/topic\n", required = true)
+        @Parameter(description = "persistent://property/cluster/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = "--force", description = "Close all producer/consumer/replicator and delete topic forcefully")
@@ -258,10 +258,10 @@ public class CmdPersistentTopics extends CmdBase {
         }
     }
 
-    @Parameters(commandDescription = "Delete a topic. \n"
-            + "\t\tThe topic cannot be deleted if there's any active subscription or producers connected to it.")
+    @Parameters(commandDescription = "Delete a topic. "
+            + "The topic cannot be deleted if there's any active subscription or producers connected to it.")
     private class DeleteCmd extends CliCommand {
-        @Parameter(description = "persistent://property/cluster/namespace/topic\n", required = true)
+        @Parameter(description = "persistent://property/cluster/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = "--force", description = "Close all producer/consumer/replicator and delete topic forcefully")
@@ -274,9 +274,9 @@ public class CmdPersistentTopics extends CmdBase {
         }
     }
 
-    @Parameters(commandDescription = "Unload a topic. \n")
+    @Parameters(commandDescription = "Unload a topic.")
     private class UnloadCmd extends CliCommand {
-        @Parameter(description = "persistent://property/cluster/namespace/topic\n", required = true)
+        @Parameter(description = "persistent://property/cluster/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -288,7 +288,7 @@ public class CmdPersistentTopics extends CmdBase {
 
     @Parameters(commandDescription = "Get the list of subscriptions on the topic")
     private class ListSubscriptions extends CliCommand {
-        @Parameter(description = "persistent://property/cluster/namespace/topic\n", required = true)
+        @Parameter(description = "persistent://property/cluster/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -298,8 +298,8 @@ public class CmdPersistentTopics extends CmdBase {
         }
     }
 
-    @Parameters(commandDescription = "Delete a durable subscriber from a topic. \n"
-            + "\t\tThe subscription cannot be deleted if there are any active consumers attached to it \n")
+    @Parameters(commandDescription = "Delete a durable subscriber from a topic. "
+            + "The subscription cannot be deleted if there are any active consumers attached to it")
     private class DeleteSubscription extends CliCommand {
         @Parameter(description = "persistent://property/cluster/namespace/topic", required = true)
         private java.util.List<String> params;
@@ -318,10 +318,10 @@ public class CmdPersistentTopics extends CmdBase {
         }
     }
 
-    @Parameters(commandDescription = "Get the stats for the topic and its connected producers and consumers. \n"
-            + "\t       All the rates are computed over a 1 minute window and are relative the last completed 1 minute period.")
+    @Parameters(commandDescription = "Get the stats for the topic and its connected producers and consumers. "
+            + "All the rates are computed over a 1 minute window and are relative the last completed 1 minute period.")
     private class GetStats extends CliCommand {
-        @Parameter(description = "persistent://property/cluster/namespace/topic\n", required = true)
+        @Parameter(description = "persistent://property/cluster/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -333,7 +333,7 @@ public class CmdPersistentTopics extends CmdBase {
 
     @Parameters(commandDescription = "Get the internal stats for the topic")
     private class GetInternalStats extends CliCommand {
-        @Parameter(description = "persistent://property/cluster/namespace/topic\n", required = true)
+        @Parameter(description = "persistent://property/cluster/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = { "-m",
@@ -349,7 +349,7 @@ public class CmdPersistentTopics extends CmdBase {
 
     @Parameters(commandDescription = "Get the internal metadata info for the topic")
     private class GetInternalInfo extends CliCommand {
-        @Parameter(description = "persistent://property/cluster/namespace/topic\n", required = true)
+        @Parameter(description = "persistent://property/cluster/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -361,10 +361,10 @@ public class CmdPersistentTopics extends CmdBase {
         }
     }
 
-    @Parameters(commandDescription = "Get the stats for the partitioned topic and its connected producers and consumers. \n"
-            + "\t       All the rates are computed over a 1 minute window and are relative the last completed 1 minute period.")
+    @Parameters(commandDescription = "Get the stats for the partitioned topic and its connected producers and consumers. "
+            + "All the rates are computed over a 1 minute window and are relative the last completed 1 minute period.")
     private class GetPartitionedStats extends CliCommand {
-        @Parameter(description = "persistent://property/cluster/namespace/topic\n", required = true)
+        @Parameter(description = "persistent://property/cluster/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = "--per-partition", description = "Get per partition stats")
@@ -377,10 +377,10 @@ public class CmdPersistentTopics extends CmdBase {
         }
     }
 
-    @Parameters(commandDescription = "Get the stats-internal for the partitioned topic and its connected producers and consumers. \n"
-            + "\t       All the rates are computed over a 1 minute window and are relative the last completed 1 minute period.")
+    @Parameters(commandDescription = "Get the stats-internal for the partitioned topic and its connected producers and consumers. "
+            + "All the rates are computed over a 1 minute window and are relative the last completed 1 minute period.")
     private class GetPartitionedStatsInternal extends CliCommand {
-        @Parameter(description = "persistent://property/cluster/namespace/topic\n", required = true)
+        @Parameter(description = "persistent://property/cluster/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Override

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdResourceGroups.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdResourceGroups.java
@@ -54,20 +54,20 @@ public class CmdResourceGroups extends CmdBase {
         private java.util.List<String> params;
 
         @Parameter(names = { "--msg-publish-rate",
-                "-mp" }, description = "message-publish-rate (default -1 will be overwrite if not passed)\n", required = false)
+                "-mp" }, description = "message-publish-rate (default -1 will be overwrite if not passed)", required = false)
         private int publishRateInMsgs = -1;
 
         @Parameter(names = { "--byte-publish-rate",
-                "-bp" }, description = "byte-publish-rate (default -1 will be overwrite if not passed)\n", required = false)
+                "-bp" }, description = "byte-publish-rate (default -1 will be overwrite if not passed)", required = false)
         private long publishRateInBytes = -1;
 
 
         @Parameter(names = { "--msg-dispatch-rate",
-                "-md" }, description = "message-dispatch-rate (default -1 will be overwrite if not passed)\n", required = false)
+                "-md" }, description = "message-dispatch-rate (default -1 will be overwrite if not passed)", required = false)
         private int dispatchRateInMsgs = -1;
 
         @Parameter(names = { "--byte-dispatch-rate",
-                "-bd" }, description = "byte-dispatch-rate (default -1 will be overwrite if not passed)\n", required = false)
+                "-bd" }, description = "byte-dispatch-rate (default -1 will be overwrite if not passed)", required = false)
         private long dispatchRateInBytes = -1;
 
         @Override
@@ -89,20 +89,20 @@ public class CmdResourceGroups extends CmdBase {
         private java.util.List<String> params;
 
         @Parameter(names = { "--msg-publish-rate",
-                "-mp" }, description = "message-publish-rate (default -1 will be overwrite if not passed)\n", required = false)
+                "-mp" }, description = "message-publish-rate (default -1 will be overwrite if not passed)", required = false)
         private int publishRateInMsgs = -1;
 
         @Parameter(names = { "--byte-publish-rate",
-                "-bp" }, description = "byte-publish-rate (default -1 will be overwrite if not passed)\n", required = false)
+                "-bp" }, description = "byte-publish-rate (default -1 will be overwrite if not passed)", required = false)
         private long publishRateInBytes = -1;
 
 
         @Parameter(names = { "--msg-dispatch-rate",
-                "-md" }, description = "message-dispatch-rate (default -1 will be overwrite if not passed)\n", required = false)
+                "-md" }, description = "message-dispatch-rate (default -1 will be overwrite if not passed)", required = false)
         private int dispatchRateInMsgs = -1;
 
         @Parameter(names = { "--byte-dispatch-rate",
-                "-bd" }, description = "byte-dispatch-rate (default -1 will be overwrite if not passed)\n", required = false)
+                "-bd" }, description = "byte-dispatch-rate (default -1 will be overwrite if not passed)", required = false)
         private long dispatchRateInBytes = -1;
 
         @Override

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdResourceQuotas.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdResourceQuotas.java
@@ -35,11 +35,11 @@ public class CmdResourceQuotas extends CmdBase {
     private class GetResourceQuota extends CliCommand {
 
         @Parameter(names = { "--namespace",
-                "-n" }, description = "property/cluster/namespace, must be specified together with '--bundle'\n")
+                "-n" }, description = "property/cluster/namespace, must be specified together with '--bundle'")
         private java.util.List<String> names;
 
         @Parameter(names = { "--bundle",
-                "-b" }, description = "{start-boundary}_{end-boundary}, must be specified together with '--namespace'\n")
+                "-b" }, description = "{start-boundary}_{end-boundary}, must be specified together with '--namespace'")
         private String bundle;
 
         @Override
@@ -59,34 +59,34 @@ public class CmdResourceQuotas extends CmdBase {
     private class SetResourceQuota extends CliCommand {
 
         @Parameter(names = { "--namespace",
-                "-n" }, description = "property/cluster/namespace, must be specified together with '--bundle'\n")
+                "-n" }, description = "property/cluster/namespace, must be specified together with '--bundle'")
         private java.util.List<String> names;
 
         @Parameter(names = { "--bundle",
-                "-b" }, description = "{start-boundary}_{end-boundary}, must be specified together with '--namespace'\n")
+                "-b" }, description = "{start-boundary}_{end-boundary}, must be specified together with '--namespace'")
         private String bundle;
 
         @Parameter(names = { "--msgRateIn",
-                "-mi" }, description = "expected incoming messages per second\n", required = true)
+                "-mi" }, description = "expected incoming messages per second", required = true)
         private long msgRateIn = 0;
 
         @Parameter(names = { "--msgRateOut",
-                "-mo" }, description = "expected outgoing messages per second\n", required = true)
+                "-mo" }, description = "expected outgoing messages per second", required = true)
         private long msgRateOut = 0;
 
         @Parameter(names = { "--bandwidthIn",
-                "-bi" }, description = "expected inbound bandwidth (bytes/second)\n", required = true)
+                "-bi" }, description = "expected inbound bandwidth (bytes/second)", required = true)
         private long bandwidthIn = 0;
 
         @Parameter(names = { "--bandwidthOut",
-                "-bo" }, description = "expected outbound bandwidth (bytes/second)\n", required = true)
+                "-bo" }, description = "expected outbound bandwidth (bytes/second)", required = true)
         private long bandwidthOut = 0;
 
-        @Parameter(names = { "--memory", "-mem" }, description = "expected memory usage (Mbytes)\n", required = true)
+        @Parameter(names = { "--memory", "-mem" }, description = "expected memory usage (Mbytes)", required = true)
         private long memory = 0;
 
         @Parameter(names = { "--dynamic",
-                "-d" }, description = "dynamic (allow to be dynamically re-calculated) or not\n")
+                "-d" }, description = "dynamic (allow to be dynamically re-calculated) or not")
         private boolean dynamic = false;
 
         @Override
@@ -113,10 +113,10 @@ public class CmdResourceQuotas extends CmdBase {
     @Parameters(commandDescription = "Reset the specified namespace bundle's resource quota to default value.")
     private class ResetNamespaceBundleResourceQuota extends CliCommand {
 
-        @Parameter(names = { "--namespace", "-n" }, description = "property/cluster/namespace\n", required = true)
+        @Parameter(names = { "--namespace", "-n" }, description = "property/cluster/namespace", required = true)
         private java.util.List<String> names;
 
-        @Parameter(names = { "--bundle", "-b" }, description = "{start-boundary}_{end-boundary}\n", required = true)
+        @Parameter(names = { "--bundle", "-b" }, description = "{start-boundary}_{end-boundary}", required = true)
         private String bundle;
 
         @Override

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
@@ -248,7 +248,7 @@ public class CmdTopics extends CmdBase {
 
     @Parameters(commandDescription = "Get the list of topics under a namespace.")
     private class ListCmd extends CliCommand {
-        @Parameter(description = "tenant/namespace\n", required = true)
+        @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -260,7 +260,7 @@ public class CmdTopics extends CmdBase {
 
     @Parameters(commandDescription = "Get the list of partitioned topics under a namespace.")
     private class PartitionedTopicListCmd extends CliCommand {
-        @Parameter(description = "tenant/namespace\n", required = true)
+        @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -288,10 +288,10 @@ public class CmdTopics extends CmdBase {
         }
     }
 
-    @Parameters(commandDescription = "Revoke permissions on a topic \n "
-            + "\t\t\t   Revoke permissions to a client role on a single topic. If the permission \n"
-            + "\t\t\t   was not set at the topic level, but rather at the namespace level, this \n"
-            + "\t\t\t   operation will return an error (HTTP status code 412).")
+    @Parameters(commandDescription = "Revoke permissions on a topic. "
+            + "Revoke permissions to a client role on a single topic. If the permission "
+            + "was not set at the topic level, but rather at the namespace level, this "
+            + "operation will return an error (HTTP status code 412).")
     private class RevokePermissions extends CliCommand {
         @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
@@ -306,12 +306,12 @@ public class CmdTopics extends CmdBase {
         }
     }
 
-    @Parameters(commandDescription = "Get the permissions on a topic\n"
-            + "\t\t     Retrieve the effective permissions for a topic. These permissions are defined \n"
-            + "\t\t     by the permissions set at the namespace level combined (union) with any eventual \n"
-            + "\t\t     specific permission set on the topic.")
+    @Parameters(commandDescription = "Get the permissions on a topic. "
+            + "Retrieve the effective permissions for a topic. These permissions are defined "
+            + "by the permissions set at the namespace level combined (union) with any eventual "
+            + "specific permission set on the topic.")
     private class Permissions extends CliCommand {
-        @Parameter(description = "persistent://tenant/namespace/topic\n", required = true)
+        @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -323,7 +323,7 @@ public class CmdTopics extends CmdBase {
 
     @Parameters(commandDescription = "Lookup a topic from the current serving broker")
     private class Lookup extends CliCommand {
-        @Parameter(description = "persistent://tenant/namespace/topic\n", required = true)
+        @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -335,7 +335,7 @@ public class CmdTopics extends CmdBase {
 
     @Parameters(commandDescription = "Lookup a partitioned topic from the current serving broker")
     private class PartitionedLookup extends CliCommand {
-        @Parameter(description = "persistent://tenant/namespace/partitionedTopic\n", required = true)
+        @Parameter(description = "persistent://tenant/namespace/partitionedTopic", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -347,7 +347,7 @@ public class CmdTopics extends CmdBase {
 
     @Parameters(commandDescription = "Get Namespace bundle range of a topic")
     private class GetBundleRange extends CliCommand {
-        @Parameter(description = "persistent://tenant/namespace/topic\n", required = true)
+        @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -357,11 +357,11 @@ public class CmdTopics extends CmdBase {
         }
     }
 
-    @Parameters(commandDescription = "Create a partitioned topic. \n"
-            + "\t\tThe partitioned topic has to be created before creating a producer on it.")
+    @Parameters(commandDescription = "Create a partitioned topic. "
+            + "The partitioned topic has to be created before creating a producer on it.")
     private class CreatePartitionedCmd extends CliCommand {
 
-        @Parameter(description = "persistent://tenant/namespace/topic\n", required = true)
+        @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = { "-p",
@@ -375,12 +375,12 @@ public class CmdTopics extends CmdBase {
         }
     }
 
-    @Parameters(commandDescription = "Try to create partitions for partitioned topic. \n"
-            + "\t\t     The partitions of partition topic has to be created, can be used by repair partitions when \n"
-            + "\t\t     topic auto creation is disabled")
+    @Parameters(commandDescription = "Try to create partitions for partitioned topic. "
+            + "The partitions of partition topic has to be created, can be used by repair partitions when "
+            + "topic auto creation is disabled")
     private class CreateMissedPartitionsCmd extends CliCommand {
 
-        @Parameter(description = "persistent://tenant/namespace/topic\n", required = true)
+        @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -393,7 +393,7 @@ public class CmdTopics extends CmdBase {
     @Parameters(commandDescription = "Create a non-partitioned topic.")
     private class CreateNonPartitionedCmd extends CliCommand {
 
-    	@Parameter(description = "persistent://tenant/namespace/topic\n", required = true)
+    	@Parameter(description = "persistent://tenant/namespace/topic", required = true)
     	private java.util.List<String> params;
 
     	@Override
@@ -403,11 +403,11 @@ public class CmdTopics extends CmdBase {
     	}
     }
 
-    @Parameters(commandDescription = "Update existing non-global partitioned topic. \n"
-            + "\t\tNew updating number of partitions must be greater than existing number of partitions.")
+    @Parameters(commandDescription = "Update existing non-global partitioned topic. "
+            + "New updating number of partitions must be greater than existing number of partitions.")
     private class UpdatePartitionedCmd extends CliCommand {
 
-        @Parameter(description = "persistent://tenant/namespace/topic\n", required = true)
+        @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = { "-p",
@@ -421,11 +421,11 @@ public class CmdTopics extends CmdBase {
         }
     }
 
-    @Parameters(commandDescription = "Get the partitioned topic metadata. \n"
-            + "\t\tIf the topic is not created or is a non-partitioned topic, it returns empty topic with 0 partitions")
+    @Parameters(commandDescription = "Get the partitioned topic metadata. "
+            + "If the topic is not created or is a non-partitioned topic, it returns empty topic with 0 partitions")
     private class GetPartitionedTopicMetadataCmd extends CliCommand {
 
-        @Parameter(description = "persistent://tenant/namespace/topic\n", required = true)
+        @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -435,11 +435,11 @@ public class CmdTopics extends CmdBase {
         }
     }
 
-    @Parameters(commandDescription = "Delete a partitioned topic. \n"
-            + "\t\tIt will also delete all the partitions of the topic if it exists.")
+    @Parameters(commandDescription = "Delete a partitioned topic. "
+            + "It will also delete all the partitions of the topic if it exists.")
     private class DeletePartitionedCmd extends CliCommand {
 
-        @Parameter(description = "persistent://tenant/namespace/topic\n", required = true)
+        @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = { "-f",
@@ -460,10 +460,10 @@ public class CmdTopics extends CmdBase {
         }
     }
 
-    @Parameters(commandDescription = "Delete a topic. \n"
-            + "\t\tThe topic cannot be deleted if there's any active subscription or producers connected to it.")
+    @Parameters(commandDescription = "Delete a topic. "
+            + "The topic cannot be deleted if there's any active subscription or producers connected to it.")
     private class DeleteCmd extends CliCommand {
-        @Parameter(description = "persistent://tenant/namespace/topic\n", required = true)
+        @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = { "-f",
@@ -484,9 +484,9 @@ public class CmdTopics extends CmdBase {
         }
     }
 
-    @Parameters(commandDescription = "Unload a topic. \n")
+    @Parameters(commandDescription = "Unload a topic.")
     private class UnloadCmd extends CliCommand {
-        @Parameter(description = "persistent://tenant/namespace/topic\n", required = true)
+        @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -498,7 +498,7 @@ public class CmdTopics extends CmdBase {
 
     @Parameters(commandDescription = "Get the list of subscriptions on the topic")
     private class ListSubscriptions extends CliCommand {
-        @Parameter(description = "persistent://tenant/namespace/topic\n", required = true)
+        @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -508,8 +508,8 @@ public class CmdTopics extends CmdBase {
         }
     }
 
-    @Parameters(commandDescription = "Delete a durable subscriber from a topic. \n"
-            + "\t\tThe subscription cannot be deleted if there are any active consumers attached to it \n")
+    @Parameters(commandDescription = "Delete a durable subscriber from a topic. "
+            + "The subscription cannot be deleted if there are any active consumers attached to it")
     private class DeleteSubscription extends CliCommand {
         @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
@@ -528,10 +528,10 @@ public class CmdTopics extends CmdBase {
         }
     }
 
-    @Parameters(commandDescription = "Get the stats for the topic and its connected producers and consumers. \n"
-            + "\t       All the rates are computed over a 1 minute window and are relative the last completed 1 minute period.")
+    @Parameters(commandDescription = "Get the stats for the topic and its connected producers and consumers. "
+            + "All the rates are computed over a 1 minute window and are relative the last completed 1 minute period.")
     private class GetStats extends CliCommand {
-        @Parameter(description = "persistent://tenant/namespace/topic\n", required = true)
+        @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = { "-gpb",
@@ -552,7 +552,7 @@ public class CmdTopics extends CmdBase {
 
     @Parameters(commandDescription = "Get the internal stats for the topic")
     private class GetInternalStats extends CliCommand {
-        @Parameter(description = "persistent://tenant/namespace/topic\n", required = true)
+        @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = { "-m",
@@ -568,7 +568,7 @@ public class CmdTopics extends CmdBase {
 
     @Parameters(commandDescription = "Get the internal metadata info for the topic")
     private class GetInternalInfo extends CliCommand {
-        @Parameter(description = "persistent://tenant/namespace/topic\n", required = true)
+        @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -580,10 +580,10 @@ public class CmdTopics extends CmdBase {
         }
     }
 
-    @Parameters(commandDescription = "Get the stats for the partitioned topic and its connected producers and consumers. \n"
-            + "\t       All the rates are computed over a 1 minute window and are relative the last completed 1 minute period.")
+    @Parameters(commandDescription = "Get the stats for the partitioned topic and its connected producers and consumers. "
+            + "All the rates are computed over a 1 minute window and are relative the last completed 1 minute period.")
     private class GetPartitionedStats extends CliCommand {
-        @Parameter(description = "persistent://tenant/namespace/topic\n", required = true)
+        @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = "--per-partition", description = "Get per partition stats")
@@ -605,10 +605,10 @@ public class CmdTopics extends CmdBase {
         }
     }
 
-    @Parameters(commandDescription = "Get the internal stats for the partitioned topic and its connected producers and consumers. \n"
-            + "\t       All the rates are computed over a 1 minute window and are relative the last completed 1 minute period.")
+    @Parameters(commandDescription = "Get the internal stats for the partitioned topic and its connected producers and consumers. "
+            + "All the rates are computed over a 1 minute window and are relative the last completed 1 minute period.")
     private class GetPartitionedStatsInternal extends CliCommand {
-        @Parameter(description = "persistent://tenant/namespace/topic\n", required = true)
+        @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -1119,7 +1119,7 @@ public class CmdTopics extends CmdBase {
 
     @Parameters(commandDescription = "Get the delayed delivery policy for a topic")
     private class GetDelayedDelivery extends CliCommand {
-        @Parameter(description = "tenant/namespace/topic\n", required = true)
+        @Parameter(description = "tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = { "-ap", "--applied" }, description = "Get the applied policy of the topic")
@@ -1577,19 +1577,19 @@ public class CmdTopics extends CmdBase {
         private java.util.List<String> params;
 
         @Parameter(names = { "--msg-dispatch-rate",
-                "-md" }, description = "message-dispatch-rate (default -1 will be overwrite if not passed)\n", required = false)
+                "-md" }, description = "message-dispatch-rate (default -1 will be overwrite if not passed)", required = false)
         private int msgDispatchRate = -1;
 
         @Parameter(names = { "--byte-dispatch-rate",
-                "-bd" }, description = "byte-dispatch-rate (default -1 will be overwrite if not passed)\n", required = false)
+                "-bd" }, description = "byte-dispatch-rate (default -1 will be overwrite if not passed)", required = false)
         private long byteDispatchRate = -1;
 
         @Parameter(names = { "--dispatch-rate-period",
-                "-dt" }, description = "dispatch-rate-period in second type (default 1 second will be overwrite if not passed)\n", required = false)
+                "-dt" }, description = "dispatch-rate-period in second type (default 1 second will be overwrite if not passed)", required = false)
         private int dispatchRatePeriodSec = 1;
 
         @Parameter(names = { "--relative-to-publish-rate",
-                "-rp" }, description = "dispatch rate relative to publish-rate (if publish-relative flag is enabled then broker will apply throttling value to (publish-rate + dispatch rate))\n", required = false)
+                "-rp" }, description = "dispatch rate relative to publish-rate (if publish-relative flag is enabled then broker will apply throttling value to (publish-rate + dispatch rate))", required = false)
         private boolean relativeToPublishRate = false;
 
         @Override
@@ -1790,11 +1790,11 @@ public class CmdTopics extends CmdBase {
         private java.util.List<String> params;
 
         @Parameter(names = { "--msg-publish-rate",
-            "-m" }, description = "message-publish-rate (default -1 will be overwrite if not passed)\n", required = false)
+            "-m" }, description = "message-publish-rate (default -1 will be overwrite if not passed)", required = false)
         private int msgPublishRate = -1;
 
          @Parameter(names = { "--byte-publish-rate",
-            "-b" }, description = "byte-publish-rate (default -1 will be overwrite if not passed)\n", required = false)
+            "-b" }, description = "byte-publish-rate (default -1 will be overwrite if not passed)", required = false)
         private long bytePublishRate = -1;
 
         @Override
@@ -1838,19 +1838,19 @@ public class CmdTopics extends CmdBase {
         private java.util.List<String> params;
 
         @Parameter(names = { "--msg-dispatch-rate",
-            "-md" }, description = "message-dispatch-rate (default -1 will be overwrite if not passed)\n", required = false)
+            "-md" }, description = "message-dispatch-rate (default -1 will be overwrite if not passed)", required = false)
         private int msgDispatchRate = -1;
 
         @Parameter(names = { "--byte-dispatch-rate",
-            "-bd" }, description = "byte-dispatch-rate (default -1 will be overwrite if not passed)\n", required = false)
+            "-bd" }, description = "byte-dispatch-rate (default -1 will be overwrite if not passed)", required = false)
         private long byteDispatchRate = -1;
 
         @Parameter(names = { "--dispatch-rate-period",
-            "-dt" }, description = "dispatch-rate-period in second type (default 1 second will be overwrite if not passed)\n", required = false)
+            "-dt" }, description = "dispatch-rate-period in second type (default 1 second will be overwrite if not passed)", required = false)
         private int dispatchRatePeriodSec = 1;
 
         @Parameter(names = { "--relative-to-publish-rate",
-                "-rp" }, description = "dispatch rate relative to publish-rate (if publish-relative flag is enabled then broker will apply throttling value to (publish-rate + dispatch rate))\n", required = false)
+                "-rp" }, description = "dispatch rate relative to publish-rate (if publish-relative flag is enabled then broker will apply throttling value to (publish-rate + dispatch rate))", required = false)
         private boolean relativeToPublishRate = false;
 
         @Override
@@ -1894,19 +1894,19 @@ public class CmdTopics extends CmdBase {
         private java.util.List<String> params;
 
         @Parameter(names = { "--msg-dispatch-rate",
-            "-md" }, description = "message-dispatch-rate (default -1 will be overwrite if not passed)\n", required = false)
+            "-md" }, description = "message-dispatch-rate (default -1 will be overwrite if not passed)", required = false)
         private int msgDispatchRate = -1;
 
         @Parameter(names = { "--byte-dispatch-rate",
-            "-bd" }, description = "byte-dispatch-rate (default -1 will be overwrite if not passed)\n", required = false)
+            "-bd" }, description = "byte-dispatch-rate (default -1 will be overwrite if not passed)", required = false)
         private long byteDispatchRate = -1;
 
         @Parameter(names = { "--dispatch-rate-period",
-            "-dt" }, description = "dispatch-rate-period in second type (default 1 second will be overwrite if not passed)\n", required = false)
+            "-dt" }, description = "dispatch-rate-period in second type (default 1 second will be overwrite if not passed)", required = false)
         private int dispatchRatePeriodSec = 1;
 
         @Parameter(names = { "--relative-to-publish-rate",
-                "-rp" }, description = "dispatch rate relative to publish-rate (if publish-relative flag is enabled then broker will apply throttling value to (publish-rate + dispatch rate))\n", required = false)
+                "-rp" }, description = "dispatch rate relative to publish-rate (if publish-relative flag is enabled then broker will apply throttling value to (publish-rate + dispatch rate))", required = false)
         private boolean relativeToPublishRate = false;
 
         @Override
@@ -2217,11 +2217,11 @@ public class CmdTopics extends CmdBase {
         private java.util.List<String> params;
 
         @Parameter(names = { "--subscribe-rate",
-                "-sr" }, description = "subscribe-rate (default -1 will be overwrite if not passed)\n", required = false)
+                "-sr" }, description = "subscribe-rate (default -1 will be overwrite if not passed)", required = false)
         private int subscribeRate = -1;
 
         @Parameter(names = { "--subscribe-rate-period",
-                "-st" }, description = "subscribe-rate-period in second type (default 30 second will be overwrite if not passed)\n", required = false)
+                "-st" }, description = "subscribe-rate-period in second type (default 30 second will be overwrite if not passed)", required = false)
         private int subscribeRatePeriodSec = 30;
 
         @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/util/RetryUtil.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/util/RetryUtil.java
@@ -1,0 +1,68 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.util;
+
+import org.apache.pulsar.client.impl.Backoff;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+public class RetryUtil {
+    private static final Logger log = LoggerFactory.getLogger(RetryUtil.class);
+
+    public static <T> void retryAsynchronously(Supplier<T> supplier, Backoff backoff,
+                                               ScheduledExecutorService scheduledExecutorService,
+                                               CompletableFuture<T> callback) {
+        if (backoff.getMax() <= 0) {
+            throw new IllegalArgumentException("Illegal max retry time");
+        }
+        if (backoff.getInitial() <= 0) {
+            throw new IllegalArgumentException("Illegal initial time");
+        }
+        scheduledExecutorService.execute(() ->
+                executeWithRetry(supplier, backoff, scheduledExecutorService, callback));
+    }
+
+    private static <T> void executeWithRetry(Supplier<T> supplier, Backoff backoff,
+                                             ScheduledExecutorService scheduledExecutorService,
+                                             CompletableFuture<T> callback) {
+        try {
+            T result = supplier.get();
+            callback.complete(result);
+        } catch (Exception e) {
+            long next = backoff.next();
+            boolean isMandatoryStop = backoff.isMandatoryStopMade();
+            if (isMandatoryStop) {
+                callback.completeExceptionally(e);
+            } else {
+                if (log.isDebugEnabled()) {
+                    log.debug("execute with retry fail, will retry in {} ms", next, e);
+                }
+                log.info("Because of {} , will retry in {} ms", e.getMessage(), next);
+                scheduledExecutorService.schedule(() ->
+                                executeWithRetry(supplier, backoff, scheduledExecutorService, callback),
+                        next, TimeUnit.MILLISECONDS);
+            }
+        }
+    }
+}

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/AvroSchemaTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/AvroSchemaTest.java
@@ -20,39 +20,36 @@ package org.apache.pulsar.client.impl.schema;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.pulsar.client.impl.schema.SchemaTestUtils.FOO_FIELDS;
-import static org.apache.pulsar.client.impl.schema.SchemaTestUtils.SCHEMA_AVRO_NOT_ALLOW_NULL;
 import static org.apache.pulsar.client.impl.schema.SchemaTestUtils.SCHEMA_AVRO_ALLOW_NULL;
+import static org.apache.pulsar.client.impl.schema.SchemaTestUtils.SCHEMA_AVRO_NOT_ALLOW_NULL;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.fail;
 import static org.testng.AssertJUnit.assertSame;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
-
 import org.apache.avro.Schema;
-import org.apache.avro.io.BinaryEncoder;
-import org.apache.avro.io.BufferedBinaryEncoder;
-import org.apache.pulsar.client.api.SchemaSerializationException;
-import org.apache.pulsar.client.api.schema.SchemaDefinition;
 import org.apache.avro.SchemaValidationException;
 import org.apache.avro.SchemaValidator;
 import org.apache.avro.SchemaValidatorBuilder;
+import org.apache.avro.io.BinaryEncoder;
+import org.apache.avro.io.BufferedBinaryEncoder;
 import org.apache.avro.reflect.AvroDefault;
 import org.apache.avro.reflect.Nullable;
 import org.apache.avro.reflect.ReflectData;
+import org.apache.pulsar.client.api.SchemaSerializationException;
 import org.apache.pulsar.client.api.schema.RecordSchemaBuilder;
 import org.apache.pulsar.client.api.schema.SchemaBuilder;
-import org.apache.pulsar.client.api.schema.SchemaDefinitionBuilder;
+import org.apache.pulsar.client.api.schema.SchemaDefinition;
 import org.apache.pulsar.client.api.schema.SchemaReader;
 import org.apache.pulsar.client.api.schema.SchemaWriter;
 import org.apache.pulsar.client.avro.generated.NasaMission;
@@ -66,8 +63,8 @@ import org.apache.pulsar.common.schema.SchemaType;
 import org.joda.time.DateTime;
 import org.joda.time.chrono.ISOChronology;
 import org.json.JSONException;
-import org.skyscreamer.jsonassert.JSONAssert;
 import org.powermock.reflect.Whitebox;
+import org.skyscreamer.jsonassert.JSONAssert;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -293,7 +290,7 @@ public class AvroSchemaTest {
         schemaLogicalType.setDecimal(new BigDecimal("12.34"));
         schemaLogicalType.setDate(LocalDate.now());
         schemaLogicalType.setTimeMicros(System.currentTimeMillis()*1000);
-        schemaLogicalType.setTimeMillis(LocalTime.now());
+        schemaLogicalType.setTimeMillis(LocalTime.now().truncatedTo(ChronoUnit.MILLIS));
 
         byte[] bytes1 = avroSchema.encode(schemaLogicalType);
         Assert.assertTrue(bytes1.length > 0);
@@ -313,7 +310,7 @@ public class AvroSchemaTest {
         schemaLogicalType.setTimestampMillis(new DateTime("2019-03-26T04:39:58.469Z", ISOChronology.getInstanceUTC()));
         schemaLogicalType.setDate(LocalDate.now());
         schemaLogicalType.setTimeMicros(System.currentTimeMillis()*1000);
-        schemaLogicalType.setTimeMillis(LocalTime.now());
+        schemaLogicalType.setTimeMillis(LocalTime.now().truncatedTo(ChronoUnit.MILLIS));
 
         byte[] bytes1 = avroSchema.encode(schemaLogicalType);
         Assert.assertTrue(bytes1.length > 0);

--- a/pulsar-proxy/src/test/resources/authentication/tls/ProxyWithAuthorizationTest/broker-cacert.pem
+++ b/pulsar-proxy/src/test/resources/authentication/tls/ProxyWithAuthorizationTest/broker-cacert.pem
@@ -2,61 +2,76 @@ Certificate:
     Data:
         Version: 3 (0x2)
         Serial Number:
-            c1:32:3f:61:ff:0d:77:64
-        Signature Algorithm: sha1WithRSAEncryption
-        Issuer: C=US, ST=CA, O=Apache Pulsar, OU=Broker, CN=Broker
+            37:55:7a:ae:71:6b:5f:f0:0d:f7:11:df:b5:f9:ce:e1:65:a4:0c:a4
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = CARoot
         Validity
-            Not Before: Feb 18 03:51:25 2018 GMT
-            Not After : Feb 17 03:51:25 2021 GMT
-        Subject: C=US, ST=CA, O=Apache Pulsar, OU=Broker, CN=Broker
+            Not Before: Apr 23 17:08:51 2021 GMT
+            Not After : Apr 21 17:08:51 2031 GMT
+        Subject: CN = CARoot
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
-            RSA Public Key: (1024 bit)
-                Modulus (1024 bit):
-                    00:ba:01:81:08:33:0c:38:03:e1:3b:7d:9e:0c:c5:
-                    9f:1e:c6:18:31:21:2d:67:1a:69:52:e0:76:52:c8:
-                    7b:c3:83:83:31:e1:5b:3f:4f:ad:7c:75:59:a1:39:
-                    df:a3:7b:a2:e6:e7:10:02:8f:2f:ad:13:9c:8a:f6:
-                    13:b1:43:6e:54:cd:a5:fe:35:57:ef:e1:a8:f3:48:
-                    09:ad:a7:1b:6d:ae:db:73:52:1c:0b:95:eb:da:e2:
-                    fa:4e:4b:d8:78:77:a1:61:8d:a3:e0:f9:9a:49:87:
-                    42:45:71:2e:a8:7a:d1:1e:c3:1d:ea:40:3f:3a:7c:
-                    a6:e3:34:ec:db:53:e7:d3:a9
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:ce:29:c8:45:af:07:8e:79:1e:55:66:7b:93:af:
+                    09:2c:72:fd:d5:33:38:30:a9:b5:50:92:90:33:b0:
+                    55:b0:c4:6b:37:4a:ba:5b:76:4d:52:0b:9f:58:b2:
+                    c5:95:8c:47:6d:2b:07:0a:f5:74:43:ec:7d:36:bf:
+                    3e:8c:d6:13:31:ce:fc:d1:77:b0:ac:3c:ae:69:4b:
+                    bd:5d:93:bd:84:57:51:a7:ef:03:2e:ae:3e:93:73:
+                    8b:1e:39:90:8b:32:e2:0a:dd:b8:20:83:98:76:91:
+                    75:d6:d5:db:43:7b:f4:c9:4e:23:52:e3:11:55:05:
+                    48:b8:82:47:ea:32:0b:56:1b:07:11:f3:06:c7:4a:
+                    d5:6b:87:c2:2e:e2:9a:8c:9d:54:ca:5e:96:08:02:
+                    5d:17:42:4d:73:86:08:ab:6e:2e:f3:a8:c3:a3:c1:
+                    bd:88:63:5e:69:7e:fa:af:31:8d:3a:49:ed:e8:cf:
+                    80:15:ca:d4:2b:fe:84:3d:aa:27:7e:98:36:48:4f:
+                    3b:27:90:1d:c1:fe:4e:13:b0:5e:a5:32:6e:16:38:
+                    2e:b7:d1:f3:6b:18:a5:3e:b6:d7:07:42:21:c7:d9:
+                    8e:d6:8c:a5:bf:25:9e:5c:fc:c7:12:18:59:23:b9:
+                    3d:39:45:3d:1c:81:e2:f2:29:91:05:20:46:b2:52:
+                    06:51
                 Exponent: 65537 (0x10001)
         X509v3 extensions:
             X509v3 Subject Key Identifier: 
-                54:D1:B0:95:A0:92:D5:5A:C0:35:8F:6C:EE:D5:6C:4E:90:48:2E:10
+                EF:DA:58:74:AA:21:F9:9E:19:7E:44:2B:84:32:93:F4:0F:79:18:3B
             X509v3 Authority Key Identifier: 
-                keyid:54:D1:B0:95:A0:92:D5:5A:C0:35:8F:6C:EE:D5:6C:4E:90:48:2E:10
-                DirName:/C=US/ST=CA/O=Apache Pulsar/OU=Broker/CN=Broker
-                serial:C1:32:3F:61:FF:0D:77:64
+                keyid:EF:DA:58:74:AA:21:F9:9E:19:7E:44:2B:84:32:93:F4:0F:79:18:3B
 
-            X509v3 Basic Constraints: 
+            X509v3 Basic Constraints: critical
                 CA:TRUE
-    Signature Algorithm: sha1WithRSAEncryption
-        81:81:2e:55:77:02:81:a6:dc:31:ce:ee:50:1e:c4:79:6f:14:
-        b0:5e:b3:85:99:0e:29:ba:ab:5e:b5:0b:f7:aa:71:bb:20:ae:
-        7a:08:1e:f3:5a:7a:a1:7d:b9:a6:89:9e:89:d4:a3:c5:68:22:
-        04:99:99:b0:e7:a8:c1:ac:17:76:1e:3d:e9:07:62:99:da:38:
-        ec:0e:7c:d8:3e:bc:0c:cb:71:31:9f:d1:6a:5c:d3:b1:1b:82:
-        11:8e:69:b7:f9:1c:a7:19:b8:6d:a4:2d:6a:85:8f:5f:f5:e3:
-        32:47:8b:85:47:ba:ef:66:c1:ad:f7:1f:b6:f2:9b:9a:65:3f:
-        2f:42
+    Signature Algorithm: sha256WithRSAEncryption
+         2e:f5:b6:f7:fc:50:89:16:1e:ea:8c:ec:57:54:f6:ca:d3:19:
+         65:fe:da:c5:73:53:f6:d0:1e:26:96:f2:d3:03:55:8d:6e:c4:
+         cd:8c:2d:7a:ea:fa:38:6c:ed:fa:d5:23:b8:52:c1:e3:52:04:
+         3d:46:8c:2d:b6:b2:47:68:41:92:f6:47:24:50:78:47:5e:2a:
+         9b:df:85:a8:92:0d:49:17:eb:51:e8:b2:69:3c:4a:f3:9f:5f:
+         ea:fd:b2:08:3c:30:1a:93:be:d3:c3:b3:c7:60:7c:ea:f4:15:
+         43:bd:3f:b1:d0:69:3c:84:5b:05:01:55:d7:d5:87:fb:58:53:
+         03:d8:91:5f:e8:e0:37:88:82:ea:dc:1c:2d:a0:8d:82:68:65:
+         6e:ea:0d:2a:e1:aa:cc:b3:d1:ce:a8:2b:2d:ed:e4:ba:0f:7f:
+         51:48:d2:4b:2f:7c:eb:02:01:4f:2c:b6:06:c1:9a:97:2c:b7:
+         6c:b7:06:86:d1:8b:cc:d6:d4:c3:ff:b5:65:c5:92:eb:9c:68:
+         6d:99:d8:4a:6d:7a:ac:fe:dc:f3:12:f8:bb:2b:0a:b9:d8:1e:
+         87:b6:e9:8b:51:32:f3:7b:0b:1a:29:57:4c:7d:5a:b6:9c:83:
+         23:e5:35:2b:98:83:aa:7c:ef:24:3a:74:a8:86:22:32:06:fb:
+         03:b7:01:9d
 -----BEGIN CERTIFICATE-----
-MIIC3jCCAkegAwIBAgIJAMEyP2H/DXdkMA0GCSqGSIb3DQEBBQUAMFQxCzAJBgNV
-BAYTAlVTMQswCQYDVQQIEwJDQTEWMBQGA1UEChMNQXBhY2hlIFB1bHNhcjEPMA0G
-A1UECxMGQnJva2VyMQ8wDQYDVQQDEwZCcm9rZXIwHhcNMTgwMjE4MDM1MTI1WhcN
-MjEwMjE3MDM1MTI1WjBUMQswCQYDVQQGEwJVUzELMAkGA1UECBMCQ0ExFjAUBgNV
-BAoTDUFwYWNoZSBQdWxzYXIxDzANBgNVBAsTBkJyb2tlcjEPMA0GA1UEAxMGQnJv
-a2VyMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC6AYEIMww4A+E7fZ4MxZ8e
-xhgxIS1nGmlS4HZSyHvDg4Mx4Vs/T618dVmhOd+je6Lm5xACjy+tE5yK9hOxQ25U
-zaX+NVfv4ajzSAmtpxttrttzUhwLleva4vpOS9h4d6FhjaPg+ZpJh0JFcS6oetEe
-wx3qQD86fKbjNOzbU+fTqQIDAQABo4G3MIG0MB0GA1UdDgQWBBRU0bCVoJLVWsA1
-j2zu1WxOkEguEDCBhAYDVR0jBH0we4AUVNGwlaCS1VrANY9s7tVsTpBILhChWKRW
-MFQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJDQTEWMBQGA1UEChMNQXBhY2hlIFB1
-bHNhcjEPMA0GA1UECxMGQnJva2VyMQ8wDQYDVQQDEwZCcm9rZXKCCQDBMj9h/w13
-ZDAMBgNVHRMEBTADAQH/MA0GCSqGSIb3DQEBBQUAA4GBAIGBLlV3AoGm3DHO7lAe
-xHlvFLBes4WZDim6q161C/eqcbsgrnoIHvNaeqF9uaaJnonUo8VoIgSZmbDnqMGs
-F3YePekHYpnaOOwOfNg+vAzLcTGf0Wpc07EbghGOabf5HKcZuG2kLWqFj1/14zJH
-i4VHuu9mwa33H7bym5plPy9C
+MIIDAzCCAeugAwIBAgIUN1V6rnFrX/AN9xHftfnO4WWkDKQwDQYJKoZIhvcNAQEL
+BQAwETEPMA0GA1UEAwwGQ0FSb290MB4XDTIxMDQyMzE3MDg1MVoXDTMxMDQyMTE3
+MDg1MVowETEPMA0GA1UEAwwGQ0FSb290MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A
+MIIBCgKCAQEAzinIRa8HjnkeVWZ7k68JLHL91TM4MKm1UJKQM7BVsMRrN0q6W3ZN
+UgufWLLFlYxHbSsHCvV0Q+x9Nr8+jNYTMc780XewrDyuaUu9XZO9hFdRp+8DLq4+
+k3OLHjmQizLiCt24IIOYdpF11tXbQ3v0yU4jUuMRVQVIuIJH6jILVhsHEfMGx0rV
+a4fCLuKajJ1Uyl6WCAJdF0JNc4YIq24u86jDo8G9iGNeaX76rzGNOknt6M+AFcrU
+K/6EPaonfpg2SE87J5Adwf5OE7BepTJuFjgut9HzaxilPrbXB0Ihx9mO1oylvyWe
+XPzHEhhZI7k9OUU9HIHi8imRBSBGslIGUQIDAQABo1MwUTAdBgNVHQ4EFgQU79pY
+dKoh+Z4ZfkQrhDKT9A95GDswHwYDVR0jBBgwFoAU79pYdKoh+Z4ZfkQrhDKT9A95
+GDswDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEALvW29/xQiRYe
+6ozsV1T2ytMZZf7axXNT9tAeJpby0wNVjW7EzYwteur6OGzt+tUjuFLB41IEPUaM
+LbayR2hBkvZHJFB4R14qm9+FqJINSRfrUeiyaTxK859f6v2yCDwwGpO+08Ozx2B8
+6vQVQ70/sdBpPIRbBQFV19WH+1hTA9iRX+jgN4iC6twcLaCNgmhlbuoNKuGqzLPR
+zqgrLe3kug9/UUjSSy986wIBTyy2BsGalyy3bLcGhtGLzNbUw/+1ZcWS65xobZnY
+Sm16rP7c8xL4uysKudgeh7bpi1Ey83sLGilXTH1atpyDI+U1K5iDqnzvJDp0qIYi
+Mgb7A7cBnQ==
 -----END CERTIFICATE-----

--- a/pulsar-proxy/src/test/resources/authentication/tls/ProxyWithAuthorizationTest/broker-cert.pem
+++ b/pulsar-proxy/src/test/resources/authentication/tls/ProxyWithAuthorizationTest/broker-cert.pem
@@ -1,18 +1,18 @@
 Certificate:
     Data:
-        Version: 3 (0x2)
+        Version: 1 (0x0)
         Serial Number:
-            c1:32:3f:61:ff:0d:77:65
-        Signature Algorithm: sha1WithRSAEncryption
-        Issuer: C=US, ST=CA, O=Apache Pulsar, OU=Broker, CN=Broker
+            0c:26:15:df:8f:71:1d:6a:31:d0:da:af:64:ef:80:de:ac:9a:46:78
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = CARoot
         Validity
-            Not Before: Feb 18 03:53:39 2018 GMT
-            Not After : Nov 16 00:00:00 2030 GMT
-        Subject: C=US, ST=CA, O=Apache Pulsar, OU=Broker, CN=Broker
+            Not Before: Apr 23 17:08:51 2021 GMT
+            Not After : Apr 21 17:08:51 2031 GMT
+        Subject: C = US, ST = CA, O = Apache Pulsar, OU = Broker, CN = Broker
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
-            RSA Public Key: (2048 bit)
-                Modulus (2048 bit):
+                RSA Public-Key: (2048 bit)
+                Modulus:
                     00:ca:77:dc:2a:13:25:24:cb:29:62:06:12:5f:a8:
                     92:c9:53:d6:3f:07:ca:aa:0a:5f:72:92:cd:b7:ea:
                     45:47:71:f0:63:4f:58:1a:3d:fa:ce:a6:73:90:c0:
@@ -32,41 +32,37 @@ Certificate:
                     07:f0:b0:06:4f:2c:4c:75:c2:37:ff:35:0d:b1:42:
                     06:0b
                 Exponent: 65537 (0x10001)
-        X509v3 extensions:
-            X509v3 Basic Constraints: 
-                CA:FALSE
-            Netscape Comment: 
-                OpenSSL Generated Certificate
-            X509v3 Subject Key Identifier: 
-                71:34:A9:AE:A7:29:C0:93:85:07:94:FE:63:AE:61:91:1D:7B:57:7D
-            X509v3 Authority Key Identifier: 
-                keyid:54:D1:B0:95:A0:92:D5:5A:C0:35:8F:6C:EE:D5:6C:4E:90:48:2E:10
-
-    Signature Algorithm: sha1WithRSAEncryption
-        24:ce:79:65:1d:bd:1a:4b:0f:7b:c2:91:e5:0b:43:4b:c7:28:
-        c0:b7:77:9b:57:ca:c7:05:37:46:2d:f9:cd:1f:f9:f7:95:44:
-        39:e9:69:64:c1:33:6e:0f:dd:56:dc:e7:f4:18:aa:e6:92:8a:
-        f1:73:ff:90:72:a1:2c:46:e5:14:9a:d7:25:fe:ac:aa:3c:bc:
-        81:50:d0:09:1a:e8:2e:3b:bc:77:ac:e1:f7:ef:eb:7d:76:44:
-        5f:29:a9:2f:4a:92:33:2d:60:0f:d5:6d:12:c4:e3:a4:4a:eb:
-        95:8c:d8:06:06:59:c1:3e:31:12:de:23:ac:af:75:0e:9c:b0:
-        9a:a5
+    Signature Algorithm: sha256WithRSAEncryption
+         46:84:81:7e:4a:91:2a:c0:d7:0c:5a:a2:fb:6e:a2:e1:66:15:
+         b9:b3:50:1c:93:8c:68:ba:90:42:07:2c:d1:d9:22:53:c4:e7:
+         74:a9:ac:0c:25:cb:ae:c9:a1:c9:35:49:5d:10:c6:ee:08:2a:
+         23:f3:a4:87:24:92:c4:4e:35:b8:23:8e:be:ad:8c:5b:25:df:
+         25:d4:49:8c:d6:11:bf:79:43:a2:88:7f:70:87:8c:fb:51:9a:
+         4c:73:8d:10:e7:5b:fa:fb:76:f9:88:7a:6a:d0:bf:0f:65:1e:
+         26:22:87:57:31:9a:c9:4c:62:cf:ef:00:2b:4e:2f:ee:d4:d8:
+         0d:2f:7f:2e:14:21:d5:c3:25:ce:29:a3:f0:ee:c6:3d:d2:dc:
+         7b:80:34:57:50:97:e7:79:d9:ca:39:10:73:2d:46:f4:98:de:
+         ec:be:98:1a:17:12:c3:9e:1f:0d:25:c8:4e:17:a1:4a:8d:6a:
+         21:11:42:56:1a:16:79:12:e2:db:39:e1:5d:c4:2e:03:31:54:
+         d9:97:53:21:bc:f0:60:e1:ba:ff:f6:a5:4b:c1:39:4f:e1:87:
+         b7:63:9a:63:fa:a2:83:1c:b5:8e:fd:48:be:d5:50:40:0b:69:
+         34:81:1e:d1:ca:c5:34:ff:bc:c3:ec:22:a5:3e:ca:31:fe:43:
+         39:00:79:72
 -----BEGIN CERTIFICATE-----
-MIIDJTCCAo6gAwIBAgIJAMEyP2H/DXdlMA0GCSqGSIb3DQEBBQUAMFQxCzAJBgNV
-BAYTAlVTMQswCQYDVQQIEwJDQTEWMBQGA1UEChMNQXBhY2hlIFB1bHNhcjEPMA0G
-A1UECxMGQnJva2VyMQ8wDQYDVQQDEwZCcm9rZXIwHhcNMTgwMjE4MDM1MzM5WhcN
-MzAxMTE2MDAwMDAwWjBUMQswCQYDVQQGEwJVUzELMAkGA1UECBMCQ0ExFjAUBgNV
-BAoTDUFwYWNoZSBQdWxzYXIxDzANBgNVBAsTBkJyb2tlcjEPMA0GA1UEAxMGQnJv
-a2VyMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAynfcKhMlJMspYgYS
-X6iSyVPWPwfKqgpfcpLNt+pFR3HwY09YGj36zqZzkMCp9yXwdnXtsgMXvtiKVvNP
-akx+A2WV5UXrjUfoYF6eOHRQVGWg7NhcZWA0G5aDfXHUXX/jYlln6PDWJH3AbjcD
-VEw9DDM5mzPhUkTFQ9rq7izzHBYuRkx8n11Nbv6MI573fp85wXEGUvQmmiLUz8Ul
-OanS5CTG2EpIou52Jcs88L/NEHf/gRFDIcw7zBB6B4T8zAKiRd6RLWvR7Rca0Eb0
-rn2zifgxd5XlRrGpMdbY40cAsoGB24oc2fHN40019jiRDeoH8LAGTyxMdcI3/zUN
-sUIGCwIDAQABo3sweTAJBgNVHRMEAjAAMCwGCWCGSAGG+EIBDQQfFh1PcGVuU1NM
-IEdlbmVyYXRlZCBDZXJ0aWZpY2F0ZTAdBgNVHQ4EFgQUcTSprqcpwJOFB5T+Y65h
-kR17V30wHwYDVR0jBBgwFoAUVNGwlaCS1VrANY9s7tVsTpBILhAwDQYJKoZIhvcN
-AQEFBQADgYEAJM55ZR29GksPe8KR5QtDS8cowLd3m1fKxwU3Ri35zR/595VEOelp
-ZMEzbg/dVtzn9Biq5pKK8XP/kHKhLEblFJrXJf6sqjy8gVDQCRroLju8d6zh9+/r
-fXZEXympL0qSMy1gD9VtEsTjpErrlYzYBgZZwT4xEt4jrK91DpywmqU=
+MIIC7DCCAdQCFAwmFd+PcR1qMdDar2TvgN6smkZ4MA0GCSqGSIb3DQEBCwUAMBEx
+DzANBgNVBAMMBkNBUm9vdDAeFw0yMTA0MjMxNzA4NTFaFw0zMTA0MjExNzA4NTFa
+MFQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJDQTEWMBQGA1UEChMNQXBhY2hlIFB1
+bHNhcjEPMA0GA1UECxMGQnJva2VyMQ8wDQYDVQQDEwZCcm9rZXIwggEiMA0GCSqG
+SIb3DQEBAQUAA4IBDwAwggEKAoIBAQDKd9wqEyUkyyliBhJfqJLJU9Y/B8qqCl9y
+ks236kVHcfBjT1gaPfrOpnOQwKn3JfB2de2yAxe+2IpW809qTH4DZZXlReuNR+hg
+Xp44dFBUZaDs2FxlYDQbloN9cdRdf+NiWWfo8NYkfcBuNwNUTD0MMzmbM+FSRMVD
+2uruLPMcFi5GTHyfXU1u/owjnvd+nznBcQZS9CaaItTPxSU5qdLkJMbYSkii7nYl
+yzzwv80Qd/+BEUMhzDvMEHoHhPzMAqJF3pEta9HtFxrQRvSufbOJ+DF3leVGsakx
+1tjjRwCygYHbihzZ8c3jTTX2OJEN6gfwsAZPLEx1wjf/NQ2xQgYLAgMBAAEwDQYJ
+KoZIhvcNAQELBQADggEBAEaEgX5KkSrA1wxaovtuouFmFbmzUByTjGi6kEIHLNHZ
+IlPE53SprAwly67Jock1SV0Qxu4IKiPzpIckksRONbgjjr6tjFsl3yXUSYzWEb95
+Q6KIf3CHjPtRmkxzjRDnW/r7dvmIemrQvw9lHiYih1cxmslMYs/vACtOL+7U2A0v
+fy4UIdXDJc4po/Duxj3S3HuANFdQl+d52co5EHMtRvSY3uy+mBoXEsOeHw0lyE4X
+oUqNaiERQlYaFnkS4ts54V3ELgMxVNmXUyG88GDhuv/2pUvBOU/hh7djmmP6ooMc
+tY79SL7VUEALaTSBHtHKxTT/vMPsIqU+yjH+QzkAeXI=
 -----END CERTIFICATE-----

--- a/pulsar-proxy/src/test/resources/authentication/tls/ProxyWithAuthorizationTest/client-cacert.pem
+++ b/pulsar-proxy/src/test/resources/authentication/tls/ProxyWithAuthorizationTest/client-cacert.pem
@@ -2,61 +2,76 @@ Certificate:
     Data:
         Version: 3 (0x2)
         Serial Number:
-            f8:db:4d:4a:12:e2:bf:0a
-        Signature Algorithm: sha1WithRSAEncryption
-        Issuer: C=US, ST=CA, O=Apache Pulsar, OU=Client, CN=Client
+            33:a3:2e:28:58:0b:7a:7b:3c:71:4e:51:1d:1d:16:f5:72:3d:99:01
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = CARoot
         Validity
-            Not Before: Feb 18 03:56:51 2018 GMT
-            Not After : Feb 17 03:56:51 2021 GMT
-        Subject: C=US, ST=CA, O=Apache Pulsar, OU=Client, CN=Client
+            Not Before: Apr 23 17:08:51 2021 GMT
+            Not After : Apr 21 17:08:51 2031 GMT
+        Subject: CN = CARoot
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
-            RSA Public Key: (1024 bit)
-                Modulus (1024 bit):
-                    00:c9:b4:bc:fe:63:eb:34:97:fb:c2:bd:84:d4:47:
-                    ea:5e:21:3f:ce:7e:0b:38:b9:a7:5c:9b:02:93:34:
-                    06:68:1c:2c:7e:5a:d9:a9:c6:db:39:d5:5a:40:52:
-                    e8:63:bb:db:76:78:8a:8c:a7:cb:dc:23:9e:b2:56:
-                    6a:c9:4f:5e:8d:f0:50:1c:2f:68:ef:0e:03:d7:e9:
-                    30:0e:6e:45:eb:a6:39:0d:67:9c:b2:f7:10:e7:a5:
-                    a4:f3:4a:6e:0d:d3:86:6f:16:66:15:04:fb:4f:95:
-                    f1:bd:c2:36:3c:5d:b3:c3:7b:a9:36:c5:f1:1a:64:
-                    c6:b5:f7:ff:c2:be:09:c0:35
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:d9:06:95:38:4a:ed:0d:ef:57:12:26:5e:2f:ea:
+                    3c:05:78:1e:36:90:6c:d6:8d:dc:18:e7:e0:24:d7:
+                    72:ae:d3:af:6a:ff:32:1f:ee:d8:93:9e:f4:53:88:
+                    0f:5d:d6:56:41:03:b9:1e:d7:d4:0d:d5:ae:27:20:
+                    d8:8f:e3:7d:65:79:d3:00:c9:cc:f4:ef:f5:c9:f6:
+                    83:a4:45:b4:6d:11:ac:fc:55:f2:94:6b:75:74:d9:
+                    f7:23:b2:5a:ba:a3:21:b4:6e:5a:2d:fc:84:32:ef:
+                    78:f5:d7:22:7c:e8:a8:15:aa:1d:9f:53:63:fd:77:
+                    f4:d7:20:cc:21:34:1c:7a:22:a9:6a:de:90:06:ae:
+                    10:ff:96:21:61:9e:6d:21:f5:66:37:ef:a0:5a:a8:
+                    51:5f:22:24:9f:a9:a9:b3:21:10:f4:7a:d9:ee:c3:
+                    20:73:c3:48:0a:c7:98:7c:5f:04:7a:e1:eb:8c:d6:
+                    f0:18:d7:e9:0c:11:cd:a1:81:f4:d4:67:c0:72:0f:
+                    e3:90:86:92:97:bd:bc:44:df:b1:b3:6d:85:4f:6b:
+                    fa:bf:9e:6a:1d:9c:77:23:3b:6f:89:38:fb:45:ff:
+                    f5:76:b3:19:f7:7c:59:2b:07:ff:6a:4a:f5:93:4a:
+                    62:ef:18:3b:ea:54:8f:2d:c2:34:c8:a3:6f:ee:f8:
+                    f2:a3
                 Exponent: 65537 (0x10001)
         X509v3 extensions:
             X509v3 Subject Key Identifier: 
-                4F:E4:CE:4A:8E:79:B6:43:C0:A4:9F:8B:78:A9:6F:BD:60:81:46:54
+                86:1F:20:03:1D:EA:65:52:AA:D7:38:B7:A7:B1:DC:0A:02:F9:F2:02
             X509v3 Authority Key Identifier: 
-                keyid:4F:E4:CE:4A:8E:79:B6:43:C0:A4:9F:8B:78:A9:6F:BD:60:81:46:54
-                DirName:/C=US/ST=CA/O=Apache Pulsar/OU=Client/CN=Client
-                serial:F8:DB:4D:4A:12:E2:BF:0A
+                keyid:86:1F:20:03:1D:EA:65:52:AA:D7:38:B7:A7:B1:DC:0A:02:F9:F2:02
 
-            X509v3 Basic Constraints: 
+            X509v3 Basic Constraints: critical
                 CA:TRUE
-    Signature Algorithm: sha1WithRSAEncryption
-        85:04:19:99:c8:27:4f:f2:60:71:6b:f4:25:d0:b2:d0:eb:6a:
-        d8:1a:1d:5f:c5:a5:c5:af:1b:41:16:30:a2:42:f2:53:85:5e:
-        42:03:9d:e8:75:35:14:46:91:18:b3:12:ad:b8:db:7f:12:0f:
-        32:8b:02:ff:51:0c:ce:d9:15:01:98:11:81:61:e0:f2:52:d3:
-        36:2b:9f:b5:93:67:80:70:57:b8:cb:a3:5d:94:14:93:cd:f7:
-        a4:b0:d0:43:a6:f7:5e:c1:bc:b1:95:1e:dc:2d:b4:67:65:24:
-        6b:9d:eb:fc:ef:6f:ea:ea:c6:59:4c:fe:05:3f:48:89:47:a1:
-        f2:b1
+    Signature Algorithm: sha256WithRSAEncryption
+         c3:8a:4d:5b:3a:01:28:08:cc:cd:8b:cc:37:0d:0b:0c:45:dd:
+         c0:44:ee:36:9c:1d:7d:1f:b9:5a:a7:fd:9a:19:34:0f:8c:09:
+         9d:24:f1:7b:a2:22:ef:7f:f3:4f:31:e2:b8:a5:f2:ec:d5:32:
+         02:f3:10:c4:82:c4:a0:33:b0:50:53:b7:2e:3d:78:30:8e:b3:
+         c1:f8:51:4d:30:5b:40:65:6f:ad:b8:99:be:d8:cc:3b:43:00:
+         2b:16:5c:9c:bd:83:24:a0:48:0d:cd:2e:29:74:a8:e6:bc:df:
+         f0:7c:2c:1f:03:72:f4:47:4d:88:e6:8f:53:77:25:23:57:0a:
+         84:fb:38:e7:b0:84:57:2b:4d:5a:f0:94:34:8a:48:ca:dc:f7:
+         08:b5:d5:1e:64:b4:03:c9:f3:3d:dd:f5:27:ac:f8:2b:d5:80:
+         ab:b5:b1:37:8e:ae:2f:03:c2:19:4d:37:d6:e2:76:24:a2:98:
+         ed:c8:c5:d0:65:29:4d:ce:0a:bf:d0:a3:3f:f6:03:47:fa:75:
+         8c:06:22:fe:8a:13:9a:9c:17:f5:35:71:7d:66:b9:cd:ca:ac:
+         1e:c3:09:c6:76:b0:6c:2b:45:fd:5b:a9:02:7b:e8:fa:65:32:
+         e3:8e:7d:25:6e:06:db:bc:fd:5b:ad:78:d3:e0:09:df:3d:9c:
+         3b:56:c5:69
 -----BEGIN CERTIFICATE-----
-MIIC3jCCAkegAwIBAgIJAPjbTUoS4r8KMA0GCSqGSIb3DQEBBQUAMFQxCzAJBgNV
-BAYTAlVTMQswCQYDVQQIEwJDQTEWMBQGA1UEChMNQXBhY2hlIFB1bHNhcjEPMA0G
-A1UECxMGQ2xpZW50MQ8wDQYDVQQDEwZDbGllbnQwHhcNMTgwMjE4MDM1NjUxWhcN
-MjEwMjE3MDM1NjUxWjBUMQswCQYDVQQGEwJVUzELMAkGA1UECBMCQ0ExFjAUBgNV
-BAoTDUFwYWNoZSBQdWxzYXIxDzANBgNVBAsTBkNsaWVudDEPMA0GA1UEAxMGQ2xp
-ZW50MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDJtLz+Y+s0l/vCvYTUR+pe
-IT/Ofgs4uadcmwKTNAZoHCx+Wtmpxts51VpAUuhju9t2eIqMp8vcI56yVmrJT16N
-8FAcL2jvDgPX6TAObkXrpjkNZ5yy9xDnpaTzSm4N04ZvFmYVBPtPlfG9wjY8XbPD
-e6k2xfEaZMa19//CvgnANQIDAQABo4G3MIG0MB0GA1UdDgQWBBRP5M5Kjnm2Q8Ck
-n4t4qW+9YIFGVDCBhAYDVR0jBH0we4AUT+TOSo55tkPApJ+LeKlvvWCBRlShWKRW
-MFQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJDQTEWMBQGA1UEChMNQXBhY2hlIFB1
-bHNhcjEPMA0GA1UECxMGQ2xpZW50MQ8wDQYDVQQDEwZDbGllbnSCCQD4201KEuK/
-CjAMBgNVHRMEBTADAQH/MA0GCSqGSIb3DQEBBQUAA4GBAIUEGZnIJ0/yYHFr9CXQ
-stDratgaHV/FpcWvG0EWMKJC8lOFXkIDneh1NRRGkRizEq24238SDzKLAv9RDM7Z
-FQGYEYFh4PJS0zYrn7WTZ4BwV7jLo12UFJPN96Sw0EOm917BvLGVHtwttGdlJGud
-6/zvb+rqxllM/gU/SIlHofKx
+MIIDAzCCAeugAwIBAgIUM6MuKFgLens8cU5RHR0W9XI9mQEwDQYJKoZIhvcNAQEL
+BQAwETEPMA0GA1UEAwwGQ0FSb290MB4XDTIxMDQyMzE3MDg1MVoXDTMxMDQyMTE3
+MDg1MVowETEPMA0GA1UEAwwGQ0FSb290MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A
+MIIBCgKCAQEA2QaVOErtDe9XEiZeL+o8BXgeNpBs1o3cGOfgJNdyrtOvav8yH+7Y
+k570U4gPXdZWQQO5HtfUDdWuJyDYj+N9ZXnTAMnM9O/1yfaDpEW0bRGs/FXylGt1
+dNn3I7JauqMhtG5aLfyEMu949dcifOioFaodn1Nj/Xf01yDMITQceiKpat6QBq4Q
+/5YhYZ5tIfVmN++gWqhRXyIkn6mpsyEQ9HrZ7sMgc8NICseYfF8EeuHrjNbwGNfp
+DBHNoYH01GfAcg/jkIaSl728RN+xs22FT2v6v55qHZx3IztviTj7Rf/1drMZ93xZ
+Kwf/akr1k0pi7xg76lSPLcI0yKNv7vjyowIDAQABo1MwUTAdBgNVHQ4EFgQUhh8g
+Ax3qZVKq1zi3p7HcCgL58gIwHwYDVR0jBBgwFoAUhh8gAx3qZVKq1zi3p7HcCgL5
+8gIwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAw4pNWzoBKAjM
+zYvMNw0LDEXdwETuNpwdfR+5Wqf9mhk0D4wJnSTxe6Ii73/zTzHiuKXy7NUyAvMQ
+xILEoDOwUFO3Lj14MI6zwfhRTTBbQGVvrbiZvtjMO0MAKxZcnL2DJKBIDc0uKXSo
+5rzf8HwsHwNy9EdNiOaPU3clI1cKhPs457CEVytNWvCUNIpIytz3CLXVHmS0A8nz
+Pd31J6z4K9WAq7WxN46uLwPCGU031uJ2JKKY7cjF0GUpTc4Kv9CjP/YDR/p1jAYi
+/ooTmpwX9TVxfWa5zcqsHsMJxnawbCtF/VupAnvo+mUy4459JW4G27z9W6140+AJ
+3z2cO1bFaQ==
 -----END CERTIFICATE-----

--- a/pulsar-proxy/src/test/resources/authentication/tls/ProxyWithAuthorizationTest/client-cert.pem
+++ b/pulsar-proxy/src/test/resources/authentication/tls/ProxyWithAuthorizationTest/client-cert.pem
@@ -1,18 +1,18 @@
 Certificate:
     Data:
-        Version: 3 (0x2)
+        Version: 1 (0x0)
         Serial Number:
-            f8:db:4d:4a:12:e2:bf:0b
-        Signature Algorithm: sha1WithRSAEncryption
-        Issuer: C=US, ST=CA, O=Apache Pulsar, OU=Client, CN=Client
+            0c:26:15:df:8f:71:1d:6a:31:d0:da:af:64:ef:80:de:ac:9a:46:79
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = CARoot
         Validity
-            Not Before: Feb 18 03:58:13 2018 GMT
-            Not After : Nov 16 00:00:00 2030 GMT
-        Subject: C=US, ST=CA, O=Apache Pulsar, OU=Client, CN=Client
+            Not Before: Apr 23 17:08:51 2021 GMT
+            Not After : Apr 21 17:08:51 2031 GMT
+        Subject: C = US, ST = CA, O = Apache Pulsar, OU = Client, CN = Client
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
-            RSA Public Key: (2048 bit)
-                Modulus (2048 bit):
+                RSA Public-Key: (2048 bit)
+                Modulus:
                     00:de:1e:10:bd:64:13:c1:6c:7a:49:86:01:3b:ab:
                     ab:1d:ec:b2:93:41:6c:6c:21:f2:e6:15:1b:51:ce:
                     ad:67:fd:18:3e:7f:7a:64:a2:62:5f:2e:0b:59:b4:
@@ -32,41 +32,37 @@ Certificate:
                     8e:18:48:4c:5f:19:e9:b0:7b:22:d3:bc:42:32:45:
                     9a:d1
                 Exponent: 65537 (0x10001)
-        X509v3 extensions:
-            X509v3 Basic Constraints: 
-                CA:FALSE
-            Netscape Comment: 
-                OpenSSL Generated Certificate
-            X509v3 Subject Key Identifier: 
-                E1:E9:57:60:A7:47:48:F0:1F:A8:C6:2F:95:BF:3A:42:DB:BC:7A:4D
-            X509v3 Authority Key Identifier: 
-                keyid:4F:E4:CE:4A:8E:79:B6:43:C0:A4:9F:8B:78:A9:6F:BD:60:81:46:54
-
-    Signature Algorithm: sha1WithRSAEncryption
-        a5:eb:02:90:4c:a3:33:e4:6c:c3:47:66:94:d8:3c:05:c0:ac:
-        f4:44:56:de:85:a8:41:4a:bb:28:0f:7e:aa:b9:58:40:a4:22:
-        b3:a3:46:94:42:0c:f2:93:0e:b5:c1:17:29:58:48:12:4a:3d:
-        83:40:e0:6b:07:11:54:ca:7b:58:a8:f3:7a:e4:3d:69:aa:04:
-        2e:3a:5e:d8:c1:ac:08:2f:41:17:b4:cb:35:89:00:65:f1:2b:
-        07:80:4c:c2:90:49:cd:2d:ca:43:8c:64:c1:eb:8a:b3:88:d1:
-        4b:50:95:14:41:4b:b7:76:b2:10:97:52:63:bf:17:c7:36:6f:
-        d8:bb
+    Signature Algorithm: sha256WithRSAEncryption
+         a4:bb:d2:e4:ba:17:1f:07:13:26:ac:e1:71:df:1e:d4:d7:a7:
+         31:dd:df:ce:e6:bb:11:fb:cf:a5:66:d2:fb:0e:26:90:fd:94:
+         0d:d2:d6:91:f3:65:75:ae:16:b6:92:2e:0a:41:b5:fc:ba:33:
+         57:85:92:e8:a3:30:97:d9:26:dc:e0:37:da:c5:bd:5f:e9:dd:
+         db:81:cb:38:96:99:6e:d2:a5:6d:92:a8:6d:be:03:6f:a9:48:
+         4a:a1:4b:91:f9:c3:11:85:79:1e:4e:77:98:ff:43:dd:e0:f9:
+         8e:95:fe:f3:e2:eb:48:72:cf:04:fe:3d:78:b3:a8:ee:56:c8:
+         12:c8:0a:3d:70:f4:86:42:d2:b9:54:4d:07:8c:45:ad:af:b9:
+         43:c8:f9:ee:fc:5d:96:a2:b6:d5:d9:48:57:4e:b5:7d:c7:8c:
+         35:21:99:13:9a:60:42:1f:39:4a:3a:1b:3b:e5:ab:1d:91:59:
+         8a:e1:82:9e:70:79:f9:9a:6e:bb:a9:99:30:4d:93:c8:bf:95:
+         91:a1:03:a3:ac:d8:cd:80:db:89:82:a7:e6:74:8d:53:b3:a6:
+         7a:b9:ca:93:14:a2:01:08:bd:9f:4e:2d:0d:50:b3:aa:e8:a6:
+         a8:43:b5:d6:a4:1c:2f:62:7a:1f:1b:92:6b:2d:fa:12:c3:1a:
+         ed:8b:11:fe
 -----BEGIN CERTIFICATE-----
-MIIDJTCCAo6gAwIBAgIJAPjbTUoS4r8LMA0GCSqGSIb3DQEBBQUAMFQxCzAJBgNV
-BAYTAlVTMQswCQYDVQQIEwJDQTEWMBQGA1UEChMNQXBhY2hlIFB1bHNhcjEPMA0G
-A1UECxMGQ2xpZW50MQ8wDQYDVQQDEwZDbGllbnQwHhcNMTgwMjE4MDM1ODEzWhcN
-MzAxMTE2MDAwMDAwWjBUMQswCQYDVQQGEwJVUzELMAkGA1UECBMCQ0ExFjAUBgNV
-BAoTDUFwYWNoZSBQdWxzYXIxDzANBgNVBAsTBkNsaWVudDEPMA0GA1UEAxMGQ2xp
-ZW50MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA3h4QvWQTwWx6SYYB
-O6urHeyyk0FsbCHy5hUbUc6tZ/0YPn96ZKJiXy4LWbTt2RcOt7xQZkG348RxyXNz
-PdhtNIDy47mYjytUFJWzURvWkYXNtzSiULbxhm4HMPquVaBd+XwckVBifbsUhpIK
-rCk+KBuZyjBj3KlfBfg4PjAQAp/MlNdH4Br0HGiWPRJeWCFBLOyWrZ4IVoN6kl9L
-5r0BFnAor6onHcT+sgm/pbRH2VhL/kGBDqJGV8E5fI3ksacl5rTd854kyefAjBq0
-q925M78Ry767Ivf8rcRAQdfvNwgalUUf2xRfC/hI/0Eky1yOGEhMXxnpsHsi07xC
-MkWa0QIDAQABo3sweTAJBgNVHRMEAjAAMCwGCWCGSAGG+EIBDQQfFh1PcGVuU1NM
-IEdlbmVyYXRlZCBDZXJ0aWZpY2F0ZTAdBgNVHQ4EFgQU4elXYKdHSPAfqMYvlb86
-Qtu8ek0wHwYDVR0jBBgwFoAUT+TOSo55tkPApJ+LeKlvvWCBRlQwDQYJKoZIhvcN
-AQEFBQADgYEApesCkEyjM+Rsw0dmlNg8BcCs9ERW3oWoQUq7KA9+qrlYQKQis6NG
-lEIM8pMOtcEXKVhIEko9g0DgawcRVMp7WKjzeuQ9aaoELjpe2MGsCC9BF7TLNYkA
-ZfErB4BMwpBJzS3KQ4xkweuKs4jRS1CVFEFLt3ayEJdSY78XxzZv2Ls=
+MIIC7DCCAdQCFAwmFd+PcR1qMdDar2TvgN6smkZ5MA0GCSqGSIb3DQEBCwUAMBEx
+DzANBgNVBAMMBkNBUm9vdDAeFw0yMTA0MjMxNzA4NTFaFw0zMTA0MjExNzA4NTFa
+MFQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJDQTEWMBQGA1UEChMNQXBhY2hlIFB1
+bHNhcjEPMA0GA1UECxMGQ2xpZW50MQ8wDQYDVQQDEwZDbGllbnQwggEiMA0GCSqG
+SIb3DQEBAQUAA4IBDwAwggEKAoIBAQDeHhC9ZBPBbHpJhgE7q6sd7LKTQWxsIfLm
+FRtRzq1n/Rg+f3pkomJfLgtZtO3ZFw63vFBmQbfjxHHJc3M92G00gPLjuZiPK1QU
+lbNRG9aRhc23NKJQtvGGbgcw+q5VoF35fByRUGJ9uxSGkgqsKT4oG5nKMGPcqV8F
++Dg+MBACn8yU10fgGvQcaJY9El5YIUEs7JatnghWg3qSX0vmvQEWcCivqicdxP6y
+Cb+ltEfZWEv+QYEOokZXwTl8jeSxpyXmtN3zniTJ58CMGrSr3bkzvxHLvrsi9/yt
+xEBB1+83CBqVRR/bFF8L+Ej/QSTLXI4YSExfGemweyLTvEIyRZrRAgMBAAEwDQYJ
+KoZIhvcNAQELBQADggEBAKS70uS6Fx8HEyas4XHfHtTXpzHd387muxH7z6Vm0vsO
+JpD9lA3S1pHzZXWuFraSLgpBtfy6M1eFkuijMJfZJtzgN9rFvV/p3duByziWmW7S
+pW2SqG2+A2+pSEqhS5H5wxGFeR5Od5j/Q93g+Y6V/vPi60hyzwT+PXizqO5WyBLI
+Cj1w9IZC0rlUTQeMRa2vuUPI+e78XZaittXZSFdOtX3HjDUhmROaYEIfOUo6Gzvl
+qx2RWYrhgp5wefmabrupmTBNk8i/lZGhA6Os2M2A24mCp+Z0jVOzpnq5ypMUogEI
+vZ9OLQ1Qs6ropqhDtdakHC9ieh8bkmst+hLDGu2LEf4=
 -----END CERTIFICATE-----

--- a/pulsar-proxy/src/test/resources/authentication/tls/ProxyWithAuthorizationTest/proxy-cacert.pem
+++ b/pulsar-proxy/src/test/resources/authentication/tls/ProxyWithAuthorizationTest/proxy-cacert.pem
@@ -2,61 +2,76 @@ Certificate:
     Data:
         Version: 3 (0x2)
         Serial Number:
-            a5:2d:2e:41:e9:fc:8a:91
-        Signature Algorithm: sha1WithRSAEncryption
-        Issuer: C=US, ST=CA, O=Apache Pulsar, OU=Proxy, CN=Proxy
+            2d:fc:78:73:ca:55:1e:32:12:3e:ef:08:24:cf:63:95:1e:ad:ea:ae
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = CARoot
         Validity
-            Not Before: Feb 18 04:00:32 2018 GMT
-            Not After : Feb 17 04:00:32 2021 GMT
-        Subject: C=US, ST=CA, O=Apache Pulsar, OU=Proxy, CN=Proxy
+            Not Before: Apr 23 17:08:51 2021 GMT
+            Not After : Apr 21 17:08:51 2031 GMT
+        Subject: CN = CARoot
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
-            RSA Public Key: (1024 bit)
-                Modulus (1024 bit):
-                    00:aa:ce:ea:82:4f:ac:a8:97:7b:0c:33:cd:ef:7f:
-                    24:45:e5:81:a2:2c:7a:ab:65:34:27:27:39:ae:f4:
-                    b2:f3:0e:cc:08:3b:8e:1d:78:95:aa:95:01:0e:a3:
-                    df:db:4b:9a:ad:85:e6:af:96:16:41:35:dc:b2:23:
-                    03:ff:b9:d6:75:25:29:37:f5:3f:26:43:c3:36:a0:
-                    9c:0f:36:a5:91:dd:7d:18:5d:45:24:d3:f6:bf:86:
-                    91:91:10:b5:00:bf:12:6a:01:9f:28:38:01:08:5f:
-                    fd:a8:6d:98:33:cc:77:fb:a1:fe:06:59:92:6d:0b:
-                    14:bc:9b:59:fd:98:69:ec:6d
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:c3:e0:f7:5d:bb:9a:76:ee:84:c6:2d:79:3f:a6:
+                    4b:3b:1f:32:31:d9:65:80:d3:02:13:23:2a:f1:2f:
+                    e6:ac:bc:24:d1:cb:b9:5b:ed:cb:63:fe:31:e4:e6:
+                    b8:f3:13:72:be:48:57:cb:d1:70:0f:67:16:6d:26:
+                    bc:23:1c:64:30:ee:c8:0e:0e:68:d9:43:7e:42:74:
+                    7a:d4:59:a4:76:67:70:9f:85:aa:f3:9f:6c:e6:a1:
+                    b5:06:3c:1d:46:38:45:05:df:88:cc:3a:ad:6c:72:
+                    96:69:55:d0:b2:a8:ed:fd:b8:07:6b:5c:6d:1c:0d:
+                    98:c2:88:3f:59:3c:d6:6c:ab:df:dd:3a:c0:5c:fe:
+                    86:74:38:bc:00:d4:f0:50:ea:f0:e6:74:23:48:6d:
+                    63:77:c7:f6:e2:94:f8:1b:0f:51:98:f6:fb:e0:20:
+                    58:c1:b6:a0:58:08:6f:ad:05:f7:71:90:b3:1a:5b:
+                    24:88:0b:ed:71:26:aa:84:c2:21:97:76:e7:d5:77:
+                    30:62:15:d4:30:5e:f9:aa:bc:7f:1f:50:5e:92:47:
+                    f2:92:c0:85:cf:ce:33:07:24:e9:ee:b7:04:0d:b7:
+                    9f:82:ae:a0:b6:73:51:8f:fe:bd:2c:f3:b5:76:61:
+                    3c:da:c6:c0:bd:44:46:6f:43:9d:47:b6:0a:80:a5:
+                    fe:3b
                 Exponent: 65537 (0x10001)
         X509v3 extensions:
             X509v3 Subject Key Identifier: 
-                4F:39:5A:C4:BF:78:EF:3D:FC:F1:68:5A:F6:B9:4B:D2:B7:03:C7:87
+                4E:9B:EB:E2:41:17:D1:24:AF:39:02:BC:42:D6:81:B7:62:6D:E3:57
             X509v3 Authority Key Identifier: 
-                keyid:4F:39:5A:C4:BF:78:EF:3D:FC:F1:68:5A:F6:B9:4B:D2:B7:03:C7:87
-                DirName:/C=US/ST=CA/O=Apache Pulsar/OU=Proxy/CN=Proxy
-                serial:A5:2D:2E:41:E9:FC:8A:91
+                keyid:4E:9B:EB:E2:41:17:D1:24:AF:39:02:BC:42:D6:81:B7:62:6D:E3:57
 
-            X509v3 Basic Constraints: 
+            X509v3 Basic Constraints: critical
                 CA:TRUE
-    Signature Algorithm: sha1WithRSAEncryption
-        84:e1:30:a5:a5:7e:39:9b:2a:1f:cb:1e:67:c6:00:75:f3:8f:
-        6a:d0:ef:d7:46:39:2c:b6:ba:1f:03:7d:eb:cf:22:ef:46:82:
-        bb:89:08:dd:3f:28:b3:6e:79:1a:14:26:ed:38:2f:f0:c9:fe:
-        7f:72:5c:8a:82:b8:05:fe:f7:45:6c:e9:6e:ff:f9:d3:a4:60:
-        1a:e9:7b:71:c8:a1:80:3d:0f:33:44:06:30:c7:c9:2f:8f:e4:
-        5d:68:25:cb:28:49:5a:5d:ac:10:f7:d2:90:cf:0c:1f:ff:7c:
-        7b:04:95:a7:b9:27:d9:66:ac:73:6e:92:84:de:68:fc:86:27:
-        e8:d3
+    Signature Algorithm: sha256WithRSAEncryption
+         16:01:53:ab:85:57:5f:92:b9:24:85:c5:70:02:fa:fe:ae:ff:
+         e9:3e:36:24:6e:9e:34:dd:7c:56:f9:31:a1:d1:ae:63:af:3c:
+         2c:e5:8e:47:34:df:b0:1c:33:48:3f:e7:32:fd:a8:38:99:a6:
+         ef:e1:7b:65:92:80:1e:68:e5:98:db:c5:50:4a:35:53:e5:86:
+         89:56:85:0c:6e:da:64:28:68:33:dc:29:3f:41:8b:cf:9c:ec:
+         fc:74:15:19:ff:da:0a:ef:d0:51:67:97:ad:2f:e4:8a:94:52:
+         96:18:bd:77:b3:2b:79:9a:f8:de:af:0f:a2:65:c4:f2:88:3a:
+         57:79:18:e1:d8:7c:e0:52:da:35:8c:dd:d9:75:0d:72:e9:e8:
+         d0:a7:a6:0b:49:88:6d:ed:86:45:25:72:15:4e:2a:0b:6f:9c:
+         2f:48:75:28:b0:aa:cd:15:7f:ae:b3:b7:ec:75:d9:63:c8:46:
+         8f:84:49:1c:e2:db:95:7b:3d:bb:fd:98:45:53:56:3c:3c:de:
+         60:16:f9:14:b8:7e:27:37:be:f0:69:b5:a0:18:bc:83:1e:c1:
+         3a:11:9b:a3:1d:1f:a6:9c:7e:c9:aa:7c:53:44:9e:1d:cb:ca:
+         c8:22:7f:cc:ad:e6:fa:51:54:4d:b5:a1:e6:e3:04:4e:49:1e:
+         67:9c:93:30
 -----BEGIN CERTIFICATE-----
-MIIC2DCCAkGgAwIBAgIJAKUtLkHp/IqRMA0GCSqGSIb3DQEBBQUAMFIxCzAJBgNV
-BAYTAlVTMQswCQYDVQQIEwJDQTEWMBQGA1UEChMNQXBhY2hlIFB1bHNhcjEOMAwG
-A1UECxMFUHJveHkxDjAMBgNVBAMTBVByb3h5MB4XDTE4MDIxODA0MDAzMloXDTIx
-MDIxNzA0MDAzMlowUjELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAkNBMRYwFAYDVQQK
-Ew1BcGFjaGUgUHVsc2FyMQ4wDAYDVQQLEwVQcm94eTEOMAwGA1UEAxMFUHJveHkw
-gZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAKrO6oJPrKiXewwzze9/JEXlgaIs
-eqtlNCcnOa70svMOzAg7jh14laqVAQ6j39tLmq2F5q+WFkE13LIjA/+51nUlKTf1
-PyZDwzagnA82pZHdfRhdRSTT9r+GkZEQtQC/EmoBnyg4AQhf/ahtmDPMd/uh/gZZ
-km0LFLybWf2YaextAgMBAAGjgbUwgbIwHQYDVR0OBBYEFE85WsS/eO89/PFoWva5
-S9K3A8eHMIGCBgNVHSMEezB5gBRPOVrEv3jvPfzxaFr2uUvStwPHh6FWpFQwUjEL
-MAkGA1UEBhMCVVMxCzAJBgNVBAgTAkNBMRYwFAYDVQQKEw1BcGFjaGUgUHVsc2Fy
-MQ4wDAYDVQQLEwVQcm94eTEOMAwGA1UEAxMFUHJveHmCCQClLS5B6fyKkTAMBgNV
-HRMEBTADAQH/MA0GCSqGSIb3DQEBBQUAA4GBAIThMKWlfjmbKh/LHmfGAHXzj2rQ
-79dGOSy2uh8DfevPIu9GgruJCN0/KLNueRoUJu04L/DJ/n9yXIqCuAX+90Vs6W7/
-+dOkYBrpe3HIoYA9DzNEBjDHyS+P5F1oJcsoSVpdrBD30pDPDB//fHsElae5J9lm
-rHNukoTeaPyGJ+jT
+MIIDAzCCAeugAwIBAgIULfx4c8pVHjISPu8IJM9jlR6t6q4wDQYJKoZIhvcNAQEL
+BQAwETEPMA0GA1UEAwwGQ0FSb290MB4XDTIxMDQyMzE3MDg1MVoXDTMxMDQyMTE3
+MDg1MVowETEPMA0GA1UEAwwGQ0FSb290MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A
+MIIBCgKCAQEAw+D3Xbuadu6Exi15P6ZLOx8yMdllgNMCEyMq8S/mrLwk0cu5W+3L
+Y/4x5Oa48xNyvkhXy9FwD2cWbSa8IxxkMO7IDg5o2UN+QnR61Fmkdmdwn4Wq859s
+5qG1BjwdRjhFBd+IzDqtbHKWaVXQsqjt/bgHa1xtHA2Ywog/WTzWbKvf3TrAXP6G
+dDi8ANTwUOrw5nQjSG1jd8f24pT4Gw9RmPb74CBYwbagWAhvrQX3cZCzGlskiAvt
+cSaqhMIhl3bn1XcwYhXUMF75qrx/H1BekkfyksCFz84zByTp7rcEDbefgq6gtnNR
+j/69LPO1dmE82sbAvURGb0OdR7YKgKX+OwIDAQABo1MwUTAdBgNVHQ4EFgQUTpvr
+4kEX0SSvOQK8QtaBt2Jt41cwHwYDVR0jBBgwFoAUTpvr4kEX0SSvOQK8QtaBt2Jt
+41cwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAFgFTq4VXX5K5
+JIXFcAL6/q7/6T42JG6eNN18VvkxodGuY688LOWORzTfsBwzSD/nMv2oOJmm7+F7
+ZZKAHmjlmNvFUEo1U+WGiVaFDG7aZChoM9wpP0GLz5zs/HQVGf/aCu/QUWeXrS/k
+ipRSlhi9d7MreZr43q8PomXE8og6V3kY4dh84FLaNYzd2XUNcuno0KemC0mIbe2G
+RSVyFU4qC2+cL0h1KLCqzRV/rrO37HXZY8hGj4RJHOLblXs9u/2YRVNWPDzeYBb5
+FLh+Jze+8Gm1oBi8gx7BOhGbox0fppx+yap8U0SeHcvKyCJ/zK3m+lFUTbWh5uME
+TkkeZ5yTMA==
 -----END CERTIFICATE-----

--- a/pulsar-proxy/src/test/resources/authentication/tls/ProxyWithAuthorizationTest/proxy-cert.pem
+++ b/pulsar-proxy/src/test/resources/authentication/tls/ProxyWithAuthorizationTest/proxy-cert.pem
@@ -1,18 +1,18 @@
 Certificate:
     Data:
-        Version: 3 (0x2)
+        Version: 1 (0x0)
         Serial Number:
-            a5:2d:2e:41:e9:fc:8a:92
-        Signature Algorithm: sha1WithRSAEncryption
-        Issuer: C=US, ST=CA, O=Apache Pulsar, OU=Proxy, CN=Proxy
+            0c:26:15:df:8f:71:1d:6a:31:d0:da:af:64:ef:80:de:ac:9a:46:7a
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = CARoot
         Validity
-            Not Before: Feb 18 04:02:27 2018 GMT
-            Not After : Nov 16 00:00:00 2030 GMT
-        Subject: C=US, ST=CA, O=Apache Pulsar, OU=Proxy, CN=Proxy
+            Not Before: Apr 23 17:08:51 2021 GMT
+            Not After : Apr 21 17:08:51 2031 GMT
+        Subject: C = US, ST = CA, O = Apache Pulsar, OU = Proxy, CN = Proxy
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
-            RSA Public Key: (2048 bit)
-                Modulus (2048 bit):
+                RSA Public-Key: (2048 bit)
+                Modulus:
                     00:c3:5c:c5:ad:17:dc:f4:d4:c4:ea:1c:60:5a:24:
                     46:13:d9:cf:c0:cd:83:2e:2f:82:70:e5:e0:8d:33:
                     bd:95:b5:cf:c6:f0:54:d5:8d:bd:87:0d:62:6c:1d:
@@ -32,41 +32,37 @@ Certificate:
                     29:e1:23:c4:ed:a0:1c:f6:2a:ed:dc:c0:df:97:a9:
                     f3:8d
                 Exponent: 65537 (0x10001)
-        X509v3 extensions:
-            X509v3 Basic Constraints: 
-                CA:FALSE
-            Netscape Comment: 
-                OpenSSL Generated Certificate
-            X509v3 Subject Key Identifier: 
-                D5:A5:19:6A:3B:38:5F:19:C7:34:C6:BC:68:BE:16:A5:0B:43:57:2D
-            X509v3 Authority Key Identifier: 
-                keyid:4F:39:5A:C4:BF:78:EF:3D:FC:F1:68:5A:F6:B9:4B:D2:B7:03:C7:87
-
-    Signature Algorithm: sha1WithRSAEncryption
-        a0:f1:e6:d4:75:75:10:0e:27:18:28:93:9f:c5:15:2b:f3:52:
-        3c:f7:c7:6d:96:b3:7f:65:6c:78:be:26:f5:f2:41:36:f0:b2:
-        fb:64:67:73:d2:bf:d7:24:af:30:1e:6f:3a:9c:80:98:34:06:
-        11:ba:45:06:57:ec:d9:f0:77:1f:d6:e8:0c:13:9d:d1:15:c7:
-        d8:73:fb:aa:dc:0d:3c:4b:3a:bb:87:3c:21:6d:05:9d:fa:74:
-        db:61:4c:47:6a:e7:6b:79:2b:3f:62:a8:fc:e6:11:c8:0f:40:
-        48:51:71:a2:ad:77:d5:fe:ff:1d:73:82:0c:3c:98:ab:26:9b:
-        78:d5
+    Signature Algorithm: sha256WithRSAEncryption
+         7b:27:a8:2a:54:35:76:e5:f8:a7:60:8d:e7:35:12:69:38:f3:
+         32:af:25:0f:69:1a:b1:af:79:e5:7c:94:5c:8f:aa:76:95:54:
+         35:b4:bb:64:20:1a:91:1e:b3:e4:d1:06:72:24:c3:35:bd:9c:
+         f6:54:61:d9:39:22:99:42:08:d4:97:aa:7d:82:46:fc:77:58:
+         df:93:29:03:6c:ba:1c:13:d1:42:49:32:f1:38:09:d3:3e:43:
+         89:1b:61:c4:40:f3:ac:4c:c1:36:2f:28:bd:57:a0:de:35:82:
+         c9:da:93:5f:09:d6:e8:5b:cd:15:45:b3:28:22:7d:48:00:c4:
+         55:0f:f6:de:d9:c2:0a:39:5e:69:a4:50:9b:3f:e1:06:44:8a:
+         13:af:0b:56:8d:70:c4:9f:d1:a2:b4:25:09:8b:19:47:e8:d2:
+         98:49:2a:a0:8b:fe:8c:cb:23:d8:f8:e6:28:c6:d9:0b:10:7c:
+         d3:ce:48:07:8d:c7:56:bb:c9:e8:d7:a8:a1:24:93:bf:5f:d2:
+         a9:f1:35:b7:40:ad:08:bf:89:63:e5:49:40:13:e7:1e:6a:77:
+         7f:9a:5b:07:0c:eb:80:77:b0:ac:fa:8a:9d:b8:83:53:a1:1e:
+         0e:14:2b:c9:50:96:81:c2:c0:0b:d1:c6:b6:2e:ea:98:3e:7b:
+         ee:5f:09:f7
 -----BEGIN CERTIFICATE-----
-MIIDITCCAoqgAwIBAgIJAKUtLkHp/IqSMA0GCSqGSIb3DQEBBQUAMFIxCzAJBgNV
-BAYTAlVTMQswCQYDVQQIEwJDQTEWMBQGA1UEChMNQXBhY2hlIFB1bHNhcjEOMAwG
-A1UECxMFUHJveHkxDjAMBgNVBAMTBVByb3h5MB4XDTE4MDIxODA0MDIyN1oXDTMw
-MTExNjAwMDAwMFowUjELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAkNBMRYwFAYDVQQK
-Ew1BcGFjaGUgUHVsc2FyMQ4wDAYDVQQLEwVQcm94eTEOMAwGA1UEAxMFUHJveHkw
-ggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDDXMWtF9z01MTqHGBaJEYT
-2c/AzYMuL4Jw5eCNM72Vtc/G8FTVjb2HDWJsHT9SZnT/BjMcPNXtLmPZlsbxmILH
-lEq8ZPKbOlTsgZm8FIJDhwxr2gOMqgtB1/4nxPmIgTSx/yrgbdBH3cERpVSpUzLN
-j/Z1WI4F5NmxrGn+tlTDrTYEonf1U7Z0g9VqAeCWtaKvUI+1152nwr34MYYJX3wK
-sts04YAlF199b4vcjtX5z8/19o9q/j6WAMlWsNDjRt65popem45/6hnMolt1Ijwd
-Nkjk8hoBlWHB8HonnYOWdMypBEIIUzSYLrfjg/nyoynhI8TtoBz2Ku3cwN+XqfON
-AgMBAAGjezB5MAkGA1UdEwQCMAAwLAYJYIZIAYb4QgENBB8WHU9wZW5TU0wgR2Vu
-ZXJhdGVkIENlcnRpZmljYXRlMB0GA1UdDgQWBBTVpRlqOzhfGcc0xrxovhalC0NX
-LTAfBgNVHSMEGDAWgBRPOVrEv3jvPfzxaFr2uUvStwPHhzANBgkqhkiG9w0BAQUF
-AAOBgQCg8ebUdXUQDicYKJOfxRUr81I898dtlrN/ZWx4vib18kE28LL7ZGdz0r/X
-JK8wHm86nICYNAYRukUGV+zZ8Hcf1ugME53RFcfYc/uq3A08Szq7hzwhbQWd+nTb
-YUxHaudreSs/Yqj85hHID0BIUXGirXfV/v8dc4IMPJirJpt41Q==
+MIIC6jCCAdICFAwmFd+PcR1qMdDar2TvgN6smkZ6MA0GCSqGSIb3DQEBCwUAMBEx
+DzANBgNVBAMMBkNBUm9vdDAeFw0yMTA0MjMxNzA4NTFaFw0zMTA0MjExNzA4NTFa
+MFIxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJDQTEWMBQGA1UEChMNQXBhY2hlIFB1
+bHNhcjEOMAwGA1UECxMFUHJveHkxDjAMBgNVBAMTBVByb3h5MIIBIjANBgkqhkiG
+9w0BAQEFAAOCAQ8AMIIBCgKCAQEAw1zFrRfc9NTE6hxgWiRGE9nPwM2DLi+CcOXg
+jTO9lbXPxvBU1Y29hw1ibB0/UmZ0/wYzHDzV7S5j2ZbG8ZiCx5RKvGTymzpU7IGZ
+vBSCQ4cMa9oDjKoLQdf+J8T5iIE0sf8q4G3QR93BEaVUqVMyzY/2dViOBeTZsaxp
+/rZUw602BKJ39VO2dIPVagHglrWir1CPtdedp8K9+DGGCV98CrLbNOGAJRdffW+L
+3I7V+c/P9faPav4+lgDJVrDQ40beuaaKXpuOf+oZzKJbdSI8HTZI5PIaAZVhwfB6
+J52DlnTMqQRCCFM0mC6344P58qMp4SPE7aAc9irt3MDfl6nzjQIDAQABMA0GCSqG
+SIb3DQEBCwUAA4IBAQB7J6gqVDV25finYI3nNRJpOPMyryUPaRqxr3nlfJRcj6p2
+lVQ1tLtkIBqRHrPk0QZyJMM1vZz2VGHZOSKZQgjUl6p9gkb8d1jfkykDbLocE9FC
+STLxOAnTPkOJG2HEQPOsTME2Lyi9V6DeNYLJ2pNfCdboW80VRbMoIn1IAMRVD/be
+2cIKOV5ppFCbP+EGRIoTrwtWjXDEn9GitCUJixlH6NKYSSqgi/6MyyPY+OYoxtkL
+EHzTzkgHjcdWu8no16ihJJO/X9Kp8TW3QK0Iv4lj5UlAE+ceand/mlsHDOuAd7Cs
++oqduINToR4OFCvJUJaBwsAL0ca2LuqYPnvuXwn3
 -----END CERTIFICATE-----

--- a/pulsar-proxy/src/test/resources/authentication/tls/cacert.pem
+++ b/pulsar-proxy/src/test/resources/authentication/tls/cacert.pem
@@ -2,61 +2,76 @@ Certificate:
     Data:
         Version: 3 (0x2)
         Serial Number:
-            88:08:98:b3:13:d8:00:94
-        Signature Algorithm: sha1WithRSAEncryption
-        Issuer: C=US, ST=CA, O=Apache, OU=Pulsar Incubator, CN=localhost
+            7f:c3:12:28:23:73:86:8e:bb:d6:e6:21:43:e3:72:e8:01:17:3e:d1
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = CARoot
         Validity
-            Not Before: Feb 17 01:37:33 2018 GMT
-            Not After : Feb 16 01:37:33 2021 GMT
-        Subject: C=US, ST=CA, O=Apache, OU=Pulsar Incubator, CN=localhost
+            Not Before: Apr 23 17:08:51 2021 GMT
+            Not After : Apr 21 17:08:51 2031 GMT
+        Subject: CN = CARoot
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
-            RSA Public Key: (1024 bit)
-                Modulus (1024 bit):
-                    00:ea:16:8d:a5:b1:19:61:34:54:07:02:60:4e:6d:
-                    54:92:08:fd:fb:23:79:9c:05:bf:14:f7:bc:aa:db:
-                    2b:42:a4:35:74:86:e3:00:ad:8b:18:79:73:7d:f2:
-                    d1:74:dd:74:bc:b8:a2:4c:80:c9:f3:80:ce:bf:f8:
-                    6d:97:f5:05:4f:f4:b2:99:50:e8:d8:b0:c4:57:a0:
-                    e7:dc:82:57:75:2a:a2:02:21:76:f7:37:c2:dc:7c:
-                    4c:36:a6:73:6f:dc:75:48:72:ad:fa:98:02:70:b2:
-                    5e:a2:83:cc:c3:8d:20:a7:1e:bc:d7:1e:c1:d1:7e:
-                    39:35:4b:f5:be:6b:c1:0f:f9
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:b3:6a:94:67:7c:33:90:4e:db:b9:94:b0:a6:1a:
+                    69:77:bb:33:31:fe:3c:8b:6d:8a:f1:cf:07:d9:87:
+                    86:ad:45:cf:4c:e3:e7:35:d5:4b:a3:76:27:9b:30:
+                    b1:82:3f:57:29:c9:f0:be:25:49:25:16:64:58:cc:
+                    b0:f1:01:2e:19:69:52:c8:38:64:61:16:b4:a7:ba:
+                    76:2b:54:e6:a5:80:6c:b6:6c:8a:3c:c1:06:c2:e1:
+                    c1:f3:18:6b:87:08:4b:bb:54:f4:b3:72:1d:f2:ce:
+                    47:18:5f:82:d3:88:c9:39:7b:71:fc:71:1a:aa:7e:
+                    55:6c:35:7f:83:c1:60:e7:7d:b1:80:d0:17:7a:ed:
+                    e7:0d:87:8b:59:e3:18:47:e9:cf:de:0d:0e:c6:3e:
+                    5c:eb:6e:f4:43:95:31:01:2d:e8:f2:ba:8a:bf:ed:
+                    82:0c:7c:14:14:13:0e:fb:ae:f0:3a:7c:29:ee:55:
+                    29:ca:46:7a:be:05:9f:fa:75:65:4c:f5:fb:cf:fe:
+                    92:8d:78:e2:e1:41:55:32:2c:36:a2:ac:96:43:aa:
+                    e2:60:5a:ff:a6:e2:3f:5b:fc:d4:d3:af:cf:78:45:
+                    b5:e7:6e:7d:b6:fa:c4:05:84:a6:49:a7:ac:16:8e:
+                    b2:17:ac:75:76:f0:29:df:c8:da:a2:01:05:25:08:
+                    4d:8f
                 Exponent: 65537 (0x10001)
         X509v3 extensions:
             X509v3 Subject Key Identifier: 
-                D4:7A:CD:0F:44:1B:16:29:25:14:ED:A2:EF:13:0F:A7:46:09:78:F6
+                09:93:47:8E:5F:F3:BD:19:A2:77:FD:09:BA:13:A9:B6:C6:75:4E:B0
             X509v3 Authority Key Identifier: 
-                keyid:D4:7A:CD:0F:44:1B:16:29:25:14:ED:A2:EF:13:0F:A7:46:09:78:F6
-                DirName:/C=US/ST=CA/O=Apache/OU=Pulsar Incubator/CN=localhost
-                serial:88:08:98:B3:13:D8:00:94
+                keyid:09:93:47:8E:5F:F3:BD:19:A2:77:FD:09:BA:13:A9:B6:C6:75:4E:B0
 
-            X509v3 Basic Constraints: 
+            X509v3 Basic Constraints: critical
                 CA:TRUE
-    Signature Algorithm: sha1WithRSAEncryption
-        5e:30:c5:7b:30:3e:1e:16:cd:ba:66:f1:2a:19:13:8a:1a:00:
-        08:f4:1e:8c:e4:3d:57:13:65:96:bf:07:58:55:52:37:3e:aa:
-        2c:19:de:ee:c3:92:6e:79:f3:06:0e:9a:7b:e0:02:50:c3:ef:
-        3b:84:ea:8f:e0:f0:16:a6:a6:67:8b:be:73:0e:5d:f7:88:39:
-        d3:d4:df:85:ad:7c:c1:4f:fa:55:55:6f:c2:48:4e:8e:82:fa:
-        72:3b:8e:9d:dc:f7:2e:9d:47:8e:e5:c9:a2:ee:b1:76:94:15:
-        7c:7a:62:bc:06:45:fa:61:2e:33:8c:18:3e:e9:d5:90:a5:a6:
-        80:5a
+    Signature Algorithm: sha256WithRSAEncryption
+         a1:52:44:1e:c0:a1:73:48:98:dd:91:b9:a7:e1:da:c5:48:65:
+         d2:6d:38:77:b5:fa:f6:f7:c5:e4:b7:51:28:ea:f1:6c:9e:82:
+         80:6d:6f:56:9c:3b:31:b8:71:0e:ad:17:f9:8e:c6:7e:87:a9:
+         5f:30:1c:0e:17:c8:c7:c2:3c:96:3d:7d:01:a9:ce:d0:cd:c3:
+         55:6b:ce:64:35:53:93:c6:8c:4c:3d:0d:38:01:17:7b:e2:d8:
+         b3:a5:78:46:77:fc:7e:da:16:f8:96:d0:72:35:89:c3:15:8c:
+         38:37:8b:7f:ff:01:f9:84:b2:e9:8d:11:64:82:36:e7:ef:86:
+         a6:de:11:d9:78:b4:07:6c:18:89:aa:d6:6d:a2:d8:24:98:40:
+         85:5d:ba:5c:36:75:ad:e8:25:03:2d:94:69:d1:ce:d9:8f:9b:
+         fd:79:5d:4b:30:7a:de:18:08:5a:54:e9:7b:7d:e2:cb:20:65:
+         99:4c:5a:31:de:c8:2c:01:b1:c8:d1:30:1d:33:bd:ef:9b:43:
+         4d:ac:7d:20:1f:c3:10:53:2e:1a:99:d5:6c:62:0e:15:b3:bd:
+         3c:88:58:88:0c:4f:06:21:b7:a4:8c:eb:9f:63:2e:5e:1d:c8:
+         91:39:9a:2b:e3:bf:e4:0a:bd:6e:4d:71:15:4d:e1:af:01:15:
+         99:38:25:12
 -----BEGIN CERTIFICATE-----
-MIIC8jCCAlugAwIBAgIJAIgImLMT2ACUMA0GCSqGSIb3DQEBBQUAMFoxCzAJBgNV
-BAYTAlVTMQswCQYDVQQIEwJDQTEPMA0GA1UEChMGQXBhY2hlMRkwFwYDVQQLExBQ
-dWxzYXIgSW5jdWJhdG9yMRIwEAYDVQQDEwlsb2NhbGhvc3QwHhcNMTgwMjE3MDEz
-NzMzWhcNMjEwMjE2MDEzNzMzWjBaMQswCQYDVQQGEwJVUzELMAkGA1UECBMCQ0Ex
-DzANBgNVBAoTBkFwYWNoZTEZMBcGA1UECxMQUHVsc2FyIEluY3ViYXRvcjESMBAG
-A1UEAxMJbG9jYWxob3N0MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDqFo2l
-sRlhNFQHAmBObVSSCP37I3mcBb8U97yq2ytCpDV0huMArYsYeXN98tF03XS8uKJM
-gMnzgM6/+G2X9QVP9LKZUOjYsMRXoOfcgld1KqICIXb3N8LcfEw2pnNv3HVIcq36
-mAJwsl6ig8zDjSCnHrzXHsHRfjk1S/W+a8EP+QIDAQABo4G/MIG8MB0GA1UdDgQW
-BBTUes0PRBsWKSUU7aLvEw+nRgl49jCBjAYDVR0jBIGEMIGBgBTUes0PRBsWKSUU
-7aLvEw+nRgl49qFepFwwWjELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAkNBMQ8wDQYD
-VQQKEwZBcGFjaGUxGTAXBgNVBAsTEFB1bHNhciBJbmN1YmF0b3IxEjAQBgNVBAMT
-CWxvY2FsaG9zdIIJAIgImLMT2ACUMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEF
-BQADgYEAXjDFezA+HhbNumbxKhkTihoACPQejOQ9VxNllr8HWFVSNz6qLBne7sOS
-bnnzBg6ae+ACUMPvO4Tqj+DwFqamZ4u+cw5d94g509Tfha18wU/6VVVvwkhOjoL6
-cjuOndz3Lp1HjuXJou6xdpQVfHpivAZF+mEuM4wYPunVkKWmgFo=
+MIIDAzCCAeugAwIBAgIUf8MSKCNzho671uYhQ+Ny6AEXPtEwDQYJKoZIhvcNAQEL
+BQAwETEPMA0GA1UEAwwGQ0FSb290MB4XDTIxMDQyMzE3MDg1MVoXDTMxMDQyMTE3
+MDg1MVowETEPMA0GA1UEAwwGQ0FSb290MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A
+MIIBCgKCAQEAs2qUZ3wzkE7buZSwphppd7szMf48i22K8c8H2YeGrUXPTOPnNdVL
+o3YnmzCxgj9XKcnwviVJJRZkWMyw8QEuGWlSyDhkYRa0p7p2K1TmpYBstmyKPMEG
+wuHB8xhrhwhLu1T0s3Id8s5HGF+C04jJOXtx/HEaqn5VbDV/g8Fg532xgNAXeu3n
+DYeLWeMYR+nP3g0Oxj5c6270Q5UxAS3o8rqKv+2CDHwUFBMO+67wOnwp7lUpykZ6
+vgWf+nVlTPX7z/6SjXji4UFVMiw2oqyWQ6riYFr/puI/W/zU06/PeEW15259tvrE
+BYSmSaesFo6yF6x1dvAp38jaogEFJQhNjwIDAQABo1MwUTAdBgNVHQ4EFgQUCZNH
+jl/zvRmid/0JuhOptsZ1TrAwHwYDVR0jBBgwFoAUCZNHjl/zvRmid/0JuhOptsZ1
+TrAwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAoVJEHsChc0iY
+3ZG5p+HaxUhl0m04d7X69vfF5LdRKOrxbJ6CgG1vVpw7MbhxDq0X+Y7GfoepXzAc
+DhfIx8I8lj19AanO0M3DVWvOZDVTk8aMTD0NOAEXe+LYs6V4Rnf8ftoW+JbQcjWJ
+wxWMODeLf/8B+YSy6Y0RZII25++Gpt4R2Xi0B2wYiarWbaLYJJhAhV26XDZ1regl
+Ay2UadHO2Y+b/XldSzB63hgIWlTpe33iyyBlmUxaMd7ILAGxyNEwHTO975tDTax9
+IB/DEFMuGpnVbGIOFbO9PIhYiAxPBiG3pIzrn2MuXh3IkTmaK+O/5Aq9bk1xFU3h
+rwEVmTglEg==
 -----END CERTIFICATE-----

--- a/pulsar-proxy/src/test/resources/authentication/tls/client-cert.pem
+++ b/pulsar-proxy/src/test/resources/authentication/tls/client-cert.pem
@@ -1,18 +1,18 @@
 Certificate:
     Data:
-        Version: 3 (0x2)
+        Version: 1 (0x0)
         Serial Number:
-            88:08:98:b3:13:d8:00:99
-        Signature Algorithm: sha1WithRSAEncryption
-        Issuer: C=US, ST=CA, O=Apache, OU=Pulsar Incubator, CN=localhost
+            0c:26:15:df:8f:71:1d:6a:31:d0:da:af:64:ef:80:de:ac:9a:46:74
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = CARoot
         Validity
-            Not Before: Feb 17 02:50:05 2018 GMT
-            Not After : Nov 16 00:00:00 2030 GMT
-        Subject: C=US, ST=CA, O=Apache, OU=Apache Pulsar, CN=superUser
+            Not Before: Apr 23 17:08:51 2021 GMT
+            Not After : Apr 21 17:08:51 2031 GMT
+        Subject: C = US, ST = CA, O = Apache, OU = Apache Pulsar, CN = superUser
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
-            RSA Public Key: (2048 bit)
-                Modulus (2048 bit):
+                RSA Public-Key: (2048 bit)
+                Modulus:
                     00:cd:43:7d:98:40:f9:b0:5b:bc:ae:db:c0:0b:ad:
                     26:90:96:e0:62:38:ed:68:b1:70:46:3b:de:44:f9:
                     14:51:86:10:eb:ca:90:e7:88:e8:f9:91:85:e0:dd:
@@ -32,42 +32,37 @@ Certificate:
                     b6:98:ef:dd:03:82:58:a3:32:dc:90:a1:b6:a6:1e:
                     e1:0b
                 Exponent: 65537 (0x10001)
-        X509v3 extensions:
-            X509v3 Basic Constraints: 
-                CA:FALSE
-            Netscape Comment: 
-                OpenSSL Generated Certificate
-            X509v3 Subject Key Identifier: 
-                53:7C:D5:D1:52:97:9A:D6:D5:EA:EC:B6:0C:9B:43:39:19:73:F6:2C
-            X509v3 Authority Key Identifier: 
-                keyid:D4:7A:CD:0F:44:1B:16:29:25:14:ED:A2:EF:13:0F:A7:46:09:78:F6
-
-    Signature Algorithm: sha1WithRSAEncryption
-        e4:03:82:ff:be:df:7c:73:2a:c5:8f:7d:87:ab:95:b1:2b:e5:
-        f7:41:22:4f:28:54:84:7a:cc:fe:70:89:0f:48:e5:8a:17:e1:
-        44:ad:12:e9:a1:3a:c7:84:55:f0:7c:29:52:0a:a1:ab:cc:5b:
-        31:e5:b2:37:73:3a:8d:f2:f1:fb:e8:f6:a2:b9:ef:11:10:f8:
-        31:43:8f:af:ce:09:f4:cb:96:0e:d4:58:42:6e:86:ab:b9:03:
-        19:8b:4a:6e:ef:50:c0:7e:c9:0b:1d:2b:42:bf:eb:d0:06:05:
-        84:ea:5a:8a:22:5c:56:fa:da:2a:9f:8a:b2:90:66:8c:5e:01:
-        87:45
+    Signature Algorithm: sha256WithRSAEncryption
+         33:40:2a:38:48:99:a0:fe:68:4d:07:3b:08:ae:af:a1:7c:ea:
+         70:ab:a7:c8:32:b4:ff:9f:5a:51:3b:2b:a2:aa:21:75:44:7d:
+         be:e7:fb:08:b9:81:e5:4c:cf:01:86:f9:06:63:4f:ce:7a:1d:
+         cb:1e:9e:8f:d5:0a:54:53:69:91:05:10:2c:b0:4f:d4:3a:b5:
+         25:0e:25:4c:eb:67:64:d7:85:29:77:63:30:da:2a:77:3f:59:
+         c2:8c:e9:02:57:49:93:3a:51:91:1a:b2:59:4d:d5:69:c9:9d:
+         cc:e2:4f:b2:6c:5b:ba:45:68:c7:f5:18:f4:1d:b8:0c:eb:fd:
+         0a:cf:10:5d:dc:3e:26:49:03:33:37:40:f7:96:88:82:99:5c:
+         38:8d:cc:3b:de:b5:b9:ee:f9:ac:ae:ce:03:9a:1e:a7:f8:02:
+         73:2e:af:e7:b0:22:cb:3d:a3:ca:85:16:e9:e6:e2:d6:bf:1c:
+         1a:4c:ea:14:49:52:84:67:38:97:c7:b3:30:72:cc:c6:08:e5:
+         40:0a:87:da:19:98:26:4f:0b:54:43:a2:a0:ea:51:b2:23:88:
+         d2:b4:0e:82:4f:02:92:a4:fb:27:e2:06:15:76:e7:27:f2:a2:
+         e4:23:7b:24:ca:e6:80:93:2b:cd:54:ca:1b:9b:fd:d9:59:d1:
+         96:31:25:7b
 -----BEGIN CERTIFICATE-----
-MIIDLjCCApegAwIBAgIJAIgImLMT2ACZMA0GCSqGSIb3DQEBBQUAMFoxCzAJBgNV
-BAYTAlVTMQswCQYDVQQIEwJDQTEPMA0GA1UEChMGQXBhY2hlMRkwFwYDVQQLExBQ
-dWxzYXIgSW5jdWJhdG9yMRIwEAYDVQQDEwlsb2NhbGhvc3QwHhcNMTgwMjE3MDI1
-MDA1WhcNMzAxMTE2MDAwMDAwWjBXMQswCQYDVQQGEwJVUzELMAkGA1UECBMCQ0Ex
-DzANBgNVBAoTBkFwYWNoZTEWMBQGA1UECxMNQXBhY2hlIFB1bHNhcjESMBAGA1UE
-AxMJc3VwZXJVc2VyMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzUN9
-mED5sFu8rtvAC60mkJbgYjjtaLFwRjveRPkUUYYQ68qQ54jo+ZGF4N21tBS5eOOG
-1VRtaOwUkrT4IlsFPe0xJWUIBYTK5gwhElgyxxpgo0/SSp4oGXxFhACMidzeiuVP
-iJHMpPGBRUx9wv/iwYnGEnOV4ja9266LWmhqkFHeK4hfqmf0qONj3L4Zgsydf+aN
-+4K+IgE9VhM7WwS06MUY5i4N+rpKjejGWqFRmkpi16/dtPzi1c2umWxcYVYL1wwa
-d1z1OmpUtZ4zrKl1KJp2r9B6VwAbkRMx/UKIIUcFEAEvWbvHOtnhWEwbbHG2mO/d
-A4JYozLckKG2ph7hCwIDAQABo3sweTAJBgNVHRMEAjAAMCwGCWCGSAGG+EIBDQQf
-Fh1PcGVuU1NMIEdlbmVyYXRlZCBDZXJ0aWZpY2F0ZTAdBgNVHQ4EFgQUU3zV0VKX
-mtbV6uy2DJtDORlz9iwwHwYDVR0jBBgwFoAU1HrND0QbFiklFO2i7xMPp0YJePYw
-DQYJKoZIhvcNAQEFBQADgYEA5AOC/77ffHMqxY99h6uVsSvl90EiTyhUhHrM/nCJ
-D0jlihfhRK0S6aE6x4RV8HwpUgqhq8xbMeWyN3M6jfLx++j2ornvERD4MUOPr84J
-9MuWDtRYQm6Gq7kDGYtKbu9QwH7JCx0rQr/r0AYFhOpaiiJcVvraKp+KspBmjF4B
-h0U=
+MIIC7zCCAdcCFAwmFd+PcR1qMdDar2TvgN6smkZ0MA0GCSqGSIb3DQEBCwUAMBEx
+DzANBgNVBAMMBkNBUm9vdDAeFw0yMTA0MjMxNzA4NTFaFw0zMTA0MjExNzA4NTFa
+MFcxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJDQTEPMA0GA1UEChMGQXBhY2hlMRYw
+FAYDVQQLEw1BcGFjaGUgUHVsc2FyMRIwEAYDVQQDEwlzdXBlclVzZXIwggEiMA0G
+CSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDNQ32YQPmwW7yu28ALrSaQluBiOO1o
+sXBGO95E+RRRhhDrypDniOj5kYXg3bW0FLl444bVVG1o7BSStPgiWwU97TElZQgF
+hMrmDCESWDLHGmCjT9JKnigZfEWEAIyJ3N6K5U+Ikcyk8YFFTH3C/+LBicYSc5Xi
+Nr3brotaaGqQUd4riF+qZ/So42PcvhmCzJ1/5o37gr4iAT1WEztbBLToxRjmLg36
+ukqN6MZaoVGaSmLXr920/OLVza6ZbFxhVgvXDBp3XPU6alS1njOsqXUomnav0HpX
+ABuREzH9QoghRwUQAS9Zu8c62eFYTBtscbaY790DglijMtyQobamHuELAgMBAAEw
+DQYJKoZIhvcNAQELBQADggEBADNAKjhImaD+aE0HOwiur6F86nCrp8gytP+fWlE7
+K6KqIXVEfb7n+wi5geVMzwGG+QZjT856Hcseno/VClRTaZEFECywT9Q6tSUOJUzr
+Z2TXhSl3YzDaKnc/WcKM6QJXSZM6UZEasllN1WnJncziT7JsW7pFaMf1GPQduAzr
+/QrPEF3cPiZJAzM3QPeWiIKZXDiNzDvetbnu+ayuzgOaHqf4AnMur+ewIss9o8qF
+Funm4ta/HBpM6hRJUoRnOJfHszByzMYI5UAKh9oZmCZPC1RDoqDqUbIjiNK0DoJP
+ApKk+yfiBhV25yfyouQjeyTK5oCTK81Uyhub/dlZ0ZYxJXs=
 -----END CERTIFICATE-----

--- a/pulsar-proxy/src/test/resources/authentication/tls/server-cert.pem
+++ b/pulsar-proxy/src/test/resources/authentication/tls/server-cert.pem
@@ -1,18 +1,18 @@
 Certificate:
     Data:
-        Version: 3 (0x2)
+        Version: 1 (0x0)
         Serial Number:
-            88:08:98:b3:13:d8:00:97
-        Signature Algorithm: sha1WithRSAEncryption
-        Issuer: C=US, ST=CA, O=Apache, OU=Pulsar Incubator, CN=localhost
+            0c:26:15:df:8f:71:1d:6a:31:d0:da:af:64:ef:80:de:ac:9a:46:75
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = CARoot
         Validity
-            Not Before: Feb 17 02:06:21 2018 GMT
-            Not After : Nov 16 00:00:00 2030 GMT
-        Subject: C=US, ST=CA, O=Apache, OU=Apache Pulsar, CN=localhost
+            Not Before: Apr 23 17:08:51 2021 GMT
+            Not After : Apr 21 17:08:51 2031 GMT
+        Subject: C = US, ST = CA, O = Apache, OU = Apache Pulsar, CN = localhost
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
-            RSA Public Key: (2048 bit)
-                Modulus (2048 bit):
+                RSA Public-Key: (2048 bit)
+                Modulus:
                     00:af:bf:b7:2d:98:ad:9d:f6:da:a3:13:d4:62:0f:
                     98:be:1c:a2:89:22:ba:6f:d5:fd:1f:67:e3:91:03:
                     98:80:81:0e:ed:d8:f6:70:7f:2c:36:68:3d:53:ea:
@@ -32,42 +32,37 @@ Certificate:
                     a0:1a:81:9d:d2:e1:66:dd:c4:cc:fc:63:04:ac:ec:
                     a7:35
                 Exponent: 65537 (0x10001)
-        X509v3 extensions:
-            X509v3 Basic Constraints: 
-                CA:FALSE
-            Netscape Comment: 
-                OpenSSL Generated Certificate
-            X509v3 Subject Key Identifier: 
-                D3:F3:19:AE:74:B1:AF:E7:AF:08:7B:16:72:78:29:87:79:ED:30:8C
-            X509v3 Authority Key Identifier: 
-                keyid:D4:7A:CD:0F:44:1B:16:29:25:14:ED:A2:EF:13:0F:A7:46:09:78:F6
-
-    Signature Algorithm: sha1WithRSAEncryption
-        0f:04:f3:91:f2:87:19:fe:9d:f8:34:5a:24:4a:00:d1:58:bf:
-        1e:b2:77:67:07:bc:78:b5:4b:9a:4b:fd:a1:e5:dc:0e:09:84:
-        9e:59:c4:dd:cf:f7:2e:bf:da:f3:31:36:6b:81:6e:a2:88:76:
-        e4:2e:0b:36:44:82:36:8f:80:93:f4:9e:fc:ed:85:d0:97:da:
-        0f:fb:c9:b9:8b:da:ae:07:3d:4f:82:b7:0c:25:22:63:12:6b:
-        0a:e9:c4:12:a4:5c:ed:11:12:cc:fe:b0:2e:d4:c1:ec:79:01:
-        60:ea:cc:cc:e5:66:cc:57:f6:55:a9:09:4c:63:01:e9:b4:2e:
-        73:a5
+    Signature Algorithm: sha256WithRSAEncryption
+         81:a7:27:69:49:e6:1b:c0:f2:a6:10:c2:ef:c7:64:27:69:53:
+         3c:bd:8e:7c:b7:b8:bd:2a:02:d4:ab:4b:f3:7b:25:e8:1e:d8:
+         3d:88:00:04:6c:a0:da:67:57:65:5d:a2:b6:1d:9a:8c:c7:bd:
+         27:53:78:6a:61:3f:61:c1:23:d5:34:65:f1:49:ec:20:5d:f1:
+         01:90:99:e8:e6:99:17:ae:c3:ed:e5:da:c4:f1:8c:89:e8:38:
+         c1:01:e0:84:27:bf:01:f5:ee:62:87:55:6c:63:fc:45:12:d3:
+         2f:f7:e2:b9:f0:33:d0:84:1e:6b:23:7b:3e:ae:25:f6:ff:11:
+         12:f4:12:63:b6:88:5d:01:aa:ce:c9:e4:d8:78:a2:2d:4c:9a:
+         50:4d:57:80:6a:4b:2d:19:4c:61:21:6a:7a:06:2b:cf:82:ae:
+         f3:61:b0:ef:62:ae:3b:2d:2d:0d:c8:da:75:49:72:5a:1c:8b:
+         15:c2:bb:07:5b:37:81:f6:42:e4:84:29:4c:cb:fc:4d:e1:86:
+         9b:86:af:1f:03:08:58:b0:15:4c:72:fd:e6:62:e2:b2:37:ca:
+         eb:a4:67:ec:12:8f:95:57:d7:e7:cf:fe:b5:f9:4a:55:66:c4:
+         2f:af:e9:65:a9:54:a8:9d:1a:1e:9a:9e:ec:60:bf:b5:ef:2b:
+         b6:d5:02:e9
 -----BEGIN CERTIFICATE-----
-MIIDLjCCApegAwIBAgIJAIgImLMT2ACXMA0GCSqGSIb3DQEBBQUAMFoxCzAJBgNV
-BAYTAlVTMQswCQYDVQQIEwJDQTEPMA0GA1UEChMGQXBhY2hlMRkwFwYDVQQLExBQ
-dWxzYXIgSW5jdWJhdG9yMRIwEAYDVQQDEwlsb2NhbGhvc3QwHhcNMTgwMjE3MDIw
-NjIxWhcNMzAxMTE2MDAwMDAwWjBXMQswCQYDVQQGEwJVUzELMAkGA1UECBMCQ0Ex
-DzANBgNVBAoTBkFwYWNoZTEWMBQGA1UECxMNQXBhY2hlIFB1bHNhcjESMBAGA1UE
-AxMJbG9jYWxob3N0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAr7+3
-LZitnfbaoxPUYg+YvhyiiSK6b9X9H2fjkQOYgIEO7dj2cH8sNmg9U+pYOqbViWZL
-vR5XcRNtSxHlQKV2hCSSQFiAlskfLMRV66N5c3BcN5qJ7S+6a+OCfGlKAlSLgV48
-v0yKy+osXoPntxAIX4JYo4nR2pK6KijuMCg/W64QcZbH4RLFsBqtRG9EOhFKmjwP
-jQaAezTvP2z0XsVEVB7I3ceAhYDZaObGUwN34f4YYQd3BUztWbxdQThq712hsmCY
-1EgolQKKDv3PexvSEcwQDFBz18w4bIPdeSaqkMibhIa8WeliafSYG8SAeH6gGoGd
-0uFm3cTM/GMErOynNQIDAQABo3sweTAJBgNVHRMEAjAAMCwGCWCGSAGG+EIBDQQf
-Fh1PcGVuU1NMIEdlbmVyYXRlZCBDZXJ0aWZpY2F0ZTAdBgNVHQ4EFgQU0/MZrnSx
-r+evCHsWcngph3ntMIwwHwYDVR0jBBgwFoAU1HrND0QbFiklFO2i7xMPp0YJePYw
-DQYJKoZIhvcNAQEFBQADgYEADwTzkfKHGf6d+DRaJEoA0Vi/HrJ3Zwe8eLVLmkv9
-oeXcDgmEnlnE3c/3Lr/a8zE2a4Fuooh25C4LNkSCNo+Ak/Se/O2F0JfaD/vJuYva
-rgc9T4K3DCUiYxJrCunEEqRc7RESzP6wLtTB7HkBYOrMzOVmzFf2VakJTGMB6bQu
-c6U=
+MIIC7zCCAdcCFAwmFd+PcR1qMdDar2TvgN6smkZ1MA0GCSqGSIb3DQEBCwUAMBEx
+DzANBgNVBAMMBkNBUm9vdDAeFw0yMTA0MjMxNzA4NTFaFw0zMTA0MjExNzA4NTFa
+MFcxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJDQTEPMA0GA1UEChMGQXBhY2hlMRYw
+FAYDVQQLEw1BcGFjaGUgUHVsc2FyMRIwEAYDVQQDEwlsb2NhbGhvc3QwggEiMA0G
+CSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCvv7ctmK2d9tqjE9RiD5i+HKKJIrpv
+1f0fZ+ORA5iAgQ7t2PZwfyw2aD1T6lg6ptWJZku9HldxE21LEeVApXaEJJJAWICW
+yR8sxFXro3lzcFw3montL7pr44J8aUoCVIuBXjy/TIrL6ixeg+e3EAhfglijidHa
+kroqKO4wKD9brhBxlsfhEsWwGq1Eb0Q6EUqaPA+NBoB7NO8/bPRexURUHsjdx4CF
+gNlo5sZTA3fh/hhhB3cFTO1ZvF1BOGrvXaGyYJjUSCiVAooO/c97G9IRzBAMUHPX
+zDhsg915JqqQyJuEhrxZ6WJp9JgbxIB4fqAagZ3S4WbdxMz8YwSs7Kc1AgMBAAEw
+DQYJKoZIhvcNAQELBQADggEBAIGnJ2lJ5hvA8qYQwu/HZCdpUzy9jny3uL0qAtSr
+S/N7Jege2D2IAARsoNpnV2VdorYdmozHvSdTeGphP2HBI9U0ZfFJ7CBd8QGQmejm
+mReuw+3l2sTxjInoOMEB4IQnvwH17mKHVWxj/EUS0y/34rnwM9CEHmsjez6uJfb/
+ERL0EmO2iF0Bqs7J5Nh4oi1MmlBNV4BqSy0ZTGEhanoGK8+CrvNhsO9irjstLQ3I
+2nVJclocixXCuwdbN4H2QuSEKUzL/E3hhpuGrx8DCFiwFUxy/eZi4rI3yuukZ+wS
+j5VX1+fP/rX5SlVmxC+v6WWpVKidGh6anuxgv7XvK7bVAuk=
 -----END CERTIFICATE-----

--- a/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/TransactionLogReplayCallback.java
+++ b/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/TransactionLogReplayCallback.java
@@ -38,5 +38,4 @@ public interface TransactionLogReplayCallback {
      * @param transactionMetadataEntry the metadata entry of transaction
      */
     void handleMetadataEntry(Position position, TransactionMetadataEntry transactionMetadataEntry);
-
 }

--- a/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/MLTransactionLogInterceptor.java
+++ b/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/MLTransactionLogInterceptor.java
@@ -1,0 +1,62 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.transaction.coordinator.impl;
+
+import org.apache.bookkeeper.client.LedgerHandle;
+import org.apache.bookkeeper.mledger.impl.OpAddEntry;
+import org.apache.bookkeeper.mledger.intercept.ManagedLedgerInterceptor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+/**
+ * Store max sequenceID in ManagedLedger properties, in order to recover transaction log.
+ */
+public class MLTransactionLogInterceptor implements ManagedLedgerInterceptor {
+
+    private static final Logger log = LoggerFactory.getLogger(MLTransactionLogInterceptor.class);
+    public static final String MAX_LOCAL_TXN_ID = "max_local_txn_id";
+
+    private volatile long maxLocalTxnId = -1;
+
+    @Override
+    public OpAddEntry beforeAddEntry(OpAddEntry op, int numberOfMessages) {
+        return null;
+    }
+
+    @Override
+    public void onManagedLedgerPropertiesInitialize(Map<String, String> propertiesMap) {
+
+    }
+
+    @Override
+    public void onManagedLedgerLastLedgerInitialize(String name, LedgerHandle ledgerHandle) {
+
+    }
+
+    @Override
+    public void onUpdateManagedLedgerInfo(Map<String, String> propertiesMap) {
+        propertiesMap.put(MAX_LOCAL_TXN_ID, maxLocalTxnId + "");
+    }
+
+    protected void setMaxLocalTxnId(long maxLocalTxnId) {
+        this.maxLocalTxnId = maxLocalTxnId;
+    }
+}

--- a/pulsar-transaction/coordinator/src/main/proto/PulsarTransactionMetadata.proto
+++ b/pulsar-transaction/coordinator/src/main/proto/PulsarTransactionMetadata.proto
@@ -50,4 +50,5 @@ message TransactionMetadataEntry {
   optional uint64 timeout_ms      = 8;
   optional uint64 start_time      = 9;
   optional uint64 last_modification_time = 10;
+  optional uint64 max_local_txn_id = 11;
 }

--- a/pulsar-transaction/coordinator/src/test/java/org/apache/pulsar/transaction/coordinator/MLTransactionMetadataStoreTest.java
+++ b/pulsar-transaction/coordinator/src/test/java/org/apache/pulsar/transaction/coordinator/MLTransactionMetadataStoreTest.java
@@ -22,7 +22,9 @@ import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
 import org.apache.bookkeeper.mledger.ManagedLedgerFactory;
 import org.apache.bookkeeper.mledger.ManagedLedgerFactoryConfig;
+import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryImpl;
+import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.pulsar.client.api.transaction.TxnID;
 import org.apache.pulsar.transaction.coordinator.exceptions.CoordinatorException;
 import org.apache.pulsar.transaction.coordinator.exceptions.CoordinatorException.TransactionNotFoundException;
@@ -32,6 +34,7 @@ import org.apache.pulsar.transaction.coordinator.proto.TxnStatus;
 import org.apache.pulsar.transaction.coordinator.test.MockedBookKeeperTestCase;
 import org.awaitility.Awaitility;
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.lang.reflect.Field;
@@ -40,6 +43,8 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+
+import static org.testng.Assert.assertEquals;
 
 public class MLTransactionMetadataStoreTest extends MockedBookKeeperTestCase {
 
@@ -67,17 +72,17 @@ public class MLTransactionMetadataStoreTest extends MockedBookKeeperTestCase {
             }
             if (transactionMetadataStore.checkIfReady()) {
                 TxnID txnID = transactionMetadataStore.newTransaction(5000).get();
-                Assert.assertEquals(transactionMetadataStore.getTxnStatus(txnID).get(), TxnStatus.OPEN);
+                assertEquals(transactionMetadataStore.getTxnStatus(txnID).get(), TxnStatus.OPEN);
 
                 List<String> partitions = new ArrayList<>();
                 partitions.add("pt-1");
                 partitions.add("pt-2");
                 transactionMetadataStore.addProducedPartitionToTxn(txnID, partitions).get();
-                Assert.assertEquals(transactionMetadataStore.getTxnMeta(txnID).get().producedPartitions(), partitions);
+                assertEquals(transactionMetadataStore.getTxnMeta(txnID).get().producedPartitions(), partitions);
 
                 partitions.add("pt-3");
                 transactionMetadataStore.addProducedPartitionToTxn(txnID, partitions).get();
-                Assert.assertEquals(transactionMetadataStore.getTxnMeta(txnID).get().producedPartitions(),
+                assertEquals(transactionMetadataStore.getTxnMeta(txnID).get().producedPartitions(),
                         partitions);
 
                 List<TransactionSubscription> subscriptions = new ArrayList<>();
@@ -87,11 +92,11 @@ public class MLTransactionMetadataStoreTest extends MockedBookKeeperTestCase {
                 Assert.assertTrue(transactionMetadataStore.getTxnMeta(txnID).get().ackedPartitions().containsAll(subscriptions));
 
                 transactionMetadataStore.addAckedPartitionToTxn(txnID, subscriptions).get();
-                Assert.assertEquals(transactionMetadataStore.getTxnMeta(txnID).get().producedPartitions(),
+                assertEquals(transactionMetadataStore.getTxnMeta(txnID).get().producedPartitions(),
                         partitions);
 
                 transactionMetadataStore.updateTxnStatus(txnID, TxnStatus.COMMITTING, TxnStatus.OPEN).get();
-                Assert.assertEquals(transactionMetadataStore.getTxnStatus(txnID).get(), TxnStatus.COMMITTING);
+                assertEquals(transactionMetadataStore.getTxnStatus(txnID).get(), TxnStatus.COMMITTING);
 
                 transactionMetadataStore.updateTxnStatus(txnID, TxnStatus.COMMITTED, TxnStatus.COMMITTING).get();
 
@@ -107,6 +112,52 @@ public class MLTransactionMetadataStoreTest extends MockedBookKeeperTestCase {
                 Thread.sleep(100);
             }
         }
+    }
+
+    @DataProvider(name = "isUseManagedLedger")
+    public Object[][] versions() {
+        return new Object[][] { { true }, { false } };
+    }
+
+    @Test(dataProvider = "isUseManagedLedger")
+    public void testRecoverSequenceId(boolean isUseManagedLedger) throws Exception {
+        ManagedLedgerFactoryConfig factoryConf = new ManagedLedgerFactoryConfig();
+        factoryConf.setMaxCacheSize(0);
+        ManagedLedgerFactory factory = new ManagedLedgerFactoryImpl(bkc, zkc, factoryConf);
+        TransactionCoordinatorID transactionCoordinatorID = new TransactionCoordinatorID(1);
+        ManagedLedgerConfig managedLedgerConfig = new ManagedLedgerConfig();
+        managedLedgerConfig.setMaxEntriesPerLedger(3);
+        MLTransactionLogImpl mlTransactionLog = new MLTransactionLogImpl(transactionCoordinatorID, factory,
+                managedLedgerConfig);
+        MLTransactionMetadataStore transactionMetadataStore =
+                new MLTransactionMetadataStore(transactionCoordinatorID, mlTransactionLog,
+                        new TransactionTimeoutTrackerImpl(), new TransactionRecoverTrackerImpl());
+
+        Awaitility.await().atMost(500, TimeUnit.MILLISECONDS).until(transactionMetadataStore::checkIfReady);
+        TxnID txnID = transactionMetadataStore.newTransaction(20000).get();
+        transactionMetadataStore.updateTxnStatus(txnID, TxnStatus.COMMITTING, TxnStatus.OPEN).get();
+        if (isUseManagedLedger) {
+            transactionMetadataStore.updateTxnStatus(txnID, TxnStatus.COMMITTED, TxnStatus.COMMITTING).get();
+        }
+        assertEquals(txnID.getLeastSigBits(), 0);
+        Field field = MLTransactionLogImpl.class.getDeclaredField("managedLedger");
+        field.setAccessible(true);
+        ManagedLedgerImpl managedLedger = (ManagedLedgerImpl) field.get(mlTransactionLog);
+        Position position = managedLedger.getLastConfirmedEntry();
+
+        if (isUseManagedLedger) {
+            Awaitility.await().atMost(2000, TimeUnit.MILLISECONDS).until(() -> {
+                managedLedger.rollCurrentLedgerIfFull();
+                return !managedLedger.ledgerExists(position.getLedgerId());
+            });
+        }
+        transactionMetadataStore =
+                new MLTransactionMetadataStore(transactionCoordinatorID, mlTransactionLog,
+                        new TransactionTimeoutTrackerImpl(), new TransactionRecoverTrackerImpl());
+
+        Awaitility.await().atMost(2000, TimeUnit.MILLISECONDS).until(transactionMetadataStore::checkIfReady);
+        txnID = transactionMetadataStore.newTransaction(100000).get();
+        assertEquals(txnID.getLeastSigBits(), 1);
     }
 
     @Test
@@ -131,8 +182,8 @@ public class MLTransactionMetadataStoreTest extends MockedBookKeeperTestCase {
             if (transactionMetadataStore.checkIfReady()) {
                 TxnID txnID1 = transactionMetadataStore.newTransaction(1000).get();
                 TxnID txnID2 = transactionMetadataStore.newTransaction(1000).get();
-                Assert.assertEquals(transactionMetadataStore.getTxnStatus(txnID1).get(), TxnStatus.OPEN);
-                Assert.assertEquals(transactionMetadataStore.getTxnStatus(txnID2).get(), TxnStatus.OPEN);
+                assertEquals(transactionMetadataStore.getTxnStatus(txnID1).get(), TxnStatus.OPEN);
+                assertEquals(transactionMetadataStore.getTxnStatus(txnID2).get(), TxnStatus.OPEN);
 
                 List<String> partitions = new ArrayList<>();
                 partitions.add("pt-1");
@@ -172,14 +223,14 @@ public class MLTransactionMetadataStoreTest extends MockedBookKeeperTestCase {
                         subscriptions.add(new TransactionSubscription("topic3", "sub3"));
                         TxnMeta txnMeta1 = transactionMetadataStoreTest.getTxnMeta(txnID1).get();
                         TxnMeta txnMeta2 = transactionMetadataStoreTest.getTxnMeta(txnID2).get();
-                        Assert.assertEquals(txnMeta1.producedPartitions(), partitions);
-                        Assert.assertEquals(txnMeta2.producedPartitions(), partitions);
-                        Assert.assertEquals(txnMeta1.ackedPartitions().size(), subscriptions.size());
-                        Assert.assertEquals(txnMeta2.ackedPartitions().size(), subscriptions.size());
+                        assertEquals(txnMeta1.producedPartitions(), partitions);
+                        assertEquals(txnMeta2.producedPartitions(), partitions);
+                        assertEquals(txnMeta1.ackedPartitions().size(), subscriptions.size());
+                        assertEquals(txnMeta2.ackedPartitions().size(), subscriptions.size());
                         Assert.assertTrue(subscriptions.containsAll(txnMeta1.ackedPartitions()));
                         Assert.assertTrue(subscriptions.containsAll(txnMeta2.ackedPartitions()));
-                        Assert.assertEquals(txnMeta1.status(), TxnStatus.COMMITTING);
-                        Assert.assertEquals(txnMeta2.status(), TxnStatus.COMMITTING);
+                        assertEquals(txnMeta1.status(), TxnStatus.COMMITTING);
+                        assertEquals(txnMeta2.status(), TxnStatus.COMMITTING);
                         transactionMetadataStoreTest
                                 .updateTxnStatus(txnID1, TxnStatus.COMMITTED, TxnStatus.COMMITTING).get();
                         transactionMetadataStoreTest
@@ -198,7 +249,7 @@ public class MLTransactionMetadataStoreTest extends MockedBookKeeperTestCase {
                             Assert.assertTrue(e.getCause() instanceof TransactionNotFoundException);
                         }
                         TxnID txnID = transactionMetadataStoreTest.newTransaction(1000).get();
-                        Assert.assertEquals(txnID.getLeastSigBits(), 2L);
+                        assertEquals(txnID.getLeastSigBits(), 2L);
                         break;
                     } else {
                         checkReplayRetryCount++;
@@ -233,8 +284,8 @@ public class MLTransactionMetadataStoreTest extends MockedBookKeeperTestCase {
             if (transactionMetadataStore.checkIfReady()) {
                 TxnID txnID1 = transactionMetadataStore.newTransaction(1000).get();
                 TxnID txnID2 = transactionMetadataStore.newTransaction(1000).get();
-                Assert.assertEquals(transactionMetadataStore.getTxnStatus(txnID1).get(), TxnStatus.OPEN);
-                Assert.assertEquals(transactionMetadataStore.getTxnStatus(txnID2).get(), TxnStatus.OPEN);
+                assertEquals(transactionMetadataStore.getTxnStatus(txnID1).get(), TxnStatus.OPEN);
+                assertEquals(transactionMetadataStore.getTxnStatus(txnID2).get(), TxnStatus.OPEN);
 
                 List<String> partitions = new ArrayList<>();
                 partitions.add("pt-1");
@@ -263,7 +314,7 @@ public class MLTransactionMetadataStoreTest extends MockedBookKeeperTestCase {
                 Field field = mlTransactionLog.getClass().getDeclaredField("cursor");
                 field.setAccessible(true);
                 ManagedCursor cursor = (ManagedCursor) field.get(mlTransactionLog);
-                Assert.assertEquals(cursor.getMarkDeletedPosition(), cursor.getManagedLedger().getLastConfirmedEntry());
+                assertEquals(cursor.getMarkDeletedPosition(), cursor.getManagedLedger().getLastConfirmedEntry());
 
                 break;
             } else {

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/schema/JodaTimeTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/schema/JodaTimeTest.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.tests.integration.schema;
 
 import com.google.common.collect.Sets;
+import java.time.temporal.ChronoUnit;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.admin.PulsarAdmin;
@@ -113,7 +114,7 @@ public class JodaTimeTest extends PulsarTestSuite {
         forSend.setDecimal(new BigDecimal("12.34"));
         forSend.setTimeMicros(System.currentTimeMillis() * 1000);
         forSend.setTimestampMillis(new DateTime("2019-03-26T04:39:58.469Z", ISOChronology.getInstanceUTC()));
-        forSend.setTimeMillis(LocalTime.now());
+        forSend.setTimeMillis(LocalTime.now().truncatedTo(ChronoUnit.MILLIS));
         forSend.setTimeMicros(System.currentTimeMillis() * 1000);
         forSend.setDate(LocalDate.now());
 

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/schema/SchemaTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/schema/SchemaTest.java
@@ -23,6 +23,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
 
 import com.google.common.collect.Sets;
+import java.time.temporal.ChronoUnit;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.api.*;
@@ -200,7 +201,7 @@ public class SchemaTest extends PulsarTestSuite {
                 .decimal(new BigDecimal("12.34"))
                 .timestampMicros(System.currentTimeMillis() * 1000)
                 .timestampMillis(Instant.parse("2019-03-26T04:39:58.469Z"))
-                .timeMillis(LocalTime.now())
+                .timeMillis(LocalTime.now().truncatedTo(ChronoUnit.MILLIS))
                 .timeMicros(System.currentTimeMillis() * 1000)
                 .date(LocalDate.now())
                 .build();


### PR DESCRIPTION
- [Transaction] Fix transaction log recover sequenceId problem. (#10224)
- Fix usage of seekAsync in MessageImpl.hasMessageAvailable and flaky-test (#10190)
- [Admin CLI] Remove unnecessary \n and \t to improve rendering of commands (#10331)
- [Tests] Fix AvroSchemaTest on JDK11 (#10342)
- [Tests] Fix ProxyWithAuthorizationTest on JDK11 (#10346)
- Fix CPU 100% when deleting namespace (#10337)
- Take a snapshot of ledgers currently in the map to prevent race conditions
- Shutdown loadmanager before the broker
