### PR TITLE
lh run jdk11 tests v2

### DIFF
--- a/.github/workflows/ci-build-macos.yaml
+++ b/.github/workflows/ci-build-macos.yaml
@@ -64,11 +64,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-m2-dependencies-all-
 
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
-        uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          distribution: 'adopt'
+          java-version: 11
+
 
       - name: Replace maven's wagon-http version
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}

--- a/.github/workflows/ci-cpp.yaml
+++ b/.github/workflows/ci-cpp.yaml
@@ -64,11 +64,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-m2-dependencies-core-modules-
 
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
         with:
-          java-version: 1.8
+          distribution: 'adopt'
+          java-version: 11
 
       - name: clean disk
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}

--- a/.github/workflows/ci-integration-backwards-compatibility.yaml
+++ b/.github/workflows/ci-integration-backwards-compatibility.yaml
@@ -65,11 +65,12 @@ jobs:
             ${{ runner.os }}-m2-dependencies-core-modules-${{ hashFiles('**/pom.xml') }}
             ${{ runner.os }}-m2-dependencies-core-modules-
 
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
-        uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          distribution: 'adopt'
+          java-version: 11
 
       - name: Replace maven's wagon-http version
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}

--- a/.github/workflows/ci-integration-cli.yaml
+++ b/.github/workflows/ci-integration-cli.yaml
@@ -65,11 +65,12 @@ jobs:
             ${{ runner.os }}-m2-dependencies-core-modules-${{ hashFiles('**/pom.xml') }}
             ${{ runner.os }}-m2-dependencies-core-modules-
 
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
         with:
-          java-version: 1.8
+          distribution: 'adopt'
+          java-version: 11
 
       - name: Replace maven's wagon-http version
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}

--- a/.github/workflows/ci-integration-function.yaml
+++ b/.github/workflows/ci-integration-function.yaml
@@ -65,11 +65,12 @@ jobs:
             ${{ runner.os }}-m2-dependencies-core-modules-${{ hashFiles('**/pom.xml') }}
             ${{ runner.os }}-m2-dependencies-core-modules-
 
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
         with:
-          java-version: 1.8
+          distribution: 'adopt'
+          java-version: 11
 
       - name: Replace maven's wagon-http version
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}

--- a/.github/workflows/ci-integration-messaging.yaml
+++ b/.github/workflows/ci-integration-messaging.yaml
@@ -65,11 +65,12 @@ jobs:
             ${{ runner.os }}-m2-dependencies-core-modules-${{ hashFiles('**/pom.xml') }}
             ${{ runner.os }}-m2-dependencies-core-modules-
 
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
         with:
-          java-version: 1.8
+          distribution: 'adopt'
+          java-version: 11
 
       - name: Replace maven's wagon-http version
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}

--- a/.github/workflows/ci-integration-process.yaml
+++ b/.github/workflows/ci-integration-process.yaml
@@ -64,11 +64,12 @@ jobs:
             ${{ runner.os }}-m2-dependencies-core-modules-${{ hashFiles('**/pom.xml') }}
             ${{ runner.os }}-m2-dependencies-core-modules-
 
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
         with:
-          java-version: 1.8
+          distribution: 'adopt'
+          java-version: 11
 
       - name: Replace maven's wagon-http version
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}

--- a/.github/workflows/ci-integration-schema.yaml
+++ b/.github/workflows/ci-integration-schema.yaml
@@ -64,11 +64,12 @@ jobs:
             ${{ runner.os }}-m2-dependencies-core-modules-${{ hashFiles('**/pom.xml') }}
             ${{ runner.os }}-m2-dependencies-core-modules-
 
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
         with:
-          java-version: 1.8
+          distribution: 'adopt'
+          java-version: 11
 
       - name: Replace maven's wagon-http version
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}

--- a/.github/workflows/ci-integration-sql.yaml
+++ b/.github/workflows/ci-integration-sql.yaml
@@ -64,11 +64,12 @@ jobs:
             ${{ runner.os }}-m2-dependencies-core-modules-${{ hashFiles('**/pom.xml') }}
             ${{ runner.os }}-m2-dependencies-core-modules-
 
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
         with:
-          java-version: 1.8
+          distribution: 'adopt'
+          java-version: 11
 
       - name: Replace maven's wagon-http version
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}

--- a/.github/workflows/ci-integration-standalone.yaml
+++ b/.github/workflows/ci-integration-standalone.yaml
@@ -64,11 +64,12 @@ jobs:
             ${{ runner.os }}-m2-dependencies-core-modules-${{ hashFiles('**/pom.xml') }}
             ${{ runner.os }}-m2-dependencies-core-modules-
 
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
         with:
-          java-version: 1.8
+          distribution: 'adopt'
+          java-version: 11
 
       - name: Replace maven's wagon-http version
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}

--- a/.github/workflows/ci-integration-thread.yaml
+++ b/.github/workflows/ci-integration-thread.yaml
@@ -64,11 +64,12 @@ jobs:
             ${{ runner.os }}-m2-dependencies-core-modules-${{ hashFiles('**/pom.xml') }}
             ${{ runner.os }}-m2-dependencies-core-modules-
 
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
         with:
-          java-version: 1.8
+          distribution: 'adopt'
+          java-version: 11
 
       - name: Replace maven's wagon-http version
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}

--- a/.github/workflows/ci-integration-tiered-filesystem.yaml
+++ b/.github/workflows/ci-integration-tiered-filesystem.yaml
@@ -64,11 +64,12 @@ jobs:
             ${{ runner.os }}-m2-dependencies-core-modules-${{ hashFiles('**/pom.xml') }}
             ${{ runner.os }}-m2-dependencies-core-modules-
 
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
         with:
-          java-version: 1.8
+          distribution: 'adopt'
+          java-version: 11
 
       - name: Replace maven's wagon-http version
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}

--- a/.github/workflows/ci-integration-tiered-jcloud.yaml
+++ b/.github/workflows/ci-integration-tiered-jcloud.yaml
@@ -64,11 +64,12 @@ jobs:
             ${{ runner.os }}-m2-dependencies-core-modules-${{ hashFiles('**/pom.xml') }}
             ${{ runner.os }}-m2-dependencies-core-modules-
 
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
         with:
-          java-version: 1.8
+          distribution: 'adopt'
+          java-version: 11
 
       - name: Replace maven's wagon-http version
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}

--- a/.github/workflows/ci-integration-transaction.yaml
+++ b/.github/workflows/ci-integration-transaction.yaml
@@ -64,11 +64,12 @@ jobs:
             ${{ runner.os }}-m2-dependencies-core-modules-${{ hashFiles('**/pom.xml') }}
             ${{ runner.os }}-m2-dependencies-core-modules-
 
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
         with:
-          java-version: 1.8
+          distribution: 'adopt'
+          java-version: 11
 
       - name: Replace maven's wagon-http version
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}

--- a/.github/workflows/ci-license.yaml
+++ b/.github/workflows/ci-license.yaml
@@ -65,11 +65,13 @@ jobs:
             ${{ runner.os }}-m2-dependencies-core-modules-${{ hashFiles('**/pom.xml') }}
             ${{ runner.os }}-m2-dependencies-core-modules-
 
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
-        uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          distribution: 'adopt'
+          java-version: 11
+
 
       - name: Replace maven's wagon-http version
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}

--- a/.github/workflows/ci-maven-cache-update.yaml
+++ b/.github/workflows/ci-maven-cache-update.yaml
@@ -98,11 +98,12 @@ jobs:
           # on growing from old entries which wouldn't never expire if the old
           # cache would be used as the starting point for a new cache entry
 
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
         if: ${{ (github.event_name == 'schedule' || steps.changes.outputs.poms == 'true') && steps.cache.outputs.cache-hit != 'true' }}
-        uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          distribution: 'adopt'
+          java-version: 11
 
       - name: Replace maven's wagon-http version
         if: ${{ (github.event_name == 'schedule' || steps.changes.outputs.poms == 'true') && steps.cache.outputs.cache-hit != 'true' }}

--- a/.github/workflows/ci-pulsar-website-build.yaml
+++ b/.github/workflows/ci-pulsar-website-build.yaml
@@ -49,10 +49,11 @@ jobs:
             ${{ runner.os }}-m2-dependencies-core-modules-${{ hashFiles('**/pom.xml') }}
             ${{ runner.os }}-m2-dependencies-core-modules-
 
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
         with:
-          java-version: 1.8
+          distribution: 'adopt'
+          java-version: 11
 
       - name: Replace maven's wagon-http version
         run: sudo ./build/replace_maven-wagon-http-version.sh

--- a/.github/workflows/ci-shade-test.yaml
+++ b/.github/workflows/ci-shade-test.yaml
@@ -65,11 +65,12 @@ jobs:
             ${{ runner.os }}-m2-dependencies-core-modules-${{ hashFiles('**/pom.xml') }}
             ${{ runner.os }}-m2-dependencies-core-modules-
 
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
         with:
-          java-version: 1.8
+          distribution: 'adopt'
+          java-version: 11
 
       - name: Replace maven's wagon-http version
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}

--- a/.github/workflows/ci-unit-broker-broker-gp1.yaml
+++ b/.github/workflows/ci-unit-broker-broker-gp1.yaml
@@ -64,11 +64,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-m2-dependencies-core-modules-
 
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
         with:
-          java-version: 1.8
+          distribution: 'adopt'
+          java-version: 11
 
       - name: Replace maven's wagon-http version
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}

--- a/.github/workflows/ci-unit-broker-broker-gp2.yaml
+++ b/.github/workflows/ci-unit-broker-broker-gp2.yaml
@@ -64,11 +64,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-m2-dependencies-core-modules-
 
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
         with:
-          java-version: 1.8
+          distribution: 'adopt'
+          java-version: 11
 
       - name: Replace maven's wagon-http version
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}

--- a/.github/workflows/ci-unit-broker-client-api.yaml
+++ b/.github/workflows/ci-unit-broker-client-api.yaml
@@ -64,11 +64,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-m2-dependencies-core-modules-
 
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
         with:
-          java-version: 1.8
+          distribution: 'adopt'
+          java-version: 11
 
       - name: Replace maven's wagon-http version
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}

--- a/.github/workflows/ci-unit-broker-client-impl.yaml
+++ b/.github/workflows/ci-unit-broker-client-impl.yaml
@@ -64,11 +64,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-m2-dependencies-core-modules-
 
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
         with:
-          java-version: 1.8
+          distribution: 'adopt'
+          java-version: 11
 
       - name: Replace maven's wagon-http version
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}

--- a/.github/workflows/ci-unit-broker-other.yaml
+++ b/.github/workflows/ci-unit-broker-other.yaml
@@ -64,11 +64,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-m2-dependencies-core-modules-
 
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
         with:
-          java-version: 1.8
+          distribution: 'adopt'
+          java-version: 11
 
       - name: Replace maven's wagon-http version
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}

--- a/.github/workflows/ci-unit-proxy.yaml
+++ b/.github/workflows/ci-unit-proxy.yaml
@@ -64,11 +64,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-m2-dependencies-core-modules-
 
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
         with:
-          java-version: 1.8
+          distribution: 'adopt'
+          java-version: 11
 
       - name: Replace maven's wagon-http version
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}

--- a/.github/workflows/ci-unit.yaml
+++ b/.github/workflows/ci-unit.yaml
@@ -64,11 +64,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-m2-dependencies-core-modules-
 
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
         with:
-          java-version: 1.8
+          distribution: 'adopt'
+          java-version: 11
 
       - name: Replace maven's wagon-http version
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}


### PR DESCRIPTION
- Add jetty-alpn-conscrypt-server jar
- Enable Conscrypt / OpenSSL provider if it is available
- Use conscrypt 2.5.2
- Set default hostname verifier for Conscrypt
- Move TlsHostnameVerifier for pulsar-client to pulsar-common
- Use Pulsar's TlsHostnameVerifier with Conscrypt
- Add conscrypt.version property for managing conscrypt version in pom.xml
- Use Java 11 to run all GitHub Actions builds
