### PR TITLE
fix python protobuf

### DIFF
--- a/pulsar-client-cpp/python/setup.py
+++ b/pulsar-client-cpp/python/setup.py
@@ -82,7 +82,7 @@ extras_require = {}
 # functions dependencies
 extras_require["functions"] = sorted(
     {
-      "protobuf>=3.6.1",
+      "protobuf>=3.6.1,<=3.21.*",
       "grpcio<1.28,>=1.8.2",
       "apache-bookkeeper-client>=4.9.2",
       "prometheus_client",

--- a/pulsar-functions/instance/src/scripts/run_python_instance_tests.sh
+++ b/pulsar-functions/instance/src/scripts/run_python_instance_tests.sh
@@ -21,7 +21,7 @@
 
 # Make sure dependencies are installed
 pip3 install mock --user
-pip3 install protobuf --user
+pip3 install protobuf==3.20.1 --user
 pip3 install fastavro --user
 
 CUR_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"


### PR DESCRIPTION
- [fix][python]Fix generated Python protobuf code not compatible with latest protobuf package Protobuf latest 4.21 version broke compatibility with files generated with protoc < 3.19 This fix downgrades protobuf python package to 3.20.1. See https://developers.google.com/protocol-buffers/docs/news/2022-05-06
- Limit protobuf version to 3.21.* in setup.py
