### PR TITLE
lh reduce memory usage stub only mocks spies

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/BrokerTestUtil.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/BrokerTestUtil.java
@@ -34,6 +34,8 @@ public class BrokerTestUtil {
      * Creates a Mockito spy directly without an intermediate instance to spy.
      * This is to address flaky test issue where a spy created with a given instance fails with
      * {@link org.mockito.exceptions.misusing.WrongTypeOfReturnValue} exception.
+     * The Mockito spy is stub-only which does not record method invocations,
+     * thus saving memory but disallowing verification of invocations.
      *
      * @param classToSpy the class to spy
      * @param args the constructor arguments to use when creating the spy instance
@@ -42,6 +44,22 @@ public class BrokerTestUtil {
     public static <T> T spyWithClassAndConstructorArgs(Class<T> classToSpy, Object... args) {
         return Mockito.mock(classToSpy, Mockito.withSettings()
                 .useConstructor(args)
-                .defaultAnswer(Mockito.CALLS_REAL_METHODS));
+                .defaultAnswer(Mockito.CALLS_REAL_METHODS)
+                .stubOnly());
+    }
+
+    /**
+     * Create a Mockito spy that is stub-only which does not record method invocations,
+     * thus saving memory but disallowing verification of invocations.
+     *
+     * @param object to spy on
+     * @return a spy of the real object
+     * @param <T> type of object
+     */
+    public static <T> T spyWithoutRecordingInvocations(T object) {
+        return Mockito.mock((Class<T>) object.getClass(), Mockito.withSettings()
+                .spiedInstance(object)
+                .defaultAnswer(Mockito.CALLS_REAL_METHODS)
+                .stubOnly());
     }
 }


### PR DESCRIPTION
- [improve][cli] Pulsar shell: allow to create a new config (--file) with a relative path (#17675)
- [fix][broker] Fix unexpected subscription deletion caused by the cursor last active time not updated in time (#17573)
- [doc] change 0.2.0 to 0.3.0 version pulsar-manager (#17633)
- [fix][common] Fix parsing partitionedKey with Base64 encode issue. (#17687)
- [fix][cli] Fix mbeans to json (#17676)
- [fix][functions] Ensure InternalConfigurationData data model is compatible across different versions (#17690)
- [improve][test] remove powermock-reflect dependency (#17696)
- [improve][cli] Pulsar shell: add command to set/get property of a config (#17651)
- [fix][metadata] Set revalidateAfterReconnection true for certain failures (#17664)
- [improve][broker] Make cursor properties support modify single value concurrently. (#17164)
- [improve][client-c++] support Exclusive Producer access mode for c++ (#17439)
- [flaky-test]Add information in ManagedLedgerBkTest to determine the problem (#17441)
- [fix][broker] Fix namespace backlog quota check with retention. (#17706)
- [fix][metadata] Handle session events in separate thread (#17638)
- [feat][CI] Add approval solution to reduce GitHub Actions resource consumption (#17693)
- [improvement][client-java] Avoid too large memory preallocation for batch message. (#15033)
- [improve][testing] Reduce memory usage by using stubOnly mocks and spies when applicable
