### PR TITLE
[run-tests] [fix][testclient] Fix proxyProtocol parsing when value is empty, fix invalid property name

### DIFF
--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceBaseArguments.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceBaseArguments.java
@@ -24,6 +24,7 @@ import com.beust.jcommander.Parameter;
 import java.io.FileInputStream;
 import java.util.Properties;
 import lombok.SneakyThrows;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.client.api.ProxyProtocol;
 
 
@@ -143,17 +144,18 @@ public abstract class PerformanceBaseArguments {
         }
 
         if (proxyServiceURL == null) {
-            proxyServiceURL = prop.getProperty("proxyServiceURL");
+            proxyServiceURL = StringUtils.trimToNull(prop.getProperty("proxyServiceUrl"));
         }
 
         if (proxyProtocol == null) {
+            String proxyProtocolString = null;
             try {
-                String proxyProtocolString = prop.getProperty("proxyProtocol");
+                proxyProtocolString = StringUtils.trimToNull(prop.getProperty("proxyProtocol"));
                 if (proxyProtocolString != null) {
-                    proxyProtocol = ProxyProtocol.valueOf(prop.getProperty("proxyProtocol"));
+                    proxyProtocol = ProxyProtocol.valueOf(proxyProtocolString.toUpperCase());
                 }
             } catch (IllegalArgumentException e) {
-                System.out.println("Incorrect proxyProtocol name");
+                System.out.println("Incorrect proxyProtocol name '" + proxyProtocolString + "'");
                 e.printStackTrace();
                 exit(-1);
             }

--- a/pulsar-testclient/src/test/resources/perf_client1.conf
+++ b/pulsar-testclient/src/test/resources/perf_client1.conf
@@ -23,5 +23,5 @@ authParams=myparams
 tlsTrustCertsFilePath=./path
 tlsAllowInsecureConnection=true
 tlsEnableHostnameVerification=true
-proxyServiceURL=https://my-proxy-pulsar:4443/
+proxyServiceUrl=https://my-proxy-pulsar:4443/
 proxyProtocol=SNI


### PR DESCRIPTION
This PR is for running tests for upstream PR https://github.com/apache/pulsar/pull/17930.