### PR TITLE
[run-tests] [improve][CI] Speed up execution of OTHER unit test group by removing -DtestReuseFork=false

### DIFF
--- a/build/run_unit_group.sh
+++ b/build/run_unit_group.sh
@@ -134,7 +134,7 @@ function test_group_other() {
            -Dexclude='**/ManagedLedgerTest.java,
                    **/OffloadersCacheTest.java
                   **/PrimitiveSchemaTest.java,
-                  BlobStoreManagedLedgerOffloaderTest.java' -DtestReuseFork=false
+                  BlobStoreManagedLedgerOffloaderTest.java'
 
   mvn_test -pl managed-ledger -Dinclude='**/ManagedLedgerTest.java,
                                                   **/OffloadersCacheTest.java'


### PR DESCRIPTION
This PR is for running tests for upstream PR https://github.com/apache/pulsar/pull/17943.