### PR TITLE
Experiment Pulsar CI build and tests with Java 21

### DIFF
--- a/.github/workflows/ci-maven-cache-update.yaml
+++ b/.github/workflows/ci-maven-cache-update.yaml
@@ -102,12 +102,12 @@ jobs:
           # on growing from old entries which wouldn't never expire if the old
           # cache would be used as the starting point for a new cache entry
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v3
         if: ${{ (github.event_name == 'schedule' || steps.changes.outputs.poms == 'true') && steps.cache.outputs.cache-hit != 'true' }}
         with:
           distribution: 'temurin'
-          java-version: 17
+          java-version: 21
 
       - name: Download dependencies
         if: ${{ (github.event_name == 'schedule' || steps.changes.outputs.poms == 'true') && steps.cache.outputs.cache-hit != 'true' }}

--- a/.github/workflows/ci-owasp-dependency-check.yaml
+++ b/.github/workflows/ci-owasp-dependency-check.yaml
@@ -41,8 +41,11 @@ jobs:
         include:
           - branch: master
           - branch: branch-3.1
+            jdk: 17
           - branch: branch-3.0
+            jdk: 17
           - branch: branch-2.11
+            jdk: 17
           - branch: branch-2.10
             jdk: 11
           - branch: branch-2.9
@@ -72,11 +75,11 @@ jobs:
             ${{ runner.os }}-m2-dependencies-core-modules-${{ hashFiles('**/pom.xml') }}
             ${{ runner.os }}-m2-dependencies-core-modules-
 
-      - name: Set up JDK ${{ matrix.jdk || '17' }}
+      - name: Set up JDK ${{ matrix.jdk || '21' }}
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: ${{ matrix.jdk || '17' }}
+          java-version: ${{ matrix.jdk || '21' }}
 
       - name: run install by skip tests
         run: mvn -B -ntp clean install -DskipTests -Dspotbugs.skip=true  -Dlicense.skip=true -Dcheckstyle.skip=true -Drat.skip=true -DskipDocker=true

--- a/.github/workflows/pulsar-ci-flaky.yaml
+++ b/.github/workflows/pulsar-ci-flaky.yaml
@@ -124,11 +124,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-m2-dependencies-core-modules-
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: 17
+          java-version: 21
 
       - name: Build core-modules
         run: |

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -125,11 +125,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-m2-dependencies-core-modules-
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: 17
+          java-version: 21
 
       - name: Check source code license headers
         run: mvn -B -T 8 -ntp initialize apache-rat:check license:check
@@ -233,11 +233,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-m2-dependencies-core-modules-
 
-      - name: Set up JDK ${{ matrix.jdk || '17' }}
+      - name: Set up JDK ${{ matrix.jdk || '21' }}
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: ${{ matrix.jdk || '17' }}
+          java-version: ${{ matrix.jdk || '21' }}
 
       - name: Install gh-actions-artifact-client.js
         uses: apache/pulsar-test-infra/gh-actions-artifact-client/dist@master
@@ -337,11 +337,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-m2-dependencies-core-modules-
 
-      - name: Set up JDK ${{ matrix.jdk || '17' }}
+      - name: Set up JDK ${{ matrix.jdk || '21' }}
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: ${{ matrix.jdk || '17' }}
+          java-version: ${{ matrix.jdk || '21' }}
 
       - name: Install gh-actions-artifact-client.js
         uses: apache/pulsar-test-infra/gh-actions-artifact-client/dist@master
@@ -417,11 +417,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-m2-dependencies-core-modules-
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: 17
+          java-version: 21
 
       - name: Install gh-actions-artifact-client.js
         uses: apache/pulsar-test-infra/gh-actions-artifact-client/dist@master
@@ -497,6 +497,12 @@ jobs:
 
           - name: Shade on Java 17
             group: SHADE_RUN
+            runtime_jdk: 17
+            setup: ./build/run_integration_group.sh SHADE_BUILD
+            no_coverage: true
+
+          - name: Shade on Java 21
+            group: SHADE_RUN
             setup: ./build/run_integration_group.sh SHADE_BUILD
             no_coverage: true
 
@@ -532,11 +538,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-m2-dependencies-core-modules-
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: 17
+          java-version: 21
 
       - name: Install gh-actions-artifact-client.js
         uses: apache/pulsar-test-infra/gh-actions-artifact-client/dist@master
@@ -648,11 +654,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-m2-dependencies-core-modules-
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: 17
+          java-version: 21
 
       - name: Install gh-actions-artifact-client.js
         uses: apache/pulsar-test-infra/gh-actions-artifact-client/dist@master
@@ -763,11 +769,11 @@ jobs:
             ${{ runner.os }}-m2-dependencies-core-modules-${{ hashFiles('**/pom.xml') }}
             ${{ runner.os }}-m2-dependencies-core-modules-
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: 17
+          java-version: 21
 
       - name: Install gh-actions-artifact-client.js
         uses: apache/pulsar-test-infra/gh-actions-artifact-client/dist@master
@@ -901,11 +907,11 @@ jobs:
             ${{ runner.os }}-m2-dependencies-core-modules-${{ hashFiles('**/pom.xml') }}
             ${{ runner.os }}-m2-dependencies-core-modules-
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: 17
+          java-version: 21
 
       - name: Install gh-actions-artifact-client.js
         uses: apache/pulsar-test-infra/gh-actions-artifact-client/dist@master
@@ -1012,11 +1018,11 @@ jobs:
             ${{ runner.os }}-m2-dependencies-core-modules-${{ hashFiles('**/pom.xml') }}
             ${{ runner.os }}-m2-dependencies-core-modules-
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: 17
+          java-version: 21
 
       - name: Install gh-actions-artifact-client.js
         uses: apache/pulsar-test-infra/gh-actions-artifact-client/dist@master
@@ -1114,11 +1120,11 @@ jobs:
             ${{ runner.os }}-m2-dependencies-core-modules-${{ hashFiles('**/pom.xml') }}
             ${{ runner.os }}-m2-dependencies-core-modules-
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: 17
+          java-version: 21
 
       - name: Install gh-actions-artifact-client.js
         uses: apache/pulsar-test-infra/gh-actions-artifact-client/dist@master
@@ -1232,11 +1238,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-m2-dependencies-all-
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: 17
+          java-version: 21
 
       - name: build package
         run: mvn -B clean package -DskipTests -T 1C -ntp
@@ -1274,11 +1280,11 @@ jobs:
           key: ${{ runner.os }}-m2-dependencies-core-modules-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-m2-dependencies-core-modules-
-      - name: Set up JDK ${{ matrix.jdk || '17' }}
+      - name: Set up JDK ${{ matrix.jdk || '21' }}
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: ${{ matrix.jdk || '17' }}
+          java-version: ${{ matrix.jdk || '21' }}
 
       - name: Clean Disk
         uses: ./.github/actions/clean-disk

--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -38,7 +38,7 @@ RUN mkdir -p /etc/apt/keyrings \
      && echo "deb [signed-by=/etc/apt/keyrings/adoptium.asc] https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list \
      && apt-get update \
      && apt-get -y dist-upgrade \
-     && apt-get -y install temurin-17-jdk
+     && apt-get -y install temurin-21-jdk
 
 # Compile and install gtest & gmock
 RUN cd /usr/src/googletest && \

--- a/build/run_integration_group.sh
+++ b/build/run_integration_group.sh
@@ -26,7 +26,8 @@ set -o errexit
 
 JAVA_MAJOR_VERSION="$(java -version 2>&1 |grep " version " | awk -F\" '{ print $2 }' | awk -F. '{ if ($1=="1") { print $2 } else { print $1 } }')"
 # Used to shade run test on Java 8, because the latest TestNG requires Java 11 or higher.
-TESTNG_VERSION="7.3.0"
+TESTNG_VERSION_JAVA_8="7.3.0"
+MOCKITO_VERSION_JAVA_8="4.11.0"
 
 # lists all active maven modules with given parameters
 # parses the modules from the "mvn initialize" output
@@ -112,7 +113,11 @@ test_group_shade() {
 }
 
 test_group_shade_build() {
-  mvn_run_integration_test --build-only "$@" -DShadeTests -DtestForkCount=1 -DtestReuseFork=false
+  local additional_args
+  if [[ $JAVA_MAJOR_VERSION -ge 8 && $JAVA_MAJOR_VERSION -lt 11 ]]; then
+      additional_args="$additional_args -Dtestng.version=$TESTNG_VERSION_JAVA_8 -Dmockito.version=$MOCKITO_VERSION_JAVA_8"
+  fi
+  mvn_run_integration_test --build-only "$@" -DShadeTests -DtestForkCount=1 -DtestReuseFork=false $additional_args
 }
 
 test_group_shade_run() {
@@ -122,7 +127,7 @@ test_group_shade_run() {
   fi
 
   if [[ $JAVA_MAJOR_VERSION -ge 8 && $JAVA_MAJOR_VERSION -lt 11 ]]; then
-      additional_args="$additional_args -Dtestng.version=$TESTNG_VERSION"
+      additional_args="$additional_args -Dtestng.version=$TESTNG_VERSION_JAVA_8 -Dmockito.version=$MOCKITO_VERSION_JAVA_8"
   fi
 
   mvn_run_integration_test --skip-build-deps --clean "$@" -Denforcer.skip=true -DShadeTests -DtestForkCount=1 -DtestReuseFork=false $additional_args

--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -52,7 +52,7 @@
     <guava.version>32.1.2-jre</guava.version>
     <ant.version>1.10.12</ant.version>
     <snakeyaml.version>2.0</snakeyaml.version>
-    <mockito.version>3.12.4</mockito.version>
+    <mockito.version>5.6.0</mockito.version>
     <!-- required for running tests on JDK11+ -->
     <test.additional.args>
       --add-opens java.base/jdk.internal.loader=ALL-UNNAMED
@@ -139,11 +139,6 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>${mockito.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-inline</artifactId>
       <version>${mockito.version}</version>
     </dependency>
   </dependencies>

--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -71,10 +71,10 @@ RUN mkdir -p /etc/apt/keyrings \
      && echo "deb [signed-by=/etc/apt/keyrings/adoptium.asc] https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list \
      && apt-get update \
      && apt-get -y dist-upgrade \
-     && apt-get -y install temurin-17-jdk \
+     && apt-get -y install temurin-21-jdk \
      && export ARCH=$(uname -m | sed -r 's/aarch64/arm64/g' |  awk '!/arm64/{$0="amd64"}1') \
-     && echo networkaddress.cache.ttl=1 >> /usr/lib/jvm/temurin-17-jdk-$ARCH/conf/security/java.security \
-     && echo networkaddress.cache.negative.ttl=1 >> /usr/lib/jvm/temurin-17-jdk-$ARCH/conf/security/java.security \
+     && echo networkaddress.cache.ttl=1 >> /usr/lib/jvm/temurin-21-jdk-$ARCH/conf/security/java.security \
+     && echo networkaddress.cache.negative.ttl=1 >> /usr/lib/jvm/temurin-21-jdk-$ARCH/conf/security/java.security \
 
 # Cleanup apt
 RUN apt-get -y --purge autoremove \

--- a/pom.xml
+++ b/pom.xml
@@ -258,10 +258,10 @@ flexible messaging model and an intuitive client API.</description>
     <docker-java.version>3.3.0</docker-java.version>
     <kerby.version>1.1.1</kerby.version>
     <testng.version>7.7.1</testng.version>
-    <mockito.version>3.12.4</mockito.version>
+    <mockito.version>5.6.0</mockito.version>
     <javassist.version>3.25.0-GA</javassist.version>
     <skyscreamer.version>1.5.0</skyscreamer.version>
-    <objenesis.version>3.1</objenesis.version>
+    <objenesis.version>3.3</objenesis.version> <!-- should match mockito-core objenesis version -->
     <awaitility.version>4.2.0</awaitility.version>
     <jettison.version>1.5.4</jettison.version>
     <woodstox.version>5.4.0</woodstox.version>
@@ -359,12 +359,6 @@ flexible messaging model and an intuitive client API.</description>
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
-        <version>${mockito.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.mockito</groupId>
-        <artifactId>mockito-inline</artifactId>
         <version>${mockito.version}</version>
       </dependency>
 
@@ -1438,12 +1432,6 @@ flexible messaging model and an intuitive client API.</description>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-inline</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminTest.java
@@ -868,10 +868,10 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
         Assert.assertEquals(responseCaptor.getValue().getStatus(), Response.Status.NO_CONTENT.getStatusCode());
         // verify permission
         response = mock(AsyncResponse.class);
-        responseCaptor = ArgumentCaptor.forClass(Response.class);
+        ArgumentCaptor<Map<String, Set<AuthAction>>> permissionsCaptor = ArgumentCaptor.forClass(Map.class);
         persistentTopics.getPermissionsOnTopic(response, property, cluster, namespace, topic);
-        verify(response, timeout(5000).times(1)).resume(responseCaptor.capture());
-        Map<String, Set<AuthAction>> permission = (Map<String, Set<AuthAction>>) responseCaptor.getValue();
+        verify(response, timeout(5000).times(1)).resume(permissionsCaptor.capture());
+        Map<String, Set<AuthAction>> permission = permissionsCaptor.getValue();
         assertEquals(permission.get(role), actions);
         // remove permission
         response = mock(AsyncResponse.class);
@@ -882,10 +882,10 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
         // verify removed permission
         Awaitility.await().untilAsserted(() -> {
             AsyncResponse response1 = mock(AsyncResponse.class);
-            ArgumentCaptor<Response> responseCaptor1 = ArgumentCaptor.forClass(Response.class);
+            ArgumentCaptor<Map<String, Set<AuthAction>>> permissionsCaptor1 = ArgumentCaptor.forClass(Map.class);
             persistentTopics.getPermissionsOnTopic(response1, property, cluster, namespace, topic);
-            verify(response1, timeout(5000).times(1)).resume(responseCaptor1.capture());
-            Map<String, Set<AuthAction>> p = (Map<String, Set<AuthAction>>) responseCaptor1.getValue();
+            verify(response1, timeout(5000).times(1)).resume(permissionsCaptor1.capture());
+            Map<String, Set<AuthAction>> p = permissionsCaptor1.getValue();
             assertTrue(p.isEmpty());
         });
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesTest.java
@@ -215,9 +215,9 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
         doReturn(null).when(namespaces).clientAuthData();
         doReturn(Set.of("use", "usw", "usc", "global")).when(namespaces).clusters();
 
-        admin.clusters().createCluster("use", ClusterData.builder().serviceUrl("http://broker-use.com:8080").build());
-        admin.clusters().createCluster("usw", ClusterData.builder().serviceUrl("http://broker-usw.com:8080").build());
-        admin.clusters().createCluster("usc", ClusterData.builder().serviceUrl("http://broker-usc.com:8080").build());
+        admin.clusters().createCluster("use", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+        admin.clusters().createCluster("usw", ClusterData.builder().serviceUrl("http://127.0.0.2:8082").build());
+        admin.clusters().createCluster("usc", ClusterData.builder().serviceUrl("http://127.0.0.3:8083").build());
         admin.tenants().createTenant(this.testTenant,
                 new TenantInfoImpl(Set.of("role1", "role2"), Set.of("use", "usc", "usw")));
         admin.tenants().createTenant(this.testOtherTenant,
@@ -317,9 +317,9 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
         expectedList.sort(null);
         AsyncResponse response = mock(AsyncResponse.class);
         namespaces.getTenantNamespaces(response, this.testTenant);
-        ArgumentCaptor<Response> captor = ArgumentCaptor.forClass(Response.class);
-        verify(response, timeout(5000).times(1)).resume(captor.capture());
-        List<String> namespacesList = (List<String>) captor.getValue();
+        ArgumentCaptor<List<String>> listOfStringsCaptor = ArgumentCaptor.forClass(List.class);
+        verify(response, timeout(5000).times(1)).resume(listOfStringsCaptor.capture());
+        List<String> namespacesList = listOfStringsCaptor.getValue();
         namespacesList.sort(null);
         assertEquals(namespacesList, expectedList);
 
@@ -713,7 +713,7 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
         verify(response, timeout(5000).times(1)).resume(captor.capture());
         assertEquals(captor.getValue().getResponse().getStatus(), Status.TEMPORARY_REDIRECT.getStatusCode());
         assertEquals(captor.getValue().getResponse().getLocation().toString(),
-                UriBuilder.fromUri(uri).host("broker-usc.com").port(8080).toString());
+                UriBuilder.fromUri(uri).host("127.0.0.3").port(8083).toString());
 
         uri = URI.create(pulsar.getWebServiceAddress() + "/admin/namespace/"
                 + this.testLocalNamespaces.get(2).toString() + "/unload");
@@ -725,7 +725,7 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
         verify(response, timeout(5000).atLeast(1)).resume(captor.capture());
         assertEquals(captor.getValue().getResponse().getStatus(), Status.TEMPORARY_REDIRECT.getStatusCode());
         assertEquals(captor.getValue().getResponse().getLocation().toString(),
-                UriBuilder.fromUri(uri).host("broker-usc.com").port(8080).toString());
+                UriBuilder.fromUri(uri).host("127.0.0.3").port(8083).toString());
 
         // check the bundle should not unload to an inactive destination broker
         namespaces.unloadNamespaceBundle(response, this.testTenant, this.testOtherCluster,
@@ -762,7 +762,7 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
         verify(response, timeout(5000).times(1)).resume(captor.capture());
         assertEquals(captor.getValue().getResponse().getStatus(), Status.TEMPORARY_REDIRECT.getStatusCode());
         assertEquals(captor.getValue().getResponse().getLocation().toString(),
-                UriBuilder.fromUri(uri).host("broker-usc.com").port(8080).toString());
+                UriBuilder.fromUri(uri).host("127.0.0.3").port(8083).toString());
 
         // cleanup
         resetBroker();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/PersistentTopicsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/PersistentTopicsTest.java
@@ -52,9 +52,9 @@ import javax.ws.rs.core.UriInfo;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.BrokerTestUtil;
+import org.apache.pulsar.broker.admin.v2.ExtPersistentTopics;
 import org.apache.pulsar.broker.admin.v2.NonPersistentTopics;
 import org.apache.pulsar.broker.admin.v2.PersistentTopics;
-import org.apache.pulsar.broker.admin.v2.ExtPersistentTopics;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
 import org.apache.pulsar.broker.authentication.AuthenticationDataHttps;
 import org.apache.pulsar.broker.namespace.NamespaceService;
@@ -165,8 +165,8 @@ public class PersistentTopicsTest extends MockedPulsarServiceBaseTest {
         doReturn(spy(new TopicResources(pulsar.getLocalMetadataStore()))).when(resources).getTopicResources();
         doReturn(resources).when(pulsar).getPulsarResources();
 
-        admin.clusters().createCluster("use", ClusterData.builder().serviceUrl("http://broker-use.com:8080").build());
-        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl("http://broker-use.com:8080").build());
+        admin.clusters().createCluster("use", ClusterData.builder().serviceUrl("http://127.0.0.3:8082").build());
+        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
         admin.tenants().createTenant(this.testTenant,
                 new TenantInfoImpl(Set.of("role1", "role2"), Set.of(testLocalCluster, "test")));
         admin.tenants().createTenant("pulsar",
@@ -791,26 +791,26 @@ public class PersistentTopicsTest extends MockedPulsarServiceBaseTest {
         Assert.assertEquals(responseCaptor.getValue().getStatus(), Response.Status.NO_CONTENT.getStatusCode());
 
         response = mock(AsyncResponse.class);
-        responseCaptor = ArgumentCaptor.forClass(Response.class);
+        ArgumentCaptor<List<String>> listOfStringsCaptor = ArgumentCaptor.forClass(List.class);
         persistentTopics.getPartitionedTopicList(response, testTenant, testNamespace, false);
-        verify(response, timeout(5000).times(1)).resume(responseCaptor.capture());
-        List<String> persistentPartitionedTopics = (List<String>) responseCaptor.getValue();
+        verify(response, timeout(5000).times(1)).resume(listOfStringsCaptor.capture());
+        List<String> persistentPartitionedTopics = listOfStringsCaptor.getValue();
         Assert.assertEquals(persistentPartitionedTopics.size(), 1);
         Assert.assertEquals(TopicName.get(persistentPartitionedTopics.get(0)).getDomain().value(),
                 TopicDomain.persistent.value());
 
         response = mock(AsyncResponse.class);
-        responseCaptor = ArgumentCaptor.forClass(Response.class);
+        listOfStringsCaptor = ArgumentCaptor.forClass(List.class);
         persistentTopics.getPartitionedTopicList(response, testTenant, testNamespace, true);
-        verify(response, timeout(5000).times(1)).resume(responseCaptor.capture());
-        persistentPartitionedTopics = (List<String>) responseCaptor.getValue();
+        verify(response, timeout(5000).times(1)).resume(listOfStringsCaptor.capture());
+        persistentPartitionedTopics = listOfStringsCaptor.getValue();
         Assert.assertEquals(persistentPartitionedTopics.size(), 2);
 
         response = mock(AsyncResponse.class);
-        responseCaptor = ArgumentCaptor.forClass(Response.class);
+        listOfStringsCaptor = ArgumentCaptor.forClass(List.class);
         nonPersistentTopic.getPartitionedTopicList(response, testTenant, testNamespace, false);
-        verify(response, timeout(5000).times(1)).resume(responseCaptor.capture());
-        List<String> nonPersistentPartitionedTopics = (List<String>) responseCaptor.getValue();
+        verify(response, timeout(5000).times(1)).resume(listOfStringsCaptor.capture());
+        List<String> nonPersistentPartitionedTopics = listOfStringsCaptor.getValue();
         Assert.assertEquals(nonPersistentPartitionedTopics.size(), 1);
         Assert.assertEquals(TopicName.get(nonPersistentPartitionedTopics.get(0)).getDomain().value(),
                 TopicDomain.non_persistent.value());
@@ -831,17 +831,17 @@ public class PersistentTopicsTest extends MockedPulsarServiceBaseTest {
         Assert.assertEquals(responseCaptor.getValue().getStatus(), Response.Status.NO_CONTENT.getStatusCode());
 
         response = mock(AsyncResponse.class);
-        responseCaptor = ArgumentCaptor.forClass(Response.class);
+        ArgumentCaptor<List<String>> listOfStringsCaptor = ArgumentCaptor.forClass(List.class);
         persistentTopics.getList(response, testTenant, testNamespace, null, false);
-        verify(response, timeout(5000).times(1)).resume(responseCaptor.capture());
-        List<String> topics = (List<String>) responseCaptor.getValue();
+        verify(response, timeout(5000).times(1)).resume(listOfStringsCaptor.capture());
+        List<String> topics = listOfStringsCaptor.getValue();
         Assert.assertEquals(topics.size(), 1);
 
         response = mock(AsyncResponse.class);
-        responseCaptor = ArgumentCaptor.forClass(Response.class);
+        listOfStringsCaptor = ArgumentCaptor.forClass(List.class);
         persistentTopics.getList(response, testTenant, testNamespace, null, true);
-        verify(response, timeout(5000).times(1)).resume(responseCaptor.capture());
-        topics = (List<String>) responseCaptor.getValue();
+        verify(response, timeout(5000).times(1)).resume(listOfStringsCaptor.capture());
+        topics = listOfStringsCaptor.getValue();
         Assert.assertEquals(topics.size(), 2);
 
         response = mock(AsyncResponse.class);
@@ -857,17 +857,17 @@ public class PersistentTopicsTest extends MockedPulsarServiceBaseTest {
         Assert.assertEquals(responseCaptor.getValue().getStatus(), Response.Status.NO_CONTENT.getStatusCode());
 
         response = mock(AsyncResponse.class);
-        responseCaptor = ArgumentCaptor.forClass(Response.class);
+        listOfStringsCaptor = ArgumentCaptor.forClass(List.class);
         nonPersistentTopic.getList(response, testTenant, testNamespace, null, false);
-        verify(response, timeout(5000).times(1)).resume(responseCaptor.capture());
-        topics = (List<String>) responseCaptor.getValue();
+        verify(response, timeout(5000).times(1)).resume(listOfStringsCaptor.capture());
+        topics = listOfStringsCaptor.getValue();
         Assert.assertEquals(topics.size(), 1);
 
         response = mock(AsyncResponse.class);
-        responseCaptor = ArgumentCaptor.forClass(Response.class);
+        listOfStringsCaptor = ArgumentCaptor.forClass(List.class);
         nonPersistentTopic.getList(response, testTenant, testNamespace, null, true);
-        verify(response, timeout(5000).times(1)).resume(responseCaptor.capture());
-        topics = (List<String>) responseCaptor.getValue();
+        verify(response, timeout(5000).times(1)).resume(listOfStringsCaptor.capture());
+        topics = listOfStringsCaptor.getValue();
         Assert.assertEquals(topics.size(), 2);
     }
 
@@ -885,24 +885,28 @@ public class PersistentTopicsTest extends MockedPulsarServiceBaseTest {
         verify(response, timeout(5000).times(1)).resume(responseCaptor.capture());
         Assert.assertEquals(responseCaptor.getValue().getStatus(), Response.Status.NO_CONTENT.getStatusCode());
         response = mock(AsyncResponse.class);
-        responseCaptor = ArgumentCaptor.forClass(Response.class);
+        ArgumentCaptor<Map<String, Set<AuthAction>>> permissionsCaptor = ArgumentCaptor.forClass(Map.class);
         persistentTopics.getPermissionsOnTopic(response, testTenant, testNamespace, topicName);
-        verify(response, timeout(5000).times(1)).resume(responseCaptor.capture());
-        Map<String, Set<AuthAction>> permissions = (Map<String, Set<AuthAction>>) responseCaptor.getValue();
+        verify(response, timeout(5000).times(1)).resume(permissionsCaptor.capture());
+        Map<String, Set<AuthAction>> permissions = permissionsCaptor.getValue();
         Assert.assertEquals(permissions.get(role), expectActions);
     }
 
     @Test
-    public void testCreateExistedPartition() {
-        final AsyncResponse response = mock(AsyncResponse.class);
-        final String topicName = "test-create-existed-partition";
+    public void testCreateExistedPartition() throws InterruptedException {
+        AsyncResponse response = mock(AsyncResponse.class);
+        ArgumentCaptor<Response> responseCaptor = ArgumentCaptor.forClass(Response.class);
+        final String topicName = "testcreateexisted";
         persistentTopics.createPartitionedTopic(response, testTenant, testNamespace, topicName, 3, true);
+        verify(response, timeout(5000).times(1)).resume(responseCaptor.capture());
+        Assert.assertEquals(responseCaptor.getValue().getStatus(), Response.Status.NO_CONTENT.getStatusCode());
 
         final String partitionName = TopicName.get(topicName).getPartition(0).getLocalName();
-        ArgumentCaptor<RestException> responseCaptor = ArgumentCaptor.forClass(RestException.class);
-        persistentTopics.createNonPartitionedTopic(response, testTenant, testNamespace, partitionName, false, null);
-        verify(response, timeout(5000).times(1)).resume(responseCaptor.capture());
-        Assert.assertEquals(responseCaptor.getValue().getResponse().getStatus(),
+        response = mock(AsyncResponse.class);
+        ArgumentCaptor<RestException> restExceptionCaptor = ArgumentCaptor.forClass(RestException.class);
+        persistentTopics.createNonPartitionedTopic(response, testTenant, testNamespace, partitionName, true, null);
+        verify(response, timeout(5000).times(1)).resume(restExceptionCaptor.capture());
+        Assert.assertEquals(restExceptionCaptor.getValue().getResponse().getStatus(),
                 Response.Status.CONFLICT.getStatusCode());
     }
 
@@ -927,10 +931,10 @@ public class PersistentTopicsTest extends MockedPulsarServiceBaseTest {
         verify(response, timeout(5000).times(1)).resume(responseCaptor.capture());
         Assert.assertEquals(responseCaptor.getValue().getStatus(), Response.Status.NO_CONTENT.getStatusCode());
         response = mock(AsyncResponse.class);
-        responseCaptor = ArgumentCaptor.forClass(Response.class);
+        ArgumentCaptor<Map<String, Set<AuthAction>>> permissionsCaptor = ArgumentCaptor.forClass(Map.class);
         persistentTopics.getPermissionsOnTopic(response, testTenant, testNamespace, partitionedTopicName);
-        verify(response, timeout(5000).times(1)).resume(responseCaptor.capture());
-        Map<String, Set<AuthAction>> permissions = (Map<String, Set<AuthAction>>) responseCaptor.getValue();
+        verify(response, timeout(5000).times(1)).resume(permissionsCaptor.capture());
+        Map<String, Set<AuthAction>> permissions = permissionsCaptor.getValue();
         Assert.assertEquals(permissions.get(role), expectActions);
     }
 
@@ -953,10 +957,10 @@ public class PersistentTopicsTest extends MockedPulsarServiceBaseTest {
         verify(response, timeout(5000).times(1)).resume(responseCaptor.capture());
         Assert.assertEquals(responseCaptor.getValue().getStatus(), Response.Status.NO_CONTENT.getStatusCode());
         response = mock(AsyncResponse.class);
-        responseCaptor = ArgumentCaptor.forClass(Response.class);
+        ArgumentCaptor<Map<String, Set<AuthAction>>> permissionsCaptor = ArgumentCaptor.forClass(Map.class);
         persistentTopics.getPermissionsOnTopic(response, testTenant, testNamespace, topicName);
-        verify(response, timeout(5000).times(1)).resume(responseCaptor.capture());
-        Map<String, Set<AuthAction>> permissions = (Map<String, Set<AuthAction>>) responseCaptor.getValue();
+        verify(response, timeout(5000).times(1)).resume(permissionsCaptor.capture());
+        Map<String, Set<AuthAction>> permissions = permissionsCaptor.getValue();
         Assert.assertEquals(permissions.get(role), null);
     }
 
@@ -985,22 +989,22 @@ public class PersistentTopicsTest extends MockedPulsarServiceBaseTest {
         verify(response, timeout(5000).times(1)).resume(responseCaptor.capture());
         Assert.assertEquals(responseCaptor.getValue().getStatus(), Response.Status.NO_CONTENT.getStatusCode());
         response = mock(AsyncResponse.class);
-        responseCaptor = ArgumentCaptor.forClass(Response.class);
+        ArgumentCaptor<Map<String, Set<AuthAction>>> permissionsCaptor = ArgumentCaptor.forClass(Map.class);
         persistentTopics.getPermissionsOnTopic(response, testTenant, testNamespace, partitionedTopicName);
-        verify(response, timeout(5000).times(1)).resume(responseCaptor.capture());
-        Map<String, Set<AuthAction>> permissions = (Map<String, Set<AuthAction>>) responseCaptor.getValue();
+        verify(response, timeout(5000).times(1)).resume(permissionsCaptor.capture());
+        Map<String, Set<AuthAction>> permissions = permissionsCaptor.getValue();
         Assert.assertEquals(permissions.get(role), null);
         TopicName topicName = TopicName.get(TopicDomain.persistent.value(), testTenant, testNamespace,
                 partitionedTopicName);
         for (int i = 0; i < numPartitions; i++) {
             TopicName partition = topicName.getPartition(i);
             response = mock(AsyncResponse.class);
-            responseCaptor = ArgumentCaptor.forClass(Response.class);
+            permissionsCaptor = ArgumentCaptor.forClass(Map.class);
             persistentTopics.getPermissionsOnTopic(response, testTenant, testNamespace,
                     partition.getEncodedLocalName());
-            verify(response, timeout(5000).times(1)).resume(responseCaptor.capture());
+            verify(response, timeout(5000).times(1)).resume(permissionsCaptor.capture());
             Map<String, Set<AuthAction>> partitionPermissions =
-                    (Map<String, Set<AuthAction>>) responseCaptor.getValue();
+                    permissionsCaptor.getValue();
             Assert.assertEquals(partitionPermissions.get(role), null);
         }
     }
@@ -1681,7 +1685,7 @@ public class PersistentTopicsTest extends MockedPulsarServiceBaseTest {
         admin.topics().createSubscription(topicName, subName, MessageId.latest);
 
         // partition-0 call from local and partition-1 call from admin.
-        NamespaceService namespaceService = spy(pulsar.getNamespaceService());
+        NamespaceService namespaceService = pulsar.getNamespaceService();
         doReturn(CompletableFuture.completedFuture(true))
                 .when(namespaceService).isServiceUnitOwnedAsync(topic.getPartition(0));
         doReturn(CompletableFuture.completedFuture(false))

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelTest.java
@@ -567,7 +567,7 @@ public class ServiceUnitStateChannelTest extends MockedPulsarServiceBaseTest {
         assertEquals(ownerAddr2, Optional.of(lookupServiceAddress1));
         assertTrue(ownerAddr1.isPresent());
 
-        NamespaceService namespaceService = spy(pulsar1.getNamespaceService());
+        NamespaceService namespaceService = pulsar1.getNamespaceService();
         CompletableFuture<Void> future = new CompletableFuture<>();
         int badVersionExceptionCount = 3;
         AtomicInteger count = new AtomicInteger(badVersionExceptionCount);
@@ -1331,7 +1331,7 @@ public class ServiceUnitStateChannelTest extends MockedPulsarServiceBaseTest {
         assertEquals(ownerAddr2, Optional.of(lookupServiceAddress1));
         assertTrue(ownerAddr1.isPresent());
 
-        NamespaceService namespaceService = spy(pulsar1.getNamespaceService());
+        NamespaceService namespaceService = pulsar1.getNamespaceService();
         CompletableFuture<Void> future = new CompletableFuture<>();
         int badVersionExceptionCount = 10;
         AtomicInteger count = new AtomicInteger(badVersionExceptionCount);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TransactionEndToEndTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TransactionEndToEndTest.java
@@ -19,8 +19,8 @@
 package org.apache.pulsar.client.impl;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyObject;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertEquals;
@@ -1417,7 +1417,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
         CompletableFuture<ProducerResponse> completableFuture = new CompletableFuture<>();
         completableFuture.complete(new ProducerResponse("test", 1,
                 "1".getBytes(), Optional.of(30L)));
-        doReturn(completableFuture).when(cnx).sendRequestWithId(anyObject(), anyLong());
+        doReturn(completableFuture).when(cnx).sendRequestWithId(any(), anyLong());
         producer.getConnectionHandler().setClientCnx(cnx);
 
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactedTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactedTopicTest.java
@@ -848,10 +848,8 @@ public class CompactedTopicTest extends MockedPulsarServiceBaseTest {
     @Test
     public void testCompactWithConcurrentGetCompactionHorizonAndCompactedTopicContext() throws Exception {
         @Cleanup
-        BookKeeper bk0 = pulsar.getBookKeeperClientFactory().create(
+        BookKeeper bk = pulsar.getBookKeeperClientFactory().create(
                 this.conf, null, null, Optional.empty(), null);
-
-        final BookKeeper bk = Mockito.spy(bk0);
 
         Mockito.doAnswer(invocation -> {
             Thread.sleep(1500);

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/shell/ConfigShellTest.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/shell/ConfigShellTest.java
@@ -21,7 +21,6 @@ package org.apache.pulsar.shell;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -52,7 +51,7 @@ public class ConfigShellTest {
     @BeforeMethod(alwaysRun = true)
     public void before() throws Exception {
 
-        pulsarShell = spy(mock(PulsarShell.class));
+        pulsarShell = mock(PulsarShell.class);
         doNothing().when(pulsarShell).reload(any());
         final Path tempJson = Files.createTempFile("pulsar-shell", ".json");
 

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConsumerBuilderImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConsumerBuilderImplTest.java
@@ -22,8 +22,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+import com.fasterxml.jackson.annotation.JsonIgnoreType;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.ArrayList;
@@ -44,8 +49,11 @@ import org.apache.pulsar.client.api.ConsumerEventListener;
 import org.apache.pulsar.client.api.CryptoKeyReader;
 import org.apache.pulsar.client.api.DeadLetterPolicy;
 import org.apache.pulsar.client.api.KeySharedPolicy;
+import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageCrypto;
 import org.apache.pulsar.client.api.MessageListener;
+import org.apache.pulsar.client.api.MessagePayload;
+import org.apache.pulsar.client.api.MessagePayloadContext;
 import org.apache.pulsar.client.api.MessagePayloadProcessor;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.RedeliveryBackoff;
@@ -59,11 +67,6 @@ import org.apache.pulsar.client.impl.conf.TopicConsumerConfigurationData;
 import org.apache.pulsar.client.impl.crypto.MessageCryptoBc;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
 
 /**
  * Unit tests of {@link ConsumerBuilderImpl}.
@@ -448,7 +451,7 @@ public class ConsumerBuilderImplTest {
 
         MessageListener<byte[]> messageListener = (consumer, message) -> {};
         conf.put("messageListener", messageListener);
-        ConsumerEventListener consumerEventListener = mock(ConsumerEventListener.class);
+        ConsumerEventListener consumerEventListener = createMockConsumerEventListener();
         conf.put("consumerEventListener", consumerEventListener);
         RedeliveryBackoff negativeAckRedeliveryBackoff = MultiplierRedeliveryBackoff.builder().build();
         conf.put("negativeAckRedeliveryBackoff", negativeAckRedeliveryBackoff);
@@ -462,7 +465,7 @@ public class ConsumerBuilderImplTest {
         conf.put("batchReceivePolicy", batchReceivePolicy);
         KeySharedPolicy keySharedPolicy = KeySharedPolicy.stickyHashRange();
         conf.put("keySharedPolicy", keySharedPolicy);
-        MessagePayloadProcessor payloadProcessor = mock(MessagePayloadProcessor.class);
+        MessagePayloadProcessor payloadProcessor = createMockMessagePayloadProcessor();
         conf.put("payloadProcessor", payloadProcessor);
 
         consumerBuilder.loadConf(conf);
@@ -593,7 +596,7 @@ public class ConsumerBuilderImplTest {
             .subscriptionName("subscription")
             .subscriptionProperties(subscriptionProperties)
             .messageListener((consumer, message) -> {})
-            .consumerEventListener(mock(ConsumerEventListener.class))
+            .consumerEventListener(createMockConsumerEventListener())
             .negativeAckRedeliveryBackoff(MultiplierRedeliveryBackoff.builder().build())
             .ackTimeoutRedeliveryBackoff(MultiplierRedeliveryBackoff.builder().build())
             .consumerName("consumer")
@@ -603,7 +606,37 @@ public class ConsumerBuilderImplTest {
             .deadLetterPolicy(DeadLetterPolicy.builder().deadLetterTopic("dlq").retryLetterTopic("retry").initialSubscriptionName("dlq-sub").maxRedeliverCount(1).build())
             .batchReceivePolicy(BatchReceivePolicy.builder().maxNumBytes(1).build())
             .keySharedPolicy(KeySharedPolicy.autoSplitHashRange())
-            .messagePayloadProcessor(mock(MessagePayloadProcessor.class));
+            .messagePayloadProcessor(createMockMessagePayloadProcessor());
         return consumerBuilder;
+    }
+
+    private static ConsumerEventListener createMockConsumerEventListener() {
+        return new MyConsumerEventListener();
+    }
+
+    private static MessagePayloadProcessor createMockMessagePayloadProcessor() {
+        return new MyMessagePayloadProcessor();
+    }
+
+    @JsonIgnoreType
+    private static class MyMessagePayloadProcessor implements MessagePayloadProcessor {
+        @Override
+        public <T> void process(MessagePayload payload, MessagePayloadContext context, Schema<T> schema,
+                                java.util.function.Consumer<Message<T>> messageConsumer) throws Exception {
+
+        }
+    }
+
+    @JsonIgnoreType
+    private static class MyConsumerEventListener implements ConsumerEventListener {
+        @Override
+        public void becameActive(Consumer<?> consumer, int partitionId) {
+
+        }
+
+        @Override
+        public void becameInactive(Consumer<?> consumer, int partitionId) {
+
+        }
     }
 }

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/FunctionMetaDataManagerTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/FunctionMetaDataManagerTest.java
@@ -145,7 +145,7 @@ public class FunctionMetaDataManagerTest {
                 .setFunctionDetails(Function.FunctionDetails.newBuilder().setName("func-1")).build();
 
         // become leader
-        Producer<byte[]> exclusiveProducer = spy(functionMetaDataManager.acquireExclusiveWrite(() -> true));
+        Producer<byte[]> exclusiveProducer = functionMetaDataManager.acquireExclusiveWrite(() -> true);
         // make sure send msg fail
         functionMetaDataManager.acquireLeadership(exclusiveProducer);
         exclusiveProducer.close();

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -300,7 +300,7 @@ The Apache Software License, Version 2.0
     - jetty-util-9.4.52.v20230823.jar
     - jetty-util-ajax-9.4.52.v20230823.jar
   * Byte Buddy
-    - byte-buddy-1.11.13.jar
+    - byte-buddy-1.14.8.jar
   * Apache BVal
     - bval-jsr-2.0.5.jar
   * Bytecode

--- a/tests/docker-images/java-test-image/Dockerfile
+++ b/tests/docker-images/java-test-image/Dockerfile
@@ -48,9 +48,9 @@ RUN mkdir -p /etc/apt/keyrings \
      && echo "deb [signed-by=/etc/apt/keyrings/adoptium.asc] https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list \
      && apt-get update \
      && apt-get -y dist-upgrade \
-     && apt-get -y install temurin-17-jdk \
+     && apt-get -y install temurin-21-jdk \
      && export ARCH=$(uname -m | sed -r 's/aarch64/arm64/g' |  awk '!/arm64/{$0="amd64"}1') \
-     && echo networkaddress.cache.ttl=1 >> /usr/lib/jvm/temurin-17-jdk-$ARCH/conf/security/java.security
+     && echo networkaddress.cache.ttl=1 >> /usr/lib/jvm/temurin-21-jdk-$ARCH/conf/security/java.security
 
 # /pulsar/bin/watch-znode.py requires python3-kazoo
 # /pulsar/bin/pulsar-managed-ledger-admin requires python3-protobuf


### PR DESCRIPTION
- Use Java 21 by default in GitHub Actions workflows
- Switch to use temurin-21-jdk in docker images
- [improve][test] Upgrade Mockito to 5.6.0 for Java 21 compatibility (#21385)
