### PR TITLE
[improve][ci] Detect test thread leaks in CI builds and add tooling for resource leak investigation

### DIFF
--- a/.github/workflows/pulsar-ci-flaky.yaml
+++ b/.github/workflows/pulsar-ci-flaky.yaml
@@ -43,7 +43,20 @@ on:
           - '17'
           - '21'
         default: '17'
-
+      trace_test_resource_cleanup:
+        description: 'Collect thread & heap information before exiting a test JVM. When set to "on", thread dump and heap histogram will be collected. When set to "full", a heap dump will also be collected.'
+        required: true
+        type: choice
+        options:
+          - 'off'
+          - 'on'
+          - 'full'
+        default: 'off'
+      thread_leak_detector_wait_millis:
+        description: 'Duration in ms to wait for threads to exit in thread leak detection between test classes. It is necessary to wait for threads to complete before they are determined to be leaked threads.'
+        required: true
+        type: number
+        default: 10000
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}${{ github.event_name == 'workflow_dispatch' && github.event.inputs.jdk_major_version || '' }}
@@ -134,6 +147,10 @@ jobs:
       COLLECT_COVERAGE: "${{ needs.preconditions.outputs.collect_coverage }}"
       GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
       CI_JDK_MAJOR_VERSION: ${{ needs.preconditions.outputs.jdk_major_version }}
+      TRACE_TEST_RESOURCE_CLEANUP: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.trace_test_resource_cleanup || 'off' }}
+      TRACE_TEST_RESOURCE_CLEANUP_DIR: ${{ github.workspace }}/target/trace-test-resource-cleanup
+      THREAD_LEAK_DETECTOR_WAIT_MILLIS: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.thread_leak_detector_wait_millis || 10000 }}
+      THREAD_LEAK_DETECTOR_DIR: ${{ github.workspace }}/target/thread-leak-dumps
     runs-on: ubuntu-22.04
     timeout-minutes: 100
     if: ${{ needs.preconditions.outputs.docs_only != 'true' }}
@@ -143,6 +160,10 @@ jobs:
 
       - name: Tune Runner VM
         uses: ./.github/actions/tune-runner-vm
+
+      - name: Clean Disk when tracing test resource cleanup
+        if: ${{ env.TRACE_TEST_RESOURCE_CLEANUP != 'off' }}
+        uses: ./.github/actions/clean-disk
 
       - name: Setup ssh access to build runner VM
         # ssh access is enabled for builds in own forks
@@ -185,8 +206,24 @@ jobs:
         if: ${{ always() }}
         uses: ./.github/actions/copy-test-reports
 
+      - name: Publish Test Report
+        uses: apache/pulsar-test-infra/action-junit-report@master
+        if: ${{ always() }}
+        with:
+          report_paths: 'test-reports/TEST-*.xml'
+          annotate_only: 'true'
+
+      - name: Report detected thread leaks
+        if: ${{ always() }}
+        run: |
+          if [ -d "$THREAD_LEAK_DETECTOR_DIR" ]; then
+            cd "$THREAD_LEAK_DETECTOR_DIR"
+            cat threadleak*.txt | awk '/^Summary:/ {print "::warning::" $0 "\n"; next} {print}'  
+          fi
+
       - name: Create Jacoco reports
         if: ${{ needs.preconditions.outputs.collect_coverage == 'true' }}
+        continue-on-error: true
         run: |
           $GITHUB_WORKSPACE/build/pulsar_ci_tool.sh create_test_coverage_report 
           cd $GITHUB_WORKSPACE/target
@@ -199,33 +236,34 @@ jobs:
           name: Jacoco-coverage-report-flaky
           path: target/jacoco_test_coverage_report_flaky.zip
           retention-days: 3
+          if-no-files-found: ignore
 
       - name: Upload to Codecov
         if: ${{ needs.preconditions.outputs.collect_coverage == 'true' }}
         uses: ./.github/actions/upload-coverage
+        continue-on-error: true
         with:
           flags: unittests
 
-      - name: Publish Test Report
-        uses: apache/pulsar-test-infra/action-junit-report@master
-        if: ${{ always() }}
-        with:
-          report_paths: 'test-reports/TEST-*.xml'
-          annotate_only: 'true'
-
       - name: Upload Surefire reports
         uses: actions/upload-artifact@v3
-        if: ${{ !success() }}
+        if: ${{ !success() || env.TRACE_TEST_RESOURCE_CLEANUP != 'off' }}
         with:
           name: Unit-BROKER_FLAKY-surefire-reports
           path: surefire-reports
           retention-days: 7
+          if-no-files-found: ignore
 
-      - name: Upload possible heap dump
+      - name: Upload possible heap dump, core dump or crash files
         uses: actions/upload-artifact@v3
         if: ${{ always() }}
         with:
-          name: Unit-BROKER_FLAKY-heapdump
-          path: /tmp/*.hprof
+          name: Unit-BROKER_FLAKY-dumps
+          path: |
+            /tmp/*.hprof
+            **/hs_err_*.log
+            **/core.*
+            ${{ env.TRACE_TEST_RESOURCE_CLEANUP_DIR }}/*
+            ${{ env.THREAD_LEAK_DETECTOR_DIR }}/*
           retention-days: 7
           if-no-files-found: ignore

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -43,6 +43,20 @@ on:
           - '17'
           - '21'
         default: '17'
+      trace_test_resource_cleanup:
+        description: 'Collect thread & heap information before exiting a test JVM. When set to "on", thread dump and heap histogram will be collected. When set to "full", a heap dump will also be collected.'
+        required: true
+        type: choice
+        options:
+          - 'off'
+          - 'on'
+          - 'full'
+        default: 'off'
+      thread_leak_detector_wait_millis:
+        description: 'Duration in ms to wait for threads to exit in thread leak detection between test classes. It is necessary to wait for threads to complete before they are determined to be leaked threads.'
+        required: true
+        type: number
+        default: 10000
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}${{ github.event_name == 'workflow_dispatch' && github.event.inputs.jdk_major_version || '' }}
@@ -209,6 +223,10 @@ jobs:
       COLLECT_COVERAGE: "${{ needs.preconditions.outputs.collect_coverage }}"
       GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
       CI_JDK_MAJOR_VERSION: ${{ needs.preconditions.outputs.jdk_major_version }}
+      TRACE_TEST_RESOURCE_CLEANUP: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.trace_test_resource_cleanup || 'off' }}
+      TRACE_TEST_RESOURCE_CLEANUP_DIR: ${{ github.workspace }}/target/trace-test-resource-cleanup
+      THREAD_LEAK_DETECTOR_WAIT_MILLIS: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.thread_leak_detector_wait_millis || 10000 }}
+      THREAD_LEAK_DETECTOR_DIR: ${{ github.workspace }}/target/thread-leak-dumps
     runs-on: ubuntu-22.04
     timeout-minutes: ${{ matrix.timeout || 60 }}
     needs: ['preconditions', 'build-and-license-check']
@@ -250,6 +268,10 @@ jobs:
 
       - name: Tune Runner VM
         uses: ./.github/actions/tune-runner-vm
+
+      - name: Clean Disk when tracing test resource cleanup
+        if: ${{ env.TRACE_TEST_RESOURCE_CLEANUP != 'off' }}
+        uses: ./.github/actions/clean-disk
 
       - name: Setup ssh access to build runner VM
         # ssh access is enabled for builds in own forks
@@ -312,9 +334,17 @@ jobs:
           report_paths: 'test-reports/TEST-*.xml'
           annotate_only: 'true'
 
+      - name: Report detected thread leaks
+        if: ${{ always() }}
+        run: |
+          if [ -d "$THREAD_LEAK_DETECTOR_DIR" ]; then
+            cd "$THREAD_LEAK_DETECTOR_DIR"
+            cat threadleak*.txt | awk '/^Summary:/ {print "::warning::" $0 "\n"; next} {print}'
+          fi
+
       - name: Upload Surefire reports
         uses: actions/upload-artifact@v3
-        if: ${{ !success() }}
+        if: ${{ !success() || env.TRACE_TEST_RESOURCE_CLEANUP != 'off' }}
         with:
           name: Unit-${{ matrix.group }}-surefire-reports
           path: surefire-reports
@@ -329,6 +359,8 @@ jobs:
             /tmp/*.hprof
             **/hs_err_*.log
             **/core.*
+            ${{ env.TRACE_TEST_RESOURCE_CLEANUP_DIR }}/*
+            ${{ env.THREAD_LEAK_DETECTOR_DIR }}/*
           retention-days: 7
           if-no-files-found: ignore
 

--- a/buildtools/src/main/java/org/apache/pulsar/tests/HeapDumpUtil.java
+++ b/buildtools/src/main/java/org/apache/pulsar/tests/HeapDumpUtil.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.tests;
+
+import com.sun.management.HotSpotDiagnosticMXBean;
+import java.io.File;
+import java.lang.management.ManagementFactory;
+import javax.management.MBeanServer;
+
+public class HeapDumpUtil {
+    private static final String HOTSPOT_BEAN_NAME = "com.sun.management:type=HotSpotDiagnostic";
+
+    // Utility method to get the HotSpotDiagnosticMXBean
+    private static HotSpotDiagnosticMXBean getHotSpotDiagnosticMXBean() {
+        try {
+            MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+            return ManagementFactory.newPlatformMXBeanProxy(server, HOTSPOT_BEAN_NAME, HotSpotDiagnosticMXBean.class);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Dump the heap of the JVM.
+     *
+     * @param file        the system-dependent filename
+     * @param liveObjects if true dump only live objects i.e. objects that are reachable from others
+     */
+    public static void dumpHeap(File file, boolean liveObjects) {
+        try {
+            HotSpotDiagnosticMXBean hotspotMBean = getHotSpotDiagnosticMXBean();
+            hotspotMBean.dumpHeap(file.getAbsolutePath(), liveObjects);
+        } catch (Exception e) {
+            throw new RuntimeException("Error generating heap dump", e);
+        }
+    }
+}

--- a/buildtools/src/main/java/org/apache/pulsar/tests/HeapHistogramUtil.java
+++ b/buildtools/src/main/java/org/apache/pulsar/tests/HeapHistogramUtil.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.tests;
+
+import java.lang.management.ManagementFactory;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import javax.management.JMException;
+import javax.management.ObjectName;
+
+public class HeapHistogramUtil {
+    public static String buildHeapHistogram() {
+        StringBuilder dump = new StringBuilder();
+        dump.append(String.format("Timestamp: %s", DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(ZonedDateTime.now())));
+        dump.append("\n\n");
+        try {
+            dump.append(callDiagnosticCommand("gcHeapInfo"));
+        } catch (Exception e) {
+            e.printStackTrace();
+            return null;
+        }
+        dump.append("\n");
+        try {
+            dump.append(callDiagnosticCommand("gcClassHistogram"));
+        } catch (Exception e) {
+            e.printStackTrace();
+            return null;
+        }
+        return dump.toString();
+    }
+
+    /**
+     * Calls a diagnostic commands.
+     * The available operations are similar to what the jcmd commandline tool has,
+     * however the naming of the operations are different. The "help" operation can be used
+     * to find out the available operations. For example, the jcmd command "Thread.print" maps
+     * to "threadPrint" operation name.
+     */
+    static String callDiagnosticCommand(String operationName, String... args)
+            throws JMException {
+        return (String) ManagementFactory.getPlatformMBeanServer()
+                .invoke(new ObjectName("com.sun.management:type=DiagnosticCommand"),
+                        operationName, new Object[] {args}, new String[] {String[].class.getName()});
+    }
+}

--- a/buildtools/src/main/java/org/apache/pulsar/tests/ThreadDumpUtil.java
+++ b/buildtools/src/main/java/org/apache/pulsar/tests/ThreadDumpUtil.java
@@ -25,7 +25,7 @@ import java.lang.management.ManagementFactory;
 import java.lang.management.MonitorInfo;
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Map;
 import javax.management.JMException;
@@ -65,7 +65,7 @@ public class ThreadDumpUtil {
         // fallback to using JMX for creating the thread dump
         StringBuilder dump = new StringBuilder();
 
-        dump.append(String.format("Timestamp: %s", DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(LocalDateTime.now())));
+        dump.append(String.format("Timestamp: %s", DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(ZonedDateTime.now())));
         dump.append("\n\n");
 
         Map<Thread, StackTraceElement[]> stackTraces = Thread.getAllStackTraces();

--- a/buildtools/src/main/java/org/apache/pulsar/tests/ThreadLeakDetectorListener.java
+++ b/buildtools/src/main/java/org/apache/pulsar/tests/ThreadLeakDetectorListener.java
@@ -16,53 +16,173 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.apache.pulsar.tests;
 
+import com.google.common.base.Charsets;
+import com.google.common.io.Files;
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.ForkJoinWorkerThread;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.ThreadUtils;
+import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Detects new threads that have been created during the test execution.
+ * Detects new threads that have been created during the test execution. This is useful to detect thread leaks.
+ * Will create files to the configured directory if new threads are detected and THREAD_LEAK_DETECTOR_WAIT_MILLIS
+ * is set to a positive value. A recommended value is 10000 for THREAD_LEAK_DETECTOR_WAIT_MILLIS. This will ensure
+ * that any asynchronous operations should have completed before the detector determines that it has found a leak.
  */
 public class ThreadLeakDetectorListener extends BetweenTestClassesListenerAdapter {
     private static final Logger LOG = LoggerFactory.getLogger(ThreadLeakDetectorListener.class);
+    private static final long WAIT_FOR_THREAD_TERMINATION_MILLIS =
+            Long.parseLong(System.getenv().getOrDefault("THREAD_LEAK_DETECTOR_WAIT_MILLIS", "0"));
+    private static final File DUMP_DIR =
+            new File(System.getenv().getOrDefault("THREAD_LEAK_DETECTOR_DIR", "target/thread-leak-dumps"));
+    private static final long THREAD_TERMINATION_POLL_INTERVAL =
+            Long.parseLong(System.getenv().getOrDefault("THREAD_LEAK_DETECTOR_POLL_INTERVAL", "250"));
+    private static final boolean COLLECT_THREADDUMP =
+            Boolean.parseBoolean(System.getenv().getOrDefault("THREAD_LEAK_DETECTOR_COLLECT_THREADDUMP", "true"));
 
     private Set<ThreadKey> capturedThreadKeys;
+
 
     @Override
     protected void onBetweenTestClasses(Class<?> endedTestClass, Class<?> startedTestClass) {
         LOG.info("Capturing identifiers of running threads.");
-        capturedThreadKeys = compareThreads(capturedThreadKeys, endedTestClass);
+        MutableBoolean differenceDetected = new MutableBoolean();
+        Set<ThreadKey> currentThreadKeys =
+                compareThreads(capturedThreadKeys, endedTestClass, WAIT_FOR_THREAD_TERMINATION_MILLIS <= 0,
+                        differenceDetected, null);
+        if (WAIT_FOR_THREAD_TERMINATION_MILLIS > 0 && endedTestClass != null && differenceDetected.booleanValue()) {
+            LOG.info("Difference detected in active threads. Waiting up to {} ms for threads to terminate.",
+                    WAIT_FOR_THREAD_TERMINATION_MILLIS);
+            long endTime = System.currentTimeMillis() + WAIT_FOR_THREAD_TERMINATION_MILLIS;
+            while (System.currentTimeMillis() < endTime) {
+                try {
+                    Thread.sleep(THREAD_TERMINATION_POLL_INTERVAL);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                differenceDetected.setFalse();
+                currentThreadKeys = compareThreads(capturedThreadKeys, endedTestClass, false, differenceDetected, null);
+                if (!differenceDetected.booleanValue()) {
+                    break;
+                }
+            }
+            if (differenceDetected.booleanValue()) {
+                String datetimePart =
+                        DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss.SSS").format(ZonedDateTime.now());
+                PrintWriter out = null;
+                try {
+                    if (!DUMP_DIR.exists()) {
+                        DUMP_DIR.mkdirs();
+                    }
+                    File threadleakdumpFile =
+                            new File(DUMP_DIR, "threadleak" + datetimePart + endedTestClass.getName() + ".txt");
+                    out = new PrintWriter(threadleakdumpFile);
+                } catch (IOException e) {
+                    LOG.error("Cannot write thread leak dump", e);
+                }
+                currentThreadKeys = compareThreads(capturedThreadKeys, endedTestClass, true, null, out);
+                if (out != null) {
+                    out.close();
+                }
+                if (COLLECT_THREADDUMP) {
+                    File threaddumpFile =
+                            new File(DUMP_DIR, "threaddump" + datetimePart + endedTestClass.getName() + ".txt");
+                    try {
+                        Files.asCharSink(threaddumpFile, Charsets.UTF_8)
+                                .write(ThreadDumpUtil.buildThreadDiagnosticString());
+                    } catch (IOException e) {
+                        LOG.error("Cannot write thread dump", e);
+                    }
+                }
+            }
+        }
+        capturedThreadKeys = currentThreadKeys;
     }
 
-    private static Set<ThreadKey> compareThreads(Set<ThreadKey> previousThreadKeys, Class<?> endedTestClass) {
+    private static Set<ThreadKey> compareThreads(Set<ThreadKey> previousThreadKeys, Class<?> endedTestClass,
+                                                 boolean logDifference, MutableBoolean differenceDetected,
+                                                 PrintWriter out) {
         Set<ThreadKey> threadKeys = Collections.unmodifiableSet(ThreadUtils.getAllThreads().stream()
+                .filter(thread -> !shouldSkipThread(thread))
                 .map(ThreadKey::of)
                 .collect(Collectors.<ThreadKey, Set<ThreadKey>>toCollection(LinkedHashSet::new)));
 
         if (endedTestClass != null && previousThreadKeys != null) {
             int newThreadsCounter = 0;
-            LOG.info("Checking for new threads created by {}.", endedTestClass.getName());
             for (ThreadKey threadKey : threadKeys) {
                 if (!previousThreadKeys.contains(threadKey)) {
                     newThreadsCounter++;
-                    LOG.warn("Tests in class {} created thread id {} with name '{}'", endedTestClass.getSimpleName(),
-                            threadKey.getThreadId(), threadKey.getThreadName());
+                    if (differenceDetected != null) {
+                        differenceDetected.setTrue();
+                    }
+                    if (logDifference || out != null) {
+                        String message = String.format("Tests in class %s created thread id %d with name '%s'",
+                                endedTestClass.getSimpleName(),
+                                threadKey.getThreadId(), threadKey.getThreadName());
+                        if (logDifference) {
+                            LOG.warn(message);
+                        }
+                        if (out != null) {
+                            out.println(message);
+                        }
+                    }
                 }
             }
-            if (newThreadsCounter > 0) {
-                LOG.warn("Summary: Tests in class {} created {} new threads", endedTestClass.getName(),
-                        newThreadsCounter);
+            if (newThreadsCounter > 0 && (logDifference || out != null)) {
+                String message = String.format(
+                        "Summary: Tests in class %s created %d new threads. There are now %d threads in total.",
+                        endedTestClass.getName(), newThreadsCounter, threadKeys.size());
+                if (logDifference) {
+                    LOG.warn(message);
+                }
+                if (out != null) {
+                    out.println(message);
+                }
             }
         }
 
         return threadKeys;
+    }
+
+    private static boolean shouldSkipThread(Thread thread) {
+        // skip ForkJoinPool threads
+        if (thread instanceof ForkJoinWorkerThread) {
+            return true;
+        }
+        String threadName = thread.getName();
+        if (threadName != null) {
+            // skip ClientTestFixtures.SCHEDULER threads
+            if (threadName.startsWith("ClientTestFixtures-SCHEDULER-")) {
+                return true;
+            }
+            // skip JVM internal threads related to java.lang.Process
+            if (threadName.equals("process reaper")) {
+                return true;
+            }
+            // skip JVM internal thread used for CompletableFuture.delayedExecutor
+            if (threadName.equals("CompletableFutureDelayScheduler")) {
+                return true;
+            }
+            // skip threadpool created in dev.failsafe.internal.util.DelegatingScheduler
+            if (threadName.equals("FailsafeDelayScheduler")) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/buildtools/src/main/java/org/apache/pulsar/tests/TraceTestResourceCleanupListener.java
+++ b/buildtools/src/main/java/org/apache/pulsar/tests/TraceTestResourceCleanupListener.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.tests;
+
+import com.google.common.base.Charsets;
+import com.google.common.io.Files;
+import java.io.File;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import org.testng.IExecutionListener;
+
+/**
+ * A TestNG listener that traces test resource cleanup by creating a thread dump, heap histogram and heap dump
+ * (when mode is 'full') before the TestNG JVM exits.
+ * The heap dump could help detecting memory leaks in tests or the sources of resource leaks that cannot be
+ * detected with the ThreadLeakDetectorListener.
+ */
+public class TraceTestResourceCleanupListener implements IExecutionListener {
+    enum TraceTestResourceCleanupMode {
+        OFF,
+        ON,
+        FULL // includes heap dump
+    }
+
+    private static final TraceTestResourceCleanupMode MODE =
+            TraceTestResourceCleanupMode.valueOf(
+                    System.getenv().getOrDefault("TRACE_TEST_RESOURCE_CLEANUP", "off").toUpperCase());
+    private static final File DUMP_DIR = new File(
+            System.getenv().getOrDefault("TRACE_TEST_RESOURCE_CLEANUP_DIR", "target/trace-test-resource-cleanup"));
+    private static final long WAIT_BEFORE_DUMP_MILLIS =
+            Long.parseLong(System.getenv().getOrDefault("TRACE_TEST_RESOURCE_CLEANUP_DELAY", "5000"));
+
+    static {
+        if (MODE != TraceTestResourceCleanupMode.OFF) {
+            Runtime.getRuntime().addShutdownHook(new Thread(TraceTestResourceCleanupListener::createDumps));
+        }
+    }
+
+    static void createDumps() {
+        if (!DUMP_DIR.isDirectory()) {
+            DUMP_DIR.mkdirs();
+        }
+        try {
+            Thread.sleep(WAIT_BEFORE_DUMP_MILLIS);
+        } catch (InterruptedException e) {
+            // ignore
+        }
+
+        String datetimePart =
+                DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss.SSS").format(ZonedDateTime.now());
+        try {
+            String threadDump = ThreadDumpUtil.buildThreadDiagnosticString();
+            File threaddumpFile = new File(DUMP_DIR, "threaddump" + datetimePart + ".txt");
+            Files.asCharSink(threaddumpFile, Charsets.UTF_8).write(threadDump);
+        } catch (Throwable t) {
+            System.err.println("Error dumping threads");
+            t.printStackTrace(System.err);
+        }
+
+        try {
+            String heapHistogram = HeapHistogramUtil.buildHeapHistogram();
+            File heapHistogramFile = new File(DUMP_DIR, "heaphistogram" + datetimePart + ".txt");
+            Files.asCharSink(heapHistogramFile, Charsets.UTF_8).write(heapHistogram);
+        } catch (Throwable t) {
+            System.err.println("Error dumping heap histogram");
+            t.printStackTrace(System.err);
+        }
+
+        if (MODE == TraceTestResourceCleanupMode.FULL) {
+            try {
+                File heapdumpFile = new File(DUMP_DIR, "heapdump" + datetimePart + ".hprof");
+                HeapDumpUtil.dumpHeap(heapdumpFile, true);
+            } catch (Throwable t) {
+                System.err.println("Error dumping heap");
+                t.printStackTrace(System.err);
+            }
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1567,7 +1567,7 @@ flexible messaging model and an intuitive client API.</description>
           <properties>
             <property>
               <name>listener</name>
-              <value>org.apache.pulsar.tests.PulsarTestListener,org.apache.pulsar.tests.JacocoDumpListener,org.apache.pulsar.tests.AnnotationListener,org.apache.pulsar.tests.FailFastNotifier,org.apache.pulsar.tests.MockitoCleanupListener,org.apache.pulsar.tests.FastThreadLocalCleanupListener,org.apache.pulsar.tests.ThreadLeakDetectorListener,org.apache.pulsar.tests.SingletonCleanerListener</value>
+              <value>org.apache.pulsar.tests.PulsarTestListener,org.apache.pulsar.tests.JacocoDumpListener,org.apache.pulsar.tests.TraceTestResourceCleanupListener,org.apache.pulsar.tests.AnnotationListener,org.apache.pulsar.tests.FailFastNotifier,org.apache.pulsar.tests.MockitoCleanupListener,org.apache.pulsar.tests.FastThreadLocalCleanupListener,org.apache.pulsar.tests.ThreadLeakDetectorListener,org.apache.pulsar.tests.SingletonCleanerListener</value>
             </property>
           </properties>
         </configuration>

--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandaloneStarter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandaloneStarter.java
@@ -47,7 +47,7 @@ public class PulsarStandaloneStarter extends PulsarStandalone {
             jcommander.parse(args);
             if (this.isHelp()) {
                 jcommander.usage();
-                System.exit(0);
+                exit(0);
             }
             if (Strings.isNullOrEmpty(this.getConfigFile())) {
                 String configFile = System.getProperty(PULSAR_CONFIG_FILE);
@@ -62,7 +62,7 @@ public class PulsarStandaloneStarter extends PulsarStandalone {
                 CmdGenerateDocs cmd = new CmdGenerateDocs("pulsar");
                 cmd.addCommand("standalone", this);
                 cmd.run(null);
-                System.exit(0);
+                exit(0);
             }
 
             if (this.isNoBroker() && this.isOnlyBroker()) {
@@ -73,7 +73,7 @@ public class PulsarStandaloneStarter extends PulsarStandalone {
         } catch (Exception e) {
             jcommander.usage();
             log.error(e.getMessage());
-            System.exit(1);
+            exit(1);
         }
 
         try (FileInputStream inputStream = new FileInputStream(this.getConfigFile())) {
@@ -109,6 +109,10 @@ public class PulsarStandaloneStarter extends PulsarStandalone {
             }
         }
 
+        registerShutdownHook();
+    }
+
+    protected void registerShutdownHook() {
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
             try {
                 if (fnWorkerService != null) {
@@ -128,6 +132,10 @@ public class PulsarStandaloneStarter extends PulsarStandalone {
                 LogManager.shutdown();
             }
         }));
+    }
+
+    protected void exit(int status) {
+        System.exit(status);
     }
 
     private static boolean argsContains(String[] args, String arg) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/CreateSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/CreateSubscriptionTest.java
@@ -31,6 +31,7 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import javax.ws.rs.ClientErrorException;
 import javax.ws.rs.core.Response.Status;
+import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.http.HttpResponse;
@@ -431,6 +432,7 @@ public class CreateSubscriptionTest extends ProducerConsumerBase {
         final int numberOfMessages = 5;
         String topic = "persistent://my-property/my-ns/my-topic";
         RequestConfig requestConfig = RequestConfig.custom().setConnectTimeout(30 * 1000).build();
+        @Cleanup
         CloseableHttpClient httpClient = HttpClientBuilder.create().setDefaultRequestConfig(requestConfig).build();
 
         // Produce some messages to pulsar

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/InvalidBrokerConfigForAuthorizationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/InvalidBrokerConfigForAuthorizationTest.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.broker.auth;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
 import org.apache.pulsar.broker.PulsarServerException;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
 public class InvalidBrokerConfigForAuthorizationTest extends MockedPulsarServiceBaseTest {
@@ -47,6 +48,8 @@ public class InvalidBrokerConfigForAuthorizationTest extends MockedPulsarService
 
     }
 
+
+    @AfterMethod(alwaysRun = true)
     @Override
     protected void cleanup() throws Exception {
         internalCleanup();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/ExceptionsBrokerInterceptorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/ExceptionsBrokerInterceptorTest.java
@@ -22,7 +22,6 @@ import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
-
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
@@ -35,6 +34,7 @@ import org.apache.pulsar.client.impl.ClientCnx;
 import org.apache.pulsar.client.impl.ConsumerImpl;
 import org.apache.pulsar.common.nar.NarClassLoader;
 import org.awaitility.Awaitility;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -53,6 +53,7 @@ public class ExceptionsBrokerInterceptorTest extends ProducerConsumerBase {
         super.producerBaseSetup();
     }
 
+    @AfterMethod(alwaysRun = true)
     @Override
     protected void cleanup() throws Exception {
         super.internalCleanup();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/AbstractReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/AbstractReplicatorTest.java
@@ -32,6 +32,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import lombok.Cleanup;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.pulsar.broker.PulsarServerException;
@@ -57,6 +58,7 @@ public class AbstractReplicatorTest {
         final String remoteCluster = "remoteCluster";
         final String topicName = "remoteTopicName";
         final String replicatorPrefix = "pulsar.repl";
+        @Cleanup("shutdownNow")
         final DefaultEventLoop eventLoopGroup = new DefaultEventLoop();
         // Mock services.
         final ServiceConfiguration pulsarConfig = mock(ServiceConfiguration.class);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
@@ -984,6 +984,7 @@ public class BrokerServiceTest extends BrokerTestBase {
         conf.setConcurrentLookupRequest(1);
         conf.setMaxLookupRequest(2);
 
+        @Cleanup("shutdownNow")
         EventLoopGroup eventLoop = EventLoopUtil.newEventLoopGroup(20, false,
                 new DefaultThreadFactory("test-pool", Thread.currentThread().isDaemon()));
         long reqId = 0xdeadbeef;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
@@ -391,11 +391,16 @@ public class BrokerServiceTest extends BrokerTestBase {
     }
 
     private void createNewConnectionAndCheckFail(String topicName, ClientBuilder builder) throws Exception {
+        PulsarClient client = null;
         try {
-            createNewConnection(topicName, builder);
+            client = createNewConnection(topicName, builder);
             fail("should fail");
         } catch (Exception e) {
             assertTrue(e.getMessage().contains("Reached the maximum number of connections"));
+        } finally {
+            if (client != null) {
+                client.close();
+            }
         }
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
@@ -71,8 +71,8 @@ import org.apache.bookkeeper.mledger.impl.ManagedCursorImpl;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryImpl;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.http.HttpResponse;
-import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitStateChannelImpl;
@@ -1454,7 +1454,8 @@ public class BrokerServiceTest extends BrokerTestBase {
     public void testMetricsProvider() throws IOException {
         PrometheusRawMetricsProvider rawMetricsProvider = stream -> stream.write("test_metrics{label1=\"xyz\"} 10 \n");
         getPulsar().addPrometheusRawMetricsProvider(rawMetricsProvider);
-        HttpClient httpClient = HttpClientBuilder.create().build();
+        @Cleanup
+        CloseableHttpClient httpClient = HttpClientBuilder.create().build();
         final String metricsEndPoint = getPulsar().getWebServiceAddress() + "/metrics";
         HttpResponse response = httpClient.execute(new HttpGet(metricsEndPoint));
         InputStream inputStream = response.getEntity().getContent();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentDispatcherFailoverConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentDispatcherFailoverConsumerTest.java
@@ -51,6 +51,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
+import lombok.Cleanup;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.AddEntryCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.DeleteCursorCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.DeleteLedgerCallback;
@@ -462,6 +463,7 @@ public class PersistentDispatcherFailoverConsumerTest {
         log.info("--- Starting PersistentDispatcherFailoverConsumerTest::testAddRemoveConsumerNonPartitionedTopic ---");
         String[] sortedConsumerNameByHashSelector = sortConsumerNameByHashSelector("Cons1", "Cons2");
         BrokerService spyBrokerService = pulsarTestContext.getBrokerService();
+        @Cleanup("shutdownNow")
         final EventLoopGroup singleEventLoopGroup = EventLoopUtil.newEventLoopGroup(1,
                 pulsarTestContext.getBrokerService().getPulsar().getConfig().isEnableBusyWait(),
                 new DefaultThreadFactory("pulsar-io"));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
@@ -46,7 +46,8 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.DefaultEventLoop;
+import io.netty.channel.DefaultEventLoopGroup;
+import io.netty.channel.EventLoopGroup;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.net.InetAddress;
@@ -164,6 +165,7 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
 
     private BrokerService brokerService;
 
+    private EventLoopGroup eventLoopGroup;
 
     @BeforeMethod(alwaysRun = true)
     public void setup() throws Exception {
@@ -202,7 +204,9 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
                 .when(serverCnx).getCommandSender();
         ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
         Channel channel = mock(Channel.class);
-        doReturn(spy(DefaultEventLoop.class)).when(channel).eventLoop();
+
+        eventLoopGroup = new DefaultEventLoopGroup();
+        doReturn(eventLoopGroup.next()).when(channel).eventLoop();
         doReturn(channel).when(ctx).channel();
         doReturn(ctx).when(serverCnx).ctx();
 
@@ -223,6 +227,10 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
         if (pulsarTestContext != null) {
             pulsarTestContext.close();
             pulsarTestContext = null;
+        }
+        if (eventLoopGroup != null) {
+            eventLoopGroup.shutdownNow();
+            eventLoopGroup = null;
         }
     }
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/ThreadDumpUtil.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/ThreadDumpUtil.java
@@ -25,7 +25,7 @@ import java.lang.management.ManagementFactory;
 import java.lang.management.MonitorInfo;
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Map;
 import javax.management.JMException;
@@ -65,7 +65,7 @@ public class ThreadDumpUtil {
         // fallback to using JMX for creating the thread dump
         StringBuilder dump = new StringBuilder();
 
-        dump.append(String.format("Timestamp: %s", DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(LocalDateTime.now())));
+        dump.append(String.format("Timestamp: %s", DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(ZonedDateTime.now())));
         dump.append("\n\n");
 
         Map<Thread, StackTraceElement[]> stackTraces = Thread.getAllStackTraces();


### PR DESCRIPTION
- [improve][ci] Detect test thread leaks in CI builds and add tooling for resource leak investigation
- Fix http client leaks
- Cleanup PulsarClient properly
- Close EventLoopGroup
- Close PulsarTestClient properly
- Close event loop group
- Add missing AfterMethod annotation
- Prevent leak in StandaloneTest
- Fix event loop thread leak
- Fix leak in AbstractReplicatorTest
