### PR TITLE
lh netty buffer leak detection in tests

### DIFF
--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -141,12 +141,11 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <!-- for testing FastThreadLocalStateCleaner -->
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-common</artifactId>
       <version>${netty.version}</version>
-      <scope>test</scope>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>

--- a/buildtools/src/main/java/org/apache/pulsar/tests/ExitJVMNettyLeakDetector.java
+++ b/buildtools/src/main/java/org/apache/pulsar/tests/ExitJVMNettyLeakDetector.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.tests;
+
+import io.netty.util.ResourceLeakDetector;
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A custom Netty leak detector that dumps the leak to a file and exits the JVM.
+ */
+public class ExitJVMNettyLeakDetector<T> extends ResourceLeakDetector<T> {
+    private static final Logger LOG = LoggerFactory.getLogger(ExitJVMNettyLeakDetector.class);
+    private static final File DUMP_DIR =
+            new File(System.getenv().getOrDefault("NETTY_LEAK_DUMP_DIR", System.getProperty("java.io.tmpdir")));
+
+    public ExitJVMNettyLeakDetector(Class<?> resourceType, int samplingInterval, long maxActive) {
+        super(resourceType, samplingInterval, maxActive);
+    }
+
+    public ExitJVMNettyLeakDetector(Class<?> resourceType, int samplingInterval) {
+        super(resourceType, samplingInterval);
+    }
+
+    public ExitJVMNettyLeakDetector(String resourceType, int samplingInterval, long maxActive) {
+        super(resourceType, samplingInterval, maxActive);
+    }
+
+
+    @Override
+    protected void reportTracedLeak(String resourceType, String records) {
+        super.reportTracedLeak(resourceType, records);
+        dumpToFile(resourceType, records);
+        exitJVM();
+    }
+
+    @Override
+    protected void reportUntracedLeak(String resourceType) {
+        super.reportUntracedLeak(resourceType);
+        dumpToFile(resourceType, null);
+        exitJVM();
+    }
+
+    private void exitJVM() {
+        Runtime.getRuntime().halt(1);
+    }
+
+    private void dumpToFile(String resourceType, String records) {
+        try {
+            if (!DUMP_DIR.exists()) {
+                DUMP_DIR.mkdirs();
+            }
+            String datetimePart =
+                    DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss.SSS").format(ZonedDateTime.now());
+            File nettyLeakDumpFile =
+                    new File(DUMP_DIR, "netty_leak_" + datetimePart + ".txt");
+            try (PrintWriter out = new PrintWriter(nettyLeakDumpFile)) {
+                if (records != null) {
+                    out.println("Traced leak detected " + resourceType);
+                    out.println(records);
+                } else {
+                    out.println("Untraced leak detected " + resourceType);
+                }
+                out.flush();
+            }
+        } catch (IOException e) {
+            LOG.error("Cannot write thread leak dump", e);
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1823,7 +1823,9 @@ flexible messaging model and an intuitive client API.</description>
         <configuration>
           <argLine>${testJacocoAgentArgument} -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=${testHeapDumpPath} -XX:+ExitOnOutOfMemoryError -Xmx${testMaxHeapSize} -XX:+UseZGC
             -Dpulsar.allocator.pooled=true
-            -Dpulsar.allocator.leak_detection=Advanced
+            -Dpulsar.allocator.leak_detection=Paranoid
+            -Dio.netty.leakDetectionLevel=paranoid
+            -Dio.netty.customResourceLeakDetector=org.apache.pulsar.tests.ExitJVMNettyLeakDetector
             -Dio.netty.leakDetection.targetRecords=40
             -Dpulsar.allocator.exit_on_oom=false
             -Dpulsar.allocator.out_of_memory_policy=FallbackToHeap

--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,14 @@ flexible messaging model and an intuitive client API.</description>
       --add-opens java.management/sun.management=ALL-UNNAMED <!--JvmDefaultGCMetricsLogger & MBeanStatsGenerator-->
       --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED <!--MBeanStatsGenerator-->
       --add-opens java.base/jdk.internal.platform=ALL-UNNAMED <!--LinuxInfoUtils-->
+      <!--
+      enable optimized Netty direct memory buffer access
+      https://pulsar.apache.org/docs/4.0.x/client-libraries-java-setup/#enabling-optimized-netty-direct-memory-buffer-access
+      -->
+      --add-opens java.base/java.nio=ALL-UNNAMED
+      --add-opens java.base/jdk.internal.misc=ALL-UNNAMED
+      -Dio.netty.tryReflectionSetAccessible=true
+      -Dorg.apache.pulsar.shade.io.netty.tryReflectionSetAccessible=true
     </test.additional.args>
     <testMaxHeapSize>1300M</testMaxHeapSize>
     <testReuseFork>true</testReuseFork>
@@ -1816,9 +1824,9 @@ flexible messaging model and an intuitive client API.</description>
           <argLine>${testJacocoAgentArgument} -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=${testHeapDumpPath} -XX:+ExitOnOutOfMemoryError -Xmx${testMaxHeapSize} -XX:+UseZGC
             -Dpulsar.allocator.pooled=true
             -Dpulsar.allocator.leak_detection=Advanced
+            -Dio.netty.leakDetection.targetRecords=40
             -Dpulsar.allocator.exit_on_oom=false
             -Dpulsar.allocator.out_of_memory_policy=FallbackToHeap
-            -Dio.netty.tryReflectionSetAccessible=true
             ${test.additional.args}
           </argLine>
           <reuseForks>${testReuseFork}</reuseForks>


### PR DESCRIPTION
- **[improve][test] Enable Netty direct memory buffer access in unit tests**
- **Exit the JVM if buffer leaks are detected**
