### PR TITLE
lh replace v1 topic names in tests with v2 names

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/ServiceUnitUtils.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/ServiceUnitUtils.java
@@ -52,7 +52,7 @@ public final class ServiceUnitUtils {
             Range<Long> range = getHashRange(parts[5]);
             return factory.getBundle(NamespaceName.get(parts[2], parts[3], parts[4]), range);
         } else {
-            // this is a V2 path prop/namespace/hash
+            // this is a V2 path tenant/namespace/hash
             Range<Long> range = getHashRange(parts[4]);
             return factory.getBundle(NamespaceName.get(parts[2], parts[3]), range);
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractReplicator.java
@@ -482,7 +482,7 @@ public abstract class AbstractReplicator implements Replicator {
      *
      * <pre>
      * eg:
-     * if topic : persistent://prop/cluster/ns/my-topic is a partitioned topic with 2 partitions then
+     * if topic : persistent://tenant/ns/my-topic is a partitioned topic with 2 partitions then
      * broker explicitly creates replicator producer for: "my-topic-partition-1" and "my-topic-partition-2".
      *
      * However, if broker tries to start producer with root topic "my-topic" then client-lib internally

--- a/pulsar-broker/src/main/java/org/apache/pulsar/common/naming/NamespaceBundleFactory.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/common/naming/NamespaceBundleFactory.java
@@ -401,9 +401,9 @@ public class NamespaceBundleFactory {
     }
 
     /*
-     * @param path - path for the namespace policies ex. /admin/policies/prop/cluster/namespace
+     * @param path - path for the namespace policies ex. /admin/policies/tenant/namespace
      *
-     * @returns namespace with path, ex. prop/cluster/namespace
+     * @returns namespace with path, ex. tenant/namespace
      */
     public static String getNamespaceFromPoliciesPath(String path) {
         if (path.isEmpty()) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/TopicEventsListenerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/TopicEventsListenerTest.java
@@ -102,9 +102,9 @@ public class TopicEventsListenerTest extends BrokerTestBase {
 
     @BeforeMethod
     protected void setupTest() throws Exception {
-        namespace = "prop/" + UUID.randomUUID();
+        namespace = BrokerTestUtil.newUniqueName("tenant/ns");
         admin.namespaces().createNamespace(namespace, Sets.newHashSet("test"));
-        assertTrue(admin.namespaces().getNamespaces("prop").contains(namespace));
+        assertTrue(admin.namespaces().getNamespaces("tenant").contains(namespace));
         admin.namespaces().setRetention(namespace, new RetentionPolicies(3, 10));
         try (PulsarAdmin admin2 = createPulsarAdmin()) {
             Awaitility.await().untilAsserted(() ->

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
@@ -1132,20 +1132,19 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
                 ClusterData.builder().serviceUrl("http://broker.messaging.east1.example.com:8080").build());
         admin.clusters().createCluster("us-east2",
                 ClusterData.builder().serviceUrl("http://broker.messaging.east2.example.com:8080").build());
-        admin.clusters().createCluster("global", ClusterData.builder().build());
 
         List<String> allClusters = admin.clusters().getClusters();
         Collections.sort(allClusters);
         assertEquals(allClusters,
                 List.of("test", "us-east1", "us-east2", "us-west1", "us-west2", "us-west3", "us-west4"));
 
-        final String property = newUniqueName("peer-prop");
+        final String tenant = newUniqueName("peer-tenant");
         Set<String> allowedClusters = Set.of("us-west1", "us-west2", "us-west3", "us-west4", "us-east1",
-                "us-east2", "global");
-        TenantInfoImpl propConfig = new TenantInfoImpl(Set.of("test"), allowedClusters);
-        admin.tenants().createTenant(property, propConfig);
+                "us-east2", "test");
+        TenantInfoImpl tenantInfo = new TenantInfoImpl(Set.of("test"), allowedClusters);
+        admin.tenants().createTenant(tenant, tenantInfo);
 
-        final String namespace = property + "/global/conflictPeer";
+        final String namespace = tenant + "/conflictPeer";
         admin.namespaces().createNamespace(namespace);
 
         admin.clusters().updatePeerClusterNames("us-west1",

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiGetLastMessageIdTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiGetLastMessageIdTest.java
@@ -64,10 +64,10 @@ public class AdminApiGetLastMessageIdTest extends MockedPulsarServiceBaseTest {
     protected void setup() throws Exception {
         super.internalSetup();
         admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(brokerUrl.toString()).build());
-        admin.tenants().createTenant("prop",
+        admin.tenants().createTenant("tenant",
                 new TenantInfoImpl(Set.of("appid1"), Set.of("test")));
-        admin.namespaces().createNamespace("prop/ns-abc");
-        admin.namespaces().setNamespaceReplicationClusters("prop/ns-abc", Set.of("test"));
+        admin.namespaces().createNamespace("tenant/ns-abc");
+        admin.namespaces().setNamespaceReplicationClusters("tenant/ns-abc", Set.of("test"));
         persistentTopics = spy(PersistentTopics.class);
         persistentTopics.setServletContext(new MockServletContext());
         persistentTopics.setPulsar(pulsar);
@@ -172,7 +172,7 @@ public class AdminApiGetLastMessageIdTest extends MockedPulsarServiceBaseTest {
         }
 
         String key = "legendtkl";
-        final String topicName = "persistent://prop/ns-abc/my-topic";
+        final String topicName = "persistent://tenant/ns-abc/my-topic";
         final String messagePredicate = "my-message-" + key + "-";
         final int numberOfMessages = 30;
 
@@ -188,7 +188,7 @@ public class AdminApiGetLastMessageIdTest extends MockedPulsarServiceBaseTest {
             producer.send(message.getBytes());
         }
 
-        persistentTopics.getLastMessageId(asyncResponse, "prop", "ns-abc", "my-topic", true);
+        persistentTopics.getLastMessageId(asyncResponse, "tenant", "ns-abc", "my-topic", true);
         Awaitility.await().until(() -> id[0] != null);
         Assert.assertTrue(((MessageIdImpl) id[0]).getLedgerId() >= 0);
         Assert.assertEquals(numberOfMessages - 1, ((MessageIdImpl) id[0]).getEntryId());
@@ -200,7 +200,7 @@ public class AdminApiGetLastMessageIdTest extends MockedPulsarServiceBaseTest {
             String message = messagePredicate + i;
             producer.send(message.getBytes());
         }
-        persistentTopics.getLastMessageId(asyncResponse, "prop", "ns-abc", "my-topic", true);
+        persistentTopics.getLastMessageId(asyncResponse, "tenant", "ns-abc", "my-topic", true);
         while (id[0] == messageId) {
             Thread.sleep(1);
         }
@@ -217,7 +217,7 @@ public class AdminApiGetLastMessageIdTest extends MockedPulsarServiceBaseTest {
      */
     @Test
     public void testGetLastMessageIdWhenTopicWithoutData() throws Exception {
-        final String topic = "persistent://prop/ns-abc/testGetLastMessageIdWhenTopicWithoutData-" + UUID.randomUUID();
+        final String topic = "persistent://tenant/ns-abc/testGetLastMessageIdWhenTopicWithoutData-" + UUID.randomUUID();
         Producer<String> producer = pulsarClient.newProducer(Schema.STRING)
                 .topic(topic)
                 .create();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminResourceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminResourceTest.java
@@ -119,7 +119,7 @@ public class AdminResourceTest extends BrokerTestBase {
 
     @Test
     public void testValidatePartitionedTopicMetadata() throws Exception {
-        String tenant = "prop";
+        String tenant = "tenant";
         String namespace = "ns-abc";
         String partitionedTopic = "partitionedTopic";
         String nonPartitionedTopic = "notPartitionedTopic";

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesTest.java
@@ -233,19 +233,19 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
                 .validateTenantOperation(this.testOtherTenant, null);
 
         doThrow(new RestException(Status.UNAUTHORIZED, "unauthorized")).when(namespaces)
-                .validateNamespacePolicyOperation(NamespaceName.get("other-tenant/use/test-namespace-1"),
+                .validateNamespacePolicyOperation(NamespaceName.get("other-tenant/test-namespace-1"),
                         PolicyName.PERSISTENCE, PolicyOperation.WRITE);
 
         doThrow(new RestException(Status.UNAUTHORIZED, "unauthorized")).when(namespaces)
-                .validateNamespacePolicyOperation(NamespaceName.get("other-tenant/use/test-namespace-1"),
+                .validateNamespacePolicyOperation(NamespaceName.get("other-tenant/test-namespace-1"),
                         PolicyName.RETENTION, PolicyOperation.WRITE);
 
         doReturn(FutureUtil.failedFuture(new RestException(Status.UNAUTHORIZED, "unauthorized"))).when(namespaces)
-                .validateNamespacePolicyOperationAsync(NamespaceName.get("other-tenant/use/test-namespace-1"),
+                .validateNamespacePolicyOperationAsync(NamespaceName.get("other-tenant/test-namespace-1"),
                         PolicyName.PERSISTENCE, PolicyOperation.WRITE);
 
         doReturn(FutureUtil.failedFuture(new RestException(Status.UNAUTHORIZED, "unauthorized"))).when(namespaces)
-                .validateNamespacePolicyOperationAsync(NamespaceName.get("other-tenant/use/test-namespace-1"),
+                .validateNamespacePolicyOperationAsync(NamespaceName.get("other-tenant/test-namespace-1"),
                         PolicyName.RETENTION, PolicyOperation.WRITE);
 
         nsSvc = pulsar.getNamespaceService();
@@ -296,7 +296,7 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
 
         mockZooKeeperGlobal.failConditional(Code.SESSIONEXPIRED, (op, path) -> {
                 return op == MockZooKeeper.Op.CREATE
-                    && path.equals("/admin/policies/my-tenant/use/my-namespace-3");
+                    && path.equals("/admin/policies/my-tenant/my-namespace-3");
             });
         try {
             asyncRequests(response -> namespaces.createNamespace(response, this.testTenant,
@@ -370,7 +370,7 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
 
         mockZooKeeperGlobal.failConditional(Code.SESSIONEXPIRED, (op, path) -> {
                 return op == MockZooKeeper.Op.GET_CHILDREN
-                    && path.equals("/admin/policies/my-tenant/use");
+                    && path.equals("/admin/policies/my-tenant");
             });
         try {
             namespaces.getNamespacesForCluster(this.testTenant, this.testLocalCluster);
@@ -1106,7 +1106,7 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
     @Test
     public void testValidateAdminAccessOnTenant() throws Exception {
         try {
-            final String tenant = "prop";
+            final String tenant = "tenant";
             pulsar.getConfiguration().setAuthenticationEnabled(true);
             pulsar.getConfiguration().setAuthorizationEnabled(true);
             pulsar.getPulsarResources().getTenantResources().createTenant(tenant,
@@ -2207,7 +2207,7 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
 
         mockZooKeeperGlobal.failConditional(Code.SESSIONEXPIRED, (op, path) -> {
             return op == MockZooKeeper.Op.CREATE
-                    && path.equals("/admin/policies/my-tenant/use/my-namespace-3");
+                    && path.equals("/admin/policies/my-tenant/my-namespace-3");
         });
         try {
             asyncRequests(response -> namespaces.createNamespace(response, this.testTenant,

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesV2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesV2Test.java
@@ -107,11 +107,11 @@ public class NamespacesV2Test extends MockedPulsarServiceBaseTest {
         createTestNamespaces(this.testLocalNamespaces);
 
         doThrow(new RestException(Response.Status.UNAUTHORIZED, "unauthorized")).when(namespaces)
-                .validateNamespacePolicyOperation(NamespaceName.get("other-tenant/use/test-namespace-1"),
+                .validateNamespacePolicyOperation(NamespaceName.get("other-tenant/test-namespace-1"),
                         PolicyName.PERSISTENCE, PolicyOperation.WRITE);
 
         doThrow(new RestException(Response.Status.UNAUTHORIZED, "unauthorized")).when(namespaces)
-                .validateNamespacePolicyOperation(NamespaceName.get("other-tenant/use/test-namespace-1"),
+                .validateNamespacePolicyOperation(NamespaceName.get("other-tenant/test-namespace-1"),
                         PolicyName.RETENTION, PolicyOperation.WRITE);
 
         nsSvc = pulsar.getNamespaceService();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImplTest.java
@@ -864,7 +864,7 @@ public class ModularLoadManagerImplTest {
 
         final String cluster = "use";
         final String tenant = "my-tenant";
-        final String namespace = "my-tenant/use/my-ns";
+        final String namespace = "my-tenant/my-ns";
         final String bundle = "0x00000000_0xffffffff";
         final String brokerHost = pulsar1.getAdvertisedAddress();
         final String brokerAddress = brokerHost  + ":8080";

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/NamespaceCreateBundlesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/NamespaceCreateBundlesTest.java
@@ -21,10 +21,10 @@ package org.apache.pulsar.broker.namespace;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
-import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import lombok.Cleanup;
+import org.apache.pulsar.broker.BrokerTestUtil;
 import org.apache.pulsar.broker.service.BrokerTestBase;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.ProducerBuilder;
@@ -54,7 +54,7 @@ public class NamespaceCreateBundlesTest extends BrokerTestBase {
 
     @Test
     public void testCreateNamespaceWithDefaultBundles() throws Exception {
-        String namespaceName = "prop/" + UUID.randomUUID().toString();
+        String namespaceName = BrokerTestUtil.newUniqueName("tenant/ns");
 
         admin.namespaces().createNamespace(namespaceName);
 
@@ -65,7 +65,7 @@ public class NamespaceCreateBundlesTest extends BrokerTestBase {
 
     @Test
     public void testSplitBundleUpdatesLocalPoliciesWithoutOverwriting() throws Exception {
-        String namespaceName = "prop/" + UUID.randomUUID().toString();
+        String namespaceName = BrokerTestUtil.newUniqueName("tenant/ns");
         String topicName = "persistent://" + namespaceName + "/my-topic5";
 
         admin.namespaces().createNamespace(namespaceName);
@@ -87,7 +87,7 @@ public class NamespaceCreateBundlesTest extends BrokerTestBase {
 
     @Test
     public void testBundleSplitListener() throws Exception {
-        String namespaceName = "prop/" + UUID.randomUUID().toString();
+        String namespaceName = BrokerTestUtil.newUniqueName("tenant/ns");
         String topicName = "persistent://" + namespaceName + "/my-topic5";
         admin.namespaces().createNamespace(namespaceName);
         @Cleanup

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/NamespaceOwnershipListenerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/NamespaceOwnershipListenerTest.java
@@ -23,10 +23,10 @@ import static org.mockito.Mockito.spy;
 import static org.testng.Assert.assertTrue;
 import com.google.common.collect.Sets;
 import java.util.List;
-import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.pulsar.broker.BrokerTestUtil;
 import org.apache.pulsar.broker.service.BrokerTestBase;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClientException;
@@ -59,7 +59,7 @@ public class NamespaceOwnershipListenerTest extends BrokerTestBase {
         final AtomicBoolean onLoad = new AtomicBoolean(false);
         final AtomicBoolean unLoad = new AtomicBoolean(false);
 
-        final String namespace = "prop/" + UUID.randomUUID().toString();
+        final String namespace = BrokerTestUtil.newUniqueName("tenant/ns");
 
         pulsar.getNamespaceService().addNamespaceBundleOwnershipListener(new NamespaceBundleOwnershipListener() {
 
@@ -82,7 +82,7 @@ public class NamespaceOwnershipListenerTest extends BrokerTestBase {
         });
 
         admin.namespaces().createNamespace(namespace, Sets.newHashSet("test"));
-        assertTrue(admin.namespaces().getNamespaces("prop").contains(namespace));
+        assertTrue(admin.namespaces().getNamespaces("tenant").contains(namespace));
 
         final String topic = "persistent://" + namespace + "/os-0";
 
@@ -123,9 +123,9 @@ public class NamespaceOwnershipListenerTest extends BrokerTestBase {
 
     @Test
     public void testGetAllPartitions() throws Exception {
-        final String namespace = "prop/" + UUID.randomUUID().toString();
+        final String namespace = BrokerTestUtil.newUniqueName("tenant/ns");
         admin.namespaces().createNamespace(namespace, Sets.newHashSet("test"));
-        assertTrue(admin.namespaces().getNamespaces("prop").contains(namespace));
+        assertTrue(admin.namespaces().getNamespaces("tenant").contains(namespace));
 
         final String topicName = "persistent://" + namespace + "/os";
         admin.topics().createPartitionedTopic(topicName, 6);
@@ -149,7 +149,7 @@ public class NamespaceOwnershipListenerTest extends BrokerTestBase {
         final AtomicInteger onLoad = new AtomicInteger(0);
         final AtomicInteger unLoad = new AtomicInteger(0);
 
-        final String namespace = "prop/" + UUID.randomUUID().toString();
+        final String namespace = BrokerTestUtil.newUniqueName("tenant/ns");
 
         pulsar.getNamespaceService().addNamespaceBundleOwnershipListener(new NamespaceBundleOwnershipListener() {
             @Override
@@ -171,7 +171,7 @@ public class NamespaceOwnershipListenerTest extends BrokerTestBase {
         });
 
         admin.namespaces().createNamespace(namespace, Sets.newHashSet("test"));
-        assertTrue(admin.namespaces().getNamespaces("prop").contains(namespace));
+        assertTrue(admin.namespaces().getNamespaces("tenant").contains(namespace));
 
         final String topic = "persistent://" + namespace + "/os-0";
         Producer<byte[]> producer = pulsarClient.newProducer()

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/NamespaceServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/NamespaceServiceTest.java
@@ -289,7 +289,7 @@ public class NamespaceServiceTest extends BrokerTestBase {
         ownership.set(pulsar.getNamespaceService(), ownershipCache);
 
         NamespaceService namespaceService = pulsar.getNamespaceService();
-        NamespaceName nsname = NamespaceName.get("prop/use/ns1");
+        NamespaceName nsname = NamespaceName.get("tenant/ns1");
         NamespaceBundles bundles = namespaceService.getNamespaceBundleFactory().getBundles(nsname);
 
         NamespaceBundle bundle = bundles.getBundles().get(0);
@@ -584,7 +584,7 @@ public class NamespaceServiceTest extends BrokerTestBase {
 
     @Test
     public void testSplitLargestBundle() throws Exception {
-        String namespace = "prop/test/ns-abc2";
+        String namespace = "tenant/test/ns-abc2";
         String topic = "persistent://" + namespace + "/t1-";
         int totalTopics = 100;
 
@@ -632,7 +632,7 @@ public class NamespaceServiceTest extends BrokerTestBase {
     public void testSplitBUndleWithNoBundle() throws  Exception {
         conf.setLoadManagerClassName(ModularLoadManagerImpl.class.getName());
         restartBroker();
-        String namespace = "prop/test/ns-abc2";
+        String namespace = "tenant/test/ns-abc2";
 
         BundlesData bundleData = BundlesData.builder().numBundles(10).build();
         admin.namespaces().createNamespace(namespace, bundleData);
@@ -659,7 +659,7 @@ public class NamespaceServiceTest extends BrokerTestBase {
 
         conf.setLoadManagerClassName(ModularLoadManagerImpl.class.getName());
         restartBroker();
-        String namespace = "prop/test/ns-abc2";
+        String namespace = "tenant/test/ns-abc2";
         String topic = "persistent://" + namespace + "/t1-";
         int totalTopics = 100;
 
@@ -778,7 +778,7 @@ public class NamespaceServiceTest extends BrokerTestBase {
 
     @Test
     public void testModularLoadManagerRemoveBundleAndLoad() throws Exception {
-        final String namespace = "prop/ns-abc";
+        final String namespace = "tenant/ns-abc";
         final String bundleName = namespace + "/0x00000000_0xffffffff";
         final String topic1 = "persistent://" + namespace + "/topic1";
         final String topic2 = "persistent://" + namespace + "/topic2";
@@ -962,7 +962,7 @@ public class NamespaceServiceTest extends BrokerTestBase {
 
     @Test(dataProvider = "topicDomain")
     public void checkTopicExistsForNonPartitionedTopic(String topicDomain) throws Exception {
-        TopicName topicName = TopicName.get(topicDomain, "prop", "ns-abc", "topic-" + UUID.randomUUID());
+        TopicName topicName = TopicName.get(topicDomain, "tenant", "ns-abc", "topic-" + UUID.randomUUID());
         admin.topics().createNonPartitionedTopic(topicName.toString());
         CompletableFuture<TopicExistsInfo> result = pulsar.getNamespaceService().checkTopicExistsAsync(topicName);
         assertThat(result)
@@ -977,7 +977,7 @@ public class NamespaceServiceTest extends BrokerTestBase {
 
     @Test(dataProvider = "topicDomain")
     public void checkTopicExistsForPartitionedTopic(String topicDomain) throws Exception {
-        TopicName topicName = TopicName.get(topicDomain, "prop", "ns-abc", "topic-" + UUID.randomUUID());
+        TopicName topicName = TopicName.get(topicDomain, "tenant", "ns-abc", "topic-" + UUID.randomUUID());
         admin.topics().createPartitionedTopic(topicName.toString(), 3);
 
         // Check the topic exists by the partitions.
@@ -1016,7 +1016,7 @@ public class NamespaceServiceTest extends BrokerTestBase {
 
     @Test(dataProvider = "topicDomain")
     public void checkTopicExistsForNonExistentNonPartitionedTopic(String topicDomain) {
-        TopicName topicName = TopicName.get(topicDomain, "prop", "ns-abc", "topic-" + UUID.randomUUID());
+        TopicName topicName = TopicName.get(topicDomain, "tenant", "ns-abc", "topic-" + UUID.randomUUID());
         CompletableFuture<TopicExistsInfo> result = pulsar.getNamespaceService().checkTopicExistsAsync(topicName);
         assertThat(result)
                 .succeedsWithin(3, TimeUnit.SECONDS)
@@ -1033,7 +1033,7 @@ public class NamespaceServiceTest extends BrokerTestBase {
     @Test(dataProvider = "topicDomain")
     public void checkTopicExistsForNonExistentPartitionTopic(String topicDomain) {
         TopicName topicName =
-                TopicName.get(topicDomain, "prop", "ns-abc", "topic-" + UUID.randomUUID() + "-partition-10");
+                TopicName.get(topicDomain, "tenant", "ns-abc", "topic-" + UUID.randomUUID() + "-partition-10");
         CompletableFuture<TopicExistsInfo> result = pulsar.getNamespaceService().checkTopicExistsAsync(topicName);
         assertThat(result)
                 .succeedsWithin(3, TimeUnit.SECONDS)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/NamespaceUnloadingTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/NamespaceUnloadingTest.java
@@ -50,33 +50,33 @@ public class NamespaceUnloadingTest extends BrokerTestBase {
 
     @Test
     public void testUnloadNotLoadedNamespace() throws Exception {
-        admin.namespaces().createNamespace("prop/ns-test-1");
-        admin.namespaces().setNamespaceReplicationClusters("prop/ns-test-1", Sets.newHashSet("test"));
+        admin.namespaces().createNamespace("tenant/ns-test-1");
+        admin.namespaces().setNamespaceReplicationClusters("tenant/ns-test-1", Sets.newHashSet("test"));
 
-        assertTrue(admin.namespaces().getNamespaces("prop").contains("prop/ns-test-1"));
+        assertTrue(admin.namespaces().getNamespaces("tenant").contains("tenant/ns-test-1"));
 
-        admin.namespaces().unload("prop/ns-test-1");
+        admin.namespaces().unload("tenant/ns-test-1");
     }
 
     @Test
     public void testUnloadPartiallyLoadedNamespace() throws Exception {
-        admin.namespaces().createNamespace("prop/ns-test-2", 16);
-        admin.namespaces().setNamespaceReplicationClusters("prop/ns-test-2", Sets.newHashSet("test"));
+        admin.namespaces().createNamespace("tenant/ns-test-2", 16);
+        admin.namespaces().setNamespaceReplicationClusters("tenant/ns-test-2", Sets.newHashSet("test"));
 
-        Producer<byte[]> producer = pulsarClient.newProducer().topic("persistent://prop/ns-test-2/my-topic")
+        Producer<byte[]> producer = pulsarClient.newProducer().topic("persistent://tenant/ns-test-2/my-topic")
                 .create();
 
-        assertTrue(admin.namespaces().getNamespaces("prop").contains("prop/ns-test-2"));
+        assertTrue(admin.namespaces().getNamespaces("tenant").contains("tenant/ns-test-2"));
 
-        admin.namespaces().unload("prop/ns-test-2");
+        admin.namespaces().unload("tenant/ns-test-2");
 
         producer.close();
     }
 
     @Test
     public void testUnloadWithTopicCreation() throws PulsarAdminException, PulsarClientException {
-        final String namespaceName = "prop/ns_unloading";
-        final String topicName = "persistent://prop/ns_unloading/with_topic_creation";
+        final String namespaceName = "tenant/ns_unloading";
+        final String topicName = "persistent://tenant/ns_unloading/with_topic_creation";
         final int partitions = 5;
         admin.namespaces().createNamespace(namespaceName, 1);
         admin.topics().createPartitionedTopic(topicName, partitions);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/resourcegroup/ResourceGroupRateLimiterTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/resourcegroup/ResourceGroupRateLimiterTest.java
@@ -42,8 +42,8 @@ public class ResourceGroupRateLimiterTest extends BrokerTestBase {
     final String rgName = "testRG";
     org.apache.pulsar.common.policies.data.ResourceGroup testAddRg =
     new org.apache.pulsar.common.policies.data.ResourceGroup();
-    final String namespaceName = "prop/ns-abc";
-    final String persistentTopicString = "persistent://prop/ns-abc/test-topic";
+    final String namespaceName = "tenant/ns-abc";
+    final String persistentTopicString = "persistent://tenant/ns-abc/test-topic";
     static final int MESSAGE_SIZE = 10;
 
     @BeforeClass

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BatchMessageTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BatchMessageTest.java
@@ -115,7 +115,7 @@ public class BatchMessageTest extends BrokerTestBase {
             throws Exception {
         int numMsgs = 50;
         int numMsgsInBatch = numMsgs / 2;
-        final String topicName = "persistent://prop/ns-abc/testSimpleBatchProducerWithFixedBatchSize-"
+        final String topicName = "persistent://tenant/ns-abc/testSimpleBatchProducerWithFixedBatchSize-"
                 + UUID.randomUUID();
         final String subscriptionName = "sub-1" + compressionType.toString();
 
@@ -163,7 +163,7 @@ public class BatchMessageTest extends BrokerTestBase {
             throws Exception {
         int numMsgs = 50;
         int numBytesInBatch = 600;
-        final String topicName = "persistent://prop/ns-abc/testSimpleBatchProducerWithFixedBatchSize-"
+        final String topicName = "persistent://tenant/ns-abc/testSimpleBatchProducerWithFixedBatchSize-"
                 + UUID.randomUUID();
         final String subscriptionName = "sub-1" + compressionType.toString();
 
@@ -213,7 +213,7 @@ public class BatchMessageTest extends BrokerTestBase {
     public void testSimpleBatchProducerWithFixedBatchTime(CompressionType compressionType, BatcherBuilder builder)
             throws Exception {
         int numMsgs = 100;
-        final String topicName = "persistent://prop/ns-abc/testSimpleBatchProducerWithFixedBatchTime-"
+        final String topicName = "persistent://tenant/ns-abc/testSimpleBatchProducerWithFixedBatchTime-"
                 + UUID.randomUUID();
         final String subscriptionName = "time-sub-1" + compressionType.toString();
 
@@ -251,7 +251,7 @@ public class BatchMessageTest extends BrokerTestBase {
     public void testSimpleBatchProducerWithFixedBatchSizeAndTime(CompressionType compressionType,
                                                                  BatcherBuilder builder) throws Exception {
         int numMsgs = 100;
-        final String topicName = "persistent://prop/ns-abc/testSimpleBatchProducerWithFixedBatchSizeAndTime-"
+        final String topicName = "persistent://tenant/ns-abc/testSimpleBatchProducerWithFixedBatchSizeAndTime-"
                 + UUID.randomUUID();
         final String subscriptionName = "time-size-sub-1" + compressionType.toString();
 
@@ -290,7 +290,7 @@ public class BatchMessageTest extends BrokerTestBase {
             throws Exception {
         int numMsgs = 50;
         int numMsgsInBatch = numMsgs / 2;
-        final String topicName = "persistent://prop/ns-abc/testBatchProducerWithLargeMessage-" + UUID.randomUUID();
+        final String topicName = "persistent://tenant/ns-abc/testBatchProducerWithLargeMessage-" + UUID.randomUUID();
         final String subscriptionName = "large-message-sub-1" + compressionType.toString();
 
         Consumer<byte[]> consumer = pulsarClient.newConsumer()
@@ -352,7 +352,7 @@ public class BatchMessageTest extends BrokerTestBase {
             throws Exception {
         int numMsgs = 500;
         int numMsgsInBatch = numMsgs / 20;
-        final String topicName = "persistent://prop/ns-abc/testSimpleBatchProducerConsumer-" + UUID.randomUUID();
+        final String topicName = "persistent://tenant/ns-abc/testSimpleBatchProducerConsumer-" + UUID.randomUUID();
         final String subscriptionName = "pc-sub-1" + compressionType.toString();
 
         Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName(subscriptionName)
@@ -412,7 +412,7 @@ public class BatchMessageTest extends BrokerTestBase {
     public void testSimpleBatchSyncProducerWithFixedBatchSize(BatcherBuilder builder) throws Exception {
         int numMsgs = 10;
         int numMsgsInBatch = numMsgs / 2;
-        final String topicName = "persistent://prop/ns-abc/testSimpleBatchSyncProducerWithFixedBatchSize-"
+        final String topicName = "persistent://tenant/ns-abc/testSimpleBatchSyncProducerWithFixedBatchSize-"
                 + UUID.randomUUID();
         final String subscriptionName = "syncsub-1";
 
@@ -457,7 +457,7 @@ public class BatchMessageTest extends BrokerTestBase {
         // Send enough messages to trigger one batch by size and then have a remaining message in the batch container
         int numMsgs = 3;
         int numMsgsInBatch = 2;
-        final String topicName = "persistent://prop/ns-abc/testSimpleBatchSyncProducerWithFixedBatchSize-"
+        final String topicName = "persistent://tenant/ns-abc/testSimpleBatchSyncProducerWithFixedBatchSize-"
                 + UUID.randomUUID();
         final String subscriptionName = "syncsub-1";
 
@@ -510,7 +510,7 @@ public class BatchMessageTest extends BrokerTestBase {
     public void testSimpleBatchProducerConsumer1kMessages(BatcherBuilder builder) throws Exception {
         int numMsgs = 2000;
         int numMsgsInBatch = 4;
-        final String topicName = "persistent://prop/ns-abc/testSimpleBatchProducerConsumer1kMessages-"
+        final String topicName = "persistent://tenant/ns-abc/testSimpleBatchProducerConsumer1kMessages-"
                 + UUID.randomUUID();
         final String subscriptionName = "pc1k-sub-1";
 
@@ -576,7 +576,7 @@ public class BatchMessageTest extends BrokerTestBase {
     public void testOutOfOrderAcksForBatchMessage() throws Exception {
         int numMsgs = 40;
         int numMsgsInBatch = numMsgs / 4;
-        final String topicName = "persistent://prop/ns-abc/testOutOfOrderAcksForBatchMessage";
+        final String topicName = "persistent://tenant/ns-abc/testOutOfOrderAcksForBatchMessage";
         final String subscriptionName = "oooack-sub-1";
 
         Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName(subscriptionName)
@@ -643,7 +643,7 @@ public class BatchMessageTest extends BrokerTestBase {
     public void testNonBatchCumulativeAckAfterBatchPublish(BatcherBuilder builder) throws Exception {
         int numMsgs = 10;
         int numMsgsInBatch = numMsgs;
-        final String topicName = "persistent://prop/ns-abc/testNonBatchCumulativeAckAfterBatchPublish-"
+        final String topicName = "persistent://tenant/ns-abc/testNonBatchCumulativeAckAfterBatchPublish-"
                 + UUID.randomUUID();
         final String subscriptionName = "nbcaabp-sub-1";
 
@@ -697,7 +697,7 @@ public class BatchMessageTest extends BrokerTestBase {
     public void testBatchAndNonBatchCumulativeAcks(BatcherBuilder builder) throws Exception {
         int numMsgs = 50;
         int numMsgsInBatch = numMsgs / 10;
-        final String topicName = "persistent://prop/ns-abc/testBatchAndNonBatchCumulativeAcks-" + UUID.randomUUID();
+        final String topicName = "persistent://tenant/ns-abc/testBatchAndNonBatchCumulativeAcks-" + UUID.randomUUID();
         final String subscriptionName = "bnb-sub-1";
 
         Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName(subscriptionName)
@@ -769,7 +769,7 @@ public class BatchMessageTest extends BrokerTestBase {
     @Test(dataProvider = "containerBuilder")
     public void testConcurrentBatchMessageAck(BatcherBuilder builder) throws Exception {
         int numMsgs = 10;
-        final String topicName = "persistent://prop/ns-abc/testConcurrentAck-" + UUID.randomUUID();
+        final String topicName = "persistent://tenant/ns-abc/testConcurrentAck-" + UUID.randomUUID();
         final String subscriptionName = "sub-1";
 
         Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName(subscriptionName)
@@ -826,7 +826,7 @@ public class BatchMessageTest extends BrokerTestBase {
     @Test
     public void testOrderingOfKeyBasedBatchMessageContainer()
             throws PulsarClientException, ExecutionException, InterruptedException {
-        final String topicName = "persistent://prop/ns-abc/testKeyBased";
+        final String topicName = "persistent://tenant/ns-abc/testKeyBased";
         final String subscriptionName = "sub-1";
         Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName)
                 .batchingMaxPublishDelay(5, TimeUnit.SECONDS)
@@ -892,7 +892,7 @@ public class BatchMessageTest extends BrokerTestBase {
 
     @Test(dataProvider = "containerBuilder")
     public void testBatchSendOneMessage(BatcherBuilder builder) throws Exception {
-        final String topicName = "persistent://prop/ns-abc/testBatchSendOneMessage-" + UUID.randomUUID();
+        final String topicName = "persistent://tenant/ns-abc/testBatchSendOneMessage-" + UUID.randomUUID();
         final String subscriptionName = "sub-1";
 
         Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName(subscriptionName)
@@ -926,7 +926,7 @@ public class BatchMessageTest extends BrokerTestBase {
     public void testRetrieveSequenceIdGenerated(BatcherBuilder builder) throws Exception {
 
         int numMsgs = 10;
-        final String topicName = "persistent://prop/ns-abc/testRetrieveSequenceIdGenerated-" + UUID.randomUUID();
+        final String topicName = "persistent://tenant/ns-abc/testRetrieveSequenceIdGenerated-" + UUID.randomUUID();
         final String subscriptionName = "sub-1";
 
         Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName(subscriptionName)
@@ -959,7 +959,7 @@ public class BatchMessageTest extends BrokerTestBase {
     public void testRetrieveSequenceIdSpecify(BatcherBuilder builder) throws Exception {
 
         int numMsgs = 10;
-        final String topicName = "persistent://prop/ns-abc/testRetrieveSequenceIdSpecify-" + UUID.randomUUID();
+        final String topicName = "persistent://tenant/ns-abc/testRetrieveSequenceIdSpecify-" + UUID.randomUUID();
         final String subscriptionName = "sub-1";
 
         Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName(subscriptionName)
@@ -992,7 +992,7 @@ public class BatchMessageTest extends BrokerTestBase {
     public void testSendOverSizeMessage(CompressionType compressionType, BatcherBuilder builder) throws Exception {
 
         final int numMsgs = 10;
-        final String topicName = "persistent://prop/ns-abc/testSendOverSizeMessage-" + UUID.randomUUID();
+        final String topicName = "persistent://tenant/ns-abc/testSendOverSizeMessage-" + UUID.randomUUID();
 
         Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName)
                 .batchingMaxPublishDelay(1, TimeUnit.MILLISECONDS)
@@ -1021,7 +1021,7 @@ public class BatchMessageTest extends BrokerTestBase {
 
         int numMsgs = 1000;
         int batchMessages = 10;
-        final String topicName = "persistent://prop/ns-abc/testBatchMessageDispatchingAccordingToPermits-"
+        final String topicName = "persistent://tenant/ns-abc/testBatchMessageDispatchingAccordingToPermits-"
                 + UUID.randomUUID();
         final String subscriptionName = "bmdap-sub-1";
 
@@ -1059,7 +1059,7 @@ public class BatchMessageTest extends BrokerTestBase {
     private void testDecreaseUnAckMessageCountWithAckReceipt(SubscriptionType subType,
                                                              boolean enableBatch) throws Exception {
         final int messageCount = 50;
-        final String topicName = "persistent://prop/ns-abc/testDecreaseWithAckReceipt" + UUID.randomUUID();
+        final String topicName = "persistent://tenant/ns-abc/testDecreaseWithAckReceipt" + UUID.randomUUID();
         final String subscriptionName = "sub-batch-1";
         @Cleanup
         ConsumerImpl<byte[]> consumer = (ConsumerImpl<byte[]>) pulsarClient

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BatchMessageWithBatchIndexLevelTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BatchMessageWithBatchIndexLevelTest.java
@@ -76,7 +76,7 @@ public class BatchMessageWithBatchIndexLevelTest extends BatchMessageTest {
     @SneakyThrows
     public void testBatchMessageAck() {
         int numMsgs = 40;
-        final String topicName = "persistent://prop/ns-abc/batchMessageAck-" + UUID.randomUUID();
+        final String topicName = "persistent://tenant/ns-abc/batchMessageAck-" + UUID.randomUUID();
         final String subscriptionName = "sub-batch-1";
 
         @Cleanup
@@ -149,7 +149,7 @@ public class BatchMessageWithBatchIndexLevelTest extends BatchMessageTest {
     @Test(dataProvider = "enabledBatchSend")
     @SneakyThrows
     public void testBatchMessageNAck(boolean enabledBatchSend) {
-        final String topicName = BrokerTestUtil.newUniqueName("persistent://prop/ns-abc/tp");
+        final String topicName = BrokerTestUtil.newUniqueName("persistent://tenant/ns-abc/tp");
         final String subscriptionName = "s1";
         ConsumerImpl<byte[]> consumer = (ConsumerImpl<byte[]>) pulsarClient.newConsumer().topic(topicName)
                 .subscriptionName(subscriptionName)
@@ -201,7 +201,7 @@ public class BatchMessageWithBatchIndexLevelTest extends BatchMessageTest {
 
     @Test
     public void testBatchMessageMultiNegtiveAck() throws Exception{
-        final String topicName = "persistent://prop/ns-abc/batchMessageMultiNegtiveAck-" + UUID.randomUUID();
+        final String topicName = "persistent://tenant/ns-abc/batchMessageMultiNegtiveAck-" + UUID.randomUUID();
         final String subscriptionName = "sub-negtive-1";
 
         @Cleanup
@@ -243,7 +243,7 @@ public class BatchMessageWithBatchIndexLevelTest extends BatchMessageTest {
         });
 
         // Test negtive ack with sleep
-        final String topicName2 = "persistent://prop/ns-abc/batchMessageMultiNegtiveAck2-" + UUID.randomUUID();
+        final String topicName2 = "persistent://tenant/ns-abc/batchMessageMultiNegtiveAck2-" + UUID.randomUUID();
         final String subscriptionName2 = "sub-negtive-2";
         @Cleanup
         Consumer<String> consumer2 = pulsarClient.newConsumer(Schema.STRING)
@@ -286,7 +286,7 @@ public class BatchMessageWithBatchIndexLevelTest extends BatchMessageTest {
     @Test
     public void testAckMessageWithNotOwnerConsumerUnAckMessageCount() throws Exception {
         final String subName = "test";
-        final String topicName = "persistent://prop/ns-abc/testAckMessageWithNotOwnerConsumerUnAckMessageCount-"
+        final String topicName = "persistent://tenant/ns-abc/testAckMessageWithNotOwnerConsumerUnAckMessageCount-"
                 + UUID.randomUUID();
 
         @Cleanup
@@ -363,7 +363,7 @@ public class BatchMessageWithBatchIndexLevelTest extends BatchMessageTest {
 
     @Test
     public void testNegativeAckAndLongAckDelayWillNotLeadRepeatConsume() throws Exception {
-        final String topicName = BrokerTestUtil.newUniqueName("persistent://prop/ns-abc/tp_");
+        final String topicName = BrokerTestUtil.newUniqueName("persistent://tenant/ns-abc/tp_");
         final String subscriptionName = "s1";
         final int redeliveryDelaySeconds = 2;
 
@@ -440,7 +440,7 @@ public class BatchMessageWithBatchIndexLevelTest extends BatchMessageTest {
 
     @Test
     public void testMixIndexAndNonIndexUnAckMessageCount() throws Exception {
-        final String topicName = "persistent://prop/ns-abc/testMixIndexAndNonIndexUnAckMessageCount-";
+        final String topicName = "persistent://tenant/ns-abc/testMixIndexAndNonIndexUnAckMessageCount-";
 
         @Cleanup
         Producer<byte[]> producer = pulsarClient.newProducer()
@@ -475,7 +475,7 @@ public class BatchMessageWithBatchIndexLevelTest extends BatchMessageTest {
 
     @Test
     public void testUnAckMessagesWhenConcurrentDeliveryAndAck() throws Exception {
-        final String topicName = BrokerTestUtil.newUniqueName("persistent://prop/ns-abc/tp");
+        final String topicName = BrokerTestUtil.newUniqueName("persistent://tenant/ns-abc/tp");
         final String subName = "s1";
         final int receiverQueueSize = 500;
         admin.topics().createNonPartitionedTopic(topicName);
@@ -648,7 +648,7 @@ public class BatchMessageWithBatchIndexLevelTest extends BatchMessageTest {
      */
     @Test
     public void testPermitsIfHalfAckBatchMessage() throws Exception {
-        final String topicName = BrokerTestUtil.newUniqueName("persistent://prop/ns-abc/tp");
+        final String topicName = BrokerTestUtil.newUniqueName("persistent://tenant/ns-abc/tp");
         final String subName = "s1";
         final int receiverQueueSize = 1000;
         final int ackedMessagesCountInTheFistStep = 2;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BkEnsemblesTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BkEnsemblesTestBase.java
@@ -104,7 +104,7 @@ public abstract class BkEnsemblesTestBase extends TestRetrySupport {
 
             admin.clusters().createCluster("usc", ClusterData.builder()
                     .serviceUrl(pulsar.getWebServiceAddress()).build());
-            admin.tenants().createTenant("prop",
+            admin.tenants().createTenant("tenant",
                     new TenantInfoImpl(Sets.newHashSet("appid1"), Sets.newHashSet("usc")));
         } catch (Throwable t) {
             log.error("Error setting up broker test", t);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerBkEnsemblesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerBkEnsemblesTest.java
@@ -93,7 +93,7 @@ public class BrokerBkEnsemblesTest extends BkEnsemblesTestBase {
                 .statsInterval(0, TimeUnit.SECONDS)
                 .build();
 
-        final String ns1 = "prop/usc/crash-broker";
+        final String ns1 = "tenant/crash-broker";
 
         admin.namespaces().createNamespace(ns1);
 
@@ -191,7 +191,7 @@ public class BrokerBkEnsemblesTest extends BkEnsemblesTestBase {
                 .statsInterval(0, TimeUnit.SECONDS)
                 .build();
 
-        final String ns1 = "prop/usc/crash-broker";
+        final String ns1 = "tenant/crash-broker";
         final int totalMessages = 99;
         final int totalDataLedgers = 5;
         final int entriesPerLedger = 20;
@@ -300,7 +300,7 @@ public class BrokerBkEnsemblesTest extends BkEnsemblesTestBase {
         final int totalDataLedgers = 5;
         final int entriesPerLedger = 20;
 
-        final String tenant = "prop";
+        final String tenant = "tenant";
         try {
             admin.tenants().createTenant(tenant, new TenantInfoImpl(Sets.newHashSet("role1", "role2"),
                     Sets.newHashSet(config.getClusterName())));
@@ -430,7 +430,7 @@ public class BrokerBkEnsemblesTest extends BkEnsemblesTestBase {
                 .statsInterval(0, TimeUnit.SECONDS)
                 .build();
 
-        final String ns1 = "prop/usc/topicWithSpecialChar";
+        final String ns1 = "tenant/topicWithSpecialChar";
         try {
             admin.namespaces().createNamespace(ns1);
         } catch (Exception e) {
@@ -454,7 +454,7 @@ public class BrokerBkEnsemblesTest extends BkEnsemblesTestBase {
 
     @Test
     public void testDeleteTopicWithMissingData() throws Exception {
-        String namespace = BrokerTestUtil.newUniqueName("prop/usc");
+        String namespace = BrokerTestUtil.newUniqueName("tenant/ns");
         admin.namespaces().createNamespace(namespace);
 
         String topic = BrokerTestUtil.newUniqueName(namespace + "/my-topic");
@@ -499,7 +499,7 @@ public class BrokerBkEnsemblesTest extends BkEnsemblesTestBase {
 
     @Test
     public void testDeleteTopicWithoutTopicLoaded() throws Exception {
-        String namespace = BrokerTestUtil.newUniqueName("prop/usc");
+        String namespace = BrokerTestUtil.newUniqueName("tenant/ns");
         admin.namespaces().createNamespace(namespace);
 
         String topic = BrokerTestUtil.newUniqueName(namespace + "/my-topic");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerEntryMetadataE2ETest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerEntryMetadataE2ETest.java
@@ -294,7 +294,7 @@ public class BrokerEntryMetadataE2ETest extends BrokerTestBase {
 
     @Test(timeOut = 20000)
     public void testGetLastMessageId() throws Exception {
-        final String topic = "persistent://prop/ns-abc/topic-test";
+        final String topic = "persistent://tenant/ns-abc/topic-test";
         final String subscription = "my-sub";
 
         @Cleanup

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerInternalClientConfigurationOverrideTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerInternalClientConfigurationOverrideTest.java
@@ -119,7 +119,7 @@ public class BrokerInternalClientConfigurationOverrideTest extends BrokerTestBas
     @Test
     public void testOldNamespacePolicy() throws Exception {
 
-        String ns = "prop/oldNsWithDefaultNonNullValues";
+        String ns = "tenant/oldNsWithDefaultNonNullValues";
         String topic = "persistent://" + ns + "/t1";
         Policies policies = new Policies();
         policies.max_consumers_per_subscription = -1;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceAutoSubscriptionCreationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceAutoSubscriptionCreationTest.java
@@ -54,14 +54,14 @@ public class BrokerServiceAutoSubscriptionCreationTest extends BrokerTestBase {
 
     @AfterMethod(alwaysRun = true)
     protected void cleanupTest() throws Exception {
-        pulsar.getAdminClient().namespaces().removeAutoSubscriptionCreation("prop/ns-abc");
+        pulsar.getAdminClient().namespaces().removeAutoSubscriptionCreation("tenant/ns-abc");
     }
 
     @Test
     public void testAutoSubscriptionCreationDisable() throws Exception {
         pulsar.getConfiguration().setAllowAutoSubscriptionCreation(false);
 
-        final String topicName = "persistent://prop/ns-abc/test-subtopic-" + testId.getAndIncrement();
+        final String topicName = "persistent://tenant/ns-abc/test-subtopic-" + testId.getAndIncrement();
         final String subscriptionName = "test-subtopic-sub";
 
         admin.topics().createNonPartitionedTopic(topicName);
@@ -79,7 +79,7 @@ public class BrokerServiceAutoSubscriptionCreationTest extends BrokerTestBase {
     public void testSubscriptionCreationWithAutoCreationDisable() throws Exception {
         pulsar.getConfiguration().setAllowAutoSubscriptionCreation(false);
 
-        final String topicName = "persistent://prop/ns-abc/test-subtopic-" + testId.getAndIncrement();
+        final String topicName = "persistent://tenant/ns-abc/test-subtopic-" + testId.getAndIncrement();
         final String subscriptionName = "test-subtopic-sub-1";
 
         admin.topics().createNonPartitionedTopic(topicName);
@@ -95,7 +95,7 @@ public class BrokerServiceAutoSubscriptionCreationTest extends BrokerTestBase {
 
     @Test
     public void testAutoSubscriptionCreationNamespaceAllowOverridesBroker() throws Exception {
-        final String topic = "persistent://prop/ns-abc/test-subtopic-" + testId.getAndIncrement();
+        final String topic = "persistent://tenant/ns-abc/test-subtopic-" + testId.getAndIncrement();
         final String subscriptionName = "test-subtopic-sub-2";
         final TopicName topicName = TopicName.get(topic);
 
@@ -117,7 +117,7 @@ public class BrokerServiceAutoSubscriptionCreationTest extends BrokerTestBase {
 
     @Test
     public void testAutoSubscriptionCreationNamespaceDisallowOverridesBroker() throws Exception {
-        final String topic = "persistent://prop/ns-abc/test-subtopic-" + testId.getAndIncrement();
+        final String topic = "persistent://tenant/ns-abc/test-subtopic-" + testId.getAndIncrement();
         final String subscriptionName = "test-subtopic-sub-3";
         final TopicName topicName = TopicName.get(topic);
 
@@ -145,7 +145,7 @@ public class BrokerServiceAutoSubscriptionCreationTest extends BrokerTestBase {
     public void testNonPersistentTopicSubscriptionCreationWithAutoCreationDisable() throws Exception {
         pulsar.getConfiguration().setAllowAutoSubscriptionCreation(false);
 
-        final String topicName = "non-persistent://prop/ns-abc/test-subtopic-" + testId.getAndIncrement();
+        final String topicName = "non-persistent://tenant/ns-abc/test-subtopic-" + testId.getAndIncrement();
         final String subscriptionName = "test-subtopic-sub";
 
         admin.topics().createNonPartitionedTopic(topicName);
@@ -162,7 +162,7 @@ public class BrokerServiceAutoSubscriptionCreationTest extends BrokerTestBase {
         pulsar.getConfiguration().setAllowAutoSubscriptionCreation(true);
         String allowAutoSubscriptionCreation = "allowAutoSubscriptionCreation";
         admin.brokers().updateDynamicConfiguration(allowAutoSubscriptionCreation, "false");
-        String topicString = "persistent://prop/ns-abc/non-partitioned-topic" + UUID.randomUUID();
+        String topicString = "persistent://tenant/ns-abc/non-partitioned-topic" + UUID.randomUUID();
         String subscriptionName = "non-partitioned-topic-sub";
         admin.topics().createNonPartitionedTopic(topicString);
         Assert.assertThrows(PulsarClientException.class,

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceAutoTopicCreationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceAutoTopicCreationTest.java
@@ -67,7 +67,7 @@ public class BrokerServiceAutoTopicCreationTest extends BrokerTestBase{
 
     @AfterMethod(alwaysRun = true)
     protected void cleanupTest() throws Exception {
-        pulsar.getAdminClient().namespaces().removeAutoTopicCreation("prop/ns-abc");
+        pulsar.getAdminClient().namespaces().removeAutoTopicCreation("tenant/ns-abc");
     }
 
     @Test
@@ -75,12 +75,12 @@ public class BrokerServiceAutoTopicCreationTest extends BrokerTestBase{
         pulsar.getConfiguration().setAllowAutoTopicCreation(true);
         pulsar.getConfiguration().setAllowAutoTopicCreationType(TopicType.NON_PARTITIONED);
 
-        final String topicString = "persistent://prop/ns-abc/non-partitioned-topic";
+        final String topicString = "persistent://tenant/ns-abc/non-partitioned-topic";
         final String subscriptionName = "non-partitioned-topic-sub";
         pulsarClient.newConsumer().topic(topicString).subscriptionName(subscriptionName).subscribe();
 
-        assertTrue(admin.namespaces().getTopics("prop/ns-abc").contains(topicString));
-        assertFalse(admin.topics().getPartitionedTopicList("prop/ns-abc").contains(topicString));
+        assertTrue(admin.namespaces().getTopics("tenant/ns-abc").contains(topicString));
+        assertFalse(admin.topics().getPartitionedTopicList("tenant/ns-abc").contains(topicString));
     }
 
     @Test
@@ -88,11 +88,11 @@ public class BrokerServiceAutoTopicCreationTest extends BrokerTestBase{
         pulsar.getConfiguration().setAllowAutoTopicCreation(true);
         pulsar.getConfiguration().setAllowAutoTopicCreationType(TopicType.NON_PARTITIONED);
 
-        final String topicString = "persistent://prop/ns-abc/non-partitioned-topic-2";
+        final String topicString = "persistent://tenant/ns-abc/non-partitioned-topic-2";
         pulsarClient.newProducer().topic(topicString).create();
 
-        assertTrue(admin.namespaces().getTopics("prop/ns-abc").contains(topicString));
-        assertFalse(admin.topics().getPartitionedTopicList("prop/ns-abc").contains(topicString));
+        assertTrue(admin.namespaces().getTopics("tenant/ns-abc").contains(topicString));
+        assertFalse(admin.topics().getPartitionedTopicList("tenant/ns-abc").contains(topicString));
     }
 
     @Test
@@ -101,13 +101,13 @@ public class BrokerServiceAutoTopicCreationTest extends BrokerTestBase{
         pulsar.getConfiguration().setAllowAutoTopicCreationType(TopicType.PARTITIONED);
         pulsar.getConfiguration().setDefaultNumPartitions(3);
 
-        final String topicString = "persistent://prop/ns-abc/partitioned-topic";
+        final String topicString = "persistent://tenant/ns-abc/partitioned-topic";
         final String subscriptionName = "partitioned-topic-sub";
         pulsarClient.newConsumer().topic(topicString).subscriptionName(subscriptionName).subscribe();
 
-        assertTrue(admin.topics().getPartitionedTopicList("prop/ns-abc").contains(topicString));
+        assertTrue(admin.topics().getPartitionedTopicList("tenant/ns-abc").contains(topicString));
         for (int i = 0; i < 3; i++) {
-            assertTrue(admin.namespaces().getTopics("prop/ns-abc").contains(topicString + "-partition-" + i));
+            assertTrue(admin.namespaces().getTopics("tenant/ns-abc").contains(topicString + "-partition-" + i));
         }
     }
 
@@ -117,12 +117,12 @@ public class BrokerServiceAutoTopicCreationTest extends BrokerTestBase{
         pulsar.getConfiguration().setAllowAutoTopicCreationType(TopicType.PARTITIONED);
         pulsar.getConfiguration().setDefaultNumPartitions(3);
 
-        final String topicString = "persistent://prop/ns-abc/partitioned-topic-1";
+        final String topicString = "persistent://tenant/ns-abc/partitioned-topic-1";
         pulsarClient.newProducer().topic(topicString).create();
 
-        assertTrue(admin.topics().getPartitionedTopicList("prop/ns-abc").contains(topicString));
+        assertTrue(admin.topics().getPartitionedTopicList("tenant/ns-abc").contains(topicString));
         for (int i = 0; i < 3; i++) {
-            assertTrue(admin.namespaces().getTopics("prop/ns-abc").contains(topicString + "-partition-" + i));
+            assertTrue(admin.namespaces().getTopics("tenant/ns-abc").contains(topicString + "-partition-" + i));
         }
     }
 
@@ -130,7 +130,7 @@ public class BrokerServiceAutoTopicCreationTest extends BrokerTestBase{
     public void testAutoTopicCreationDisable() throws Exception{
         pulsar.getConfiguration().setAllowAutoTopicCreation(false);
 
-        final String topicString = "persistent://prop/ns-abc/test-topic";
+        final String topicString = "persistent://tenant/ns-abc/test-topic";
         final String subscriptionName = "test-topic-sub";
         try {
             pulsarClient.newConsumer().topic(topicString).subscriptionName(subscriptionName).subscribe();
@@ -138,7 +138,7 @@ public class BrokerServiceAutoTopicCreationTest extends BrokerTestBase{
         } catch (Exception e) {
             assertTrue(e instanceof PulsarClientException);
         }
-        assertFalse(admin.namespaces().getTopics("prop/ns-abc").contains(topicString));
+        assertFalse(admin.namespaces().getTopics("tenant/ns-abc").contains(topicString));
     }
 
     @Test
@@ -147,16 +147,16 @@ public class BrokerServiceAutoTopicCreationTest extends BrokerTestBase{
         pulsar.getConfiguration().setAllowAutoTopicCreationType(TopicType.PARTITIONED);
         pulsar.getConfiguration().setDefaultNumPartitions(3);
 
-        final String topicString = "persistent://prop/ns-abc/test-topic-2";
+        final String topicString = "persistent://tenant/ns-abc/test-topic-2";
         final String subscriptionName = "partitioned-topic-sub";
         admin.topics().createNonPartitionedTopic(topicString);
         pulsarClient.newConsumer().topic(topicString).subscriptionName(subscriptionName).subscribe();
 
-        assertFalse(admin.topics().getPartitionedTopicList("prop/ns-abc").contains(topicString));
+        assertFalse(admin.topics().getPartitionedTopicList("tenant/ns-abc").contains(topicString));
         for (int i = 0; i < 3; i++) {
-            assertFalse(admin.namespaces().getTopics("prop/ns-abc").contains(topicString + "-partition-" + i));
+            assertFalse(admin.namespaces().getTopics("tenant/ns-abc").contains(topicString + "-partition-" + i));
         }
-        assertTrue(admin.namespaces().getTopics("prop/ns-abc").contains(topicString));
+        assertTrue(admin.namespaces().getTopics("tenant/ns-abc").contains(topicString));
         admin.topics().delete(topicString, true);
     }
 
@@ -171,17 +171,17 @@ public class BrokerServiceAutoTopicCreationTest extends BrokerTestBase{
         pulsar.getConfiguration().setAllowAutoTopicCreationType(TopicType.PARTITIONED);
         pulsar.getConfiguration().setDefaultNumPartitions(3);
 
-        final String topicString = "persistent://prop/ns-abc/test-topic-3";
+        final String topicString = "persistent://tenant/ns-abc/test-topic-3";
         try {
             admin.topics().getPartitionedTopicMetadata(topicString);
         } catch (PulsarAdminException.NotFoundException expected) {
         }
-        assertFalse(admin.namespaces().getTopics("prop/ns-abc").contains(topicString));
+        assertFalse(admin.namespaces().getTopics("tenant/ns-abc").contains(topicString));
     }
 
     @Test
     public void testAutoCreationNamespaceAllowOverridesBroker() throws Exception {
-        final String topicString = "persistent://prop/ns-abc/test-topic-4";
+        final String topicString = "persistent://tenant/ns-abc/test-topic-4";
         final String subscriptionName = "test-topic-sub-4";
         final TopicName topicName = TopicName.get(topicString);
         pulsar.getConfiguration().setAllowAutoTopicCreation(false);
@@ -194,13 +194,13 @@ public class BrokerServiceAutoTopicCreationTest extends BrokerTestBase{
                 autoTopicCreationOverride);
 
         pulsarClient.newConsumer().topic(topicString).subscriptionName(subscriptionName).subscribe();
-        assertTrue(admin.namespaces().getTopics("prop/ns-abc").contains(topicString));
-        assertFalse(admin.topics().getPartitionedTopicList("prop/ns-abc").contains(topicString));
+        assertTrue(admin.namespaces().getTopics("tenant/ns-abc").contains(topicString));
+        assertFalse(admin.topics().getPartitionedTopicList("tenant/ns-abc").contains(topicString));
     }
 
     @Test
     public void testAutoCreationNamespaceDisallowOverridesBroker() throws Exception {
-        final String topicString = "persistent://prop/ns-abc/test-topic-5";
+        final String topicString = "persistent://tenant/ns-abc/test-topic-5";
         final String subscriptionName = "test-topic-sub-5";
         final TopicName topicName = TopicName.get(topicString);
         pulsar.getConfiguration().setAllowAutoTopicCreation(true);
@@ -217,12 +217,12 @@ public class BrokerServiceAutoTopicCreationTest extends BrokerTestBase{
         } catch (Exception e) {
             assertTrue(e instanceof PulsarClientException);
         }
-        assertFalse(admin.namespaces().getTopics("prop/ns-abc").contains(topicString));
+        assertFalse(admin.namespaces().getTopics("tenant/ns-abc").contains(topicString));
     }
 
     @Test
     public void testAutoCreationNamespaceOverrideAllowsPartitionedTopics() throws Exception {
-        final String topicString = "persistent://prop/ns-abc/partitioned-test-topic-6";
+        final String topicString = "persistent://tenant/ns-abc/partitioned-test-topic-6";
         final TopicName topicName = TopicName.get(topicString);
 
         pulsar.getConfiguration().setAllowAutoTopicCreation(false);
@@ -238,15 +238,15 @@ public class BrokerServiceAutoTopicCreationTest extends BrokerTestBase{
         final String subscriptionName = "test-topic-sub-6";
         pulsarClient.newConsumer().topic(topicString).subscriptionName(subscriptionName).subscribe();
 
-        assertTrue(admin.topics().getPartitionedTopicList("prop/ns-abc").contains(topicString));
+        assertTrue(admin.topics().getPartitionedTopicList("tenant/ns-abc").contains(topicString));
         for (int i = 0; i < 4; i++) {
-            assertTrue(admin.namespaces().getTopics("prop/ns-abc").contains(topicString + "-partition-" + i));
+            assertTrue(admin.namespaces().getTopics("tenant/ns-abc").contains(topicString + "-partition-" + i));
         }
     }
 
     @Test
     public void testAutoCreationNamespaceOverridesTopicTypePartitioned() throws Exception {
-        final String topicString = "persistent://prop/ns-abc/partitioned-test-topic-7";
+        final String topicString = "persistent://tenant/ns-abc/partitioned-test-topic-7";
         final TopicName topicName = TopicName.get(topicString);
 
         pulsar.getConfiguration().setAllowAutoTopicCreation(true);
@@ -261,15 +261,15 @@ public class BrokerServiceAutoTopicCreationTest extends BrokerTestBase{
         final String subscriptionName = "test-topic-sub-7";
         pulsarClient.newConsumer().topic(topicString).subscriptionName(subscriptionName).subscribe();
 
-        assertTrue(admin.topics().getPartitionedTopicList("prop/ns-abc").contains(topicString));
+        assertTrue(admin.topics().getPartitionedTopicList("tenant/ns-abc").contains(topicString));
         for (int i = 0; i < 3; i++) {
-            assertTrue(admin.namespaces().getTopics("prop/ns-abc").contains(topicString + "-partition-" + i));
+            assertTrue(admin.namespaces().getTopics("tenant/ns-abc").contains(topicString + "-partition-" + i));
         }
     }
 
     @Test
     public void testAutoCreationNamespaceOverridesTopicTypeNonPartitioned() throws Exception {
-        final String topicString = "persistent://prop/ns-abc/partitioned-test-topic-8";
+        final String topicString = "persistent://tenant/ns-abc/partitioned-test-topic-8";
         final TopicName topicName = TopicName.get(topicString);
 
         pulsar.getConfiguration().setAllowAutoTopicCreation(true);
@@ -284,13 +284,13 @@ public class BrokerServiceAutoTopicCreationTest extends BrokerTestBase{
         final String subscriptionName = "test-topic-sub-8";
         pulsarClient.newConsumer().topic(topicString).subscriptionName(subscriptionName).subscribe();
 
-        assertTrue(admin.namespaces().getTopics("prop/ns-abc").contains(topicString));
-        assertFalse(admin.topics().getPartitionedTopicList("prop/ns-abc").contains(topicString));
+        assertTrue(admin.namespaces().getTopics("tenant/ns-abc").contains(topicString));
+        assertFalse(admin.topics().getPartitionedTopicList("tenant/ns-abc").contains(topicString));
     }
 
     @Test
     public void testAutoCreationNamespaceOverridesDefaultNumPartitions() throws Exception {
-        final String topicString = "persistent://prop/ns-abc/partitioned-test-topic-9";
+        final String topicString = "persistent://tenant/ns-abc/partitioned-test-topic-9";
         final TopicName topicName = TopicName.get(topicString);
 
         pulsar.getConfiguration().setAllowAutoTopicCreation(true);
@@ -307,15 +307,15 @@ public class BrokerServiceAutoTopicCreationTest extends BrokerTestBase{
 
         pulsarClient.newConsumer().topic(topicString).subscriptionName(subscriptionName).subscribe();
 
-        assertTrue(admin.topics().getPartitionedTopicList("prop/ns-abc").contains(topicString));
+        assertTrue(admin.topics().getPartitionedTopicList("tenant/ns-abc").contains(topicString));
         for (int i = 0; i < 4; i++) {
-            assertTrue(admin.namespaces().getTopics("prop/ns-abc").contains(topicString + "-partition-" + i));
+            assertTrue(admin.namespaces().getTopics("tenant/ns-abc").contains(topicString + "-partition-" + i));
         }
     }
 
     @Test
     public void testAutoCreationNamespaceAllowOverridesBrokerOnProduce() throws Exception {
-        final String topicString = "persistent://prop/ns-abc/test-topic-10";
+        final String topicString = "persistent://tenant/ns-abc/test-topic-10";
         final TopicName topicName = TopicName.get(topicString);
         pulsar.getConfiguration().setAllowAutoTopicCreation(false);
         pulsar.getAdminClient().namespaces().setAutoTopicCreation(topicName.getNamespace(),
@@ -325,15 +325,15 @@ public class BrokerServiceAutoTopicCreationTest extends BrokerTestBase{
                         .build());
 
         pulsarClient.newProducer().topic(topicString).create();
-        assertTrue(admin.namespaces().getTopics("prop/ns-abc").contains(topicString));
-        assertFalse(admin.topics().getPartitionedTopicList("prop/ns-abc").contains(topicString));
+        assertTrue(admin.namespaces().getTopics("tenant/ns-abc").contains(topicString));
+        assertFalse(admin.topics().getPartitionedTopicList("tenant/ns-abc").contains(topicString));
     }
 
 
     @Test
     public void testNotAllowSubscriptionTopicCreation() throws Exception{
         pulsar.getConfiguration().setAllowAutoTopicCreation(false);
-        String topicName = "persistent://prop/ns-abc/non-partitioned-topic" + System.currentTimeMillis();
+        String topicName = "persistent://tenant/ns-abc/non-partitioned-topic" + System.currentTimeMillis();
         String subscriptionName = "non-partitioned-topic-sub";
 
         try {
@@ -351,8 +351,8 @@ public class BrokerServiceAutoTopicCreationTest extends BrokerTestBase{
             // expected
         }
 
-        assertFalse(admin.namespaces().getTopics("prop/ns-abc").contains(topicName));
-        assertFalse(admin.topics().getPartitionedTopicList("prop/ns-abc").contains(topicName));
+        assertFalse(admin.namespaces().getTopics("tenant/ns-abc").contains(topicName));
+        assertFalse(admin.topics().getPartitionedTopicList("tenant/ns-abc").contains(topicName));
 
         try {
             admin.topics().createNonPartitionedTopic(topicName);
@@ -363,7 +363,7 @@ public class BrokerServiceAutoTopicCreationTest extends BrokerTestBase{
         }
 
         try {
-            String partitionTopic = "persistent://prop/ns-abc/partitioned-topic" + System.currentTimeMillis();
+            String partitionTopic = "persistent://tenant/ns-abc/partitioned-topic" + System.currentTimeMillis();
             admin.topics().createPartitionedTopic(partitionTopic, 1);
             admin.topics().createSubscription(partitionTopic + "-partition-0", subscriptionName, MessageId.earliest);
         } catch (Exception e) {
@@ -376,7 +376,7 @@ public class BrokerServiceAutoTopicCreationTest extends BrokerTestBase{
     @Test
     public void testAutoCreationNamespaceOverridesSubscriptionTopicCreation() throws Exception {
         pulsar.getConfiguration().setAllowAutoTopicCreation(false);
-        String topicString = "persistent://prop/ns-abc/non-partitioned-topic" + System.currentTimeMillis();
+        String topicString = "persistent://tenant/ns-abc/non-partitioned-topic" + System.currentTimeMillis();
         String subscriptionName = "non-partitioned-topic-sub";
         final TopicName topicName = TopicName.get(topicString);
         pulsar.getAdminClient().namespaces().setAutoTopicCreation(topicName.getNamespace(),
@@ -395,7 +395,7 @@ public class BrokerServiceAutoTopicCreationTest extends BrokerTestBase{
         pulsar.getConfiguration().setDefaultNumPartitions(3);
         pulsar.getConfiguration().setMaxNumPartitionsPerPartitionedTopic(2);
 
-        final String topicString = "persistent://prop/ns-abc/partitioned-test-topic-11";
+        final String topicString = "persistent://tenant/ns-abc/partitioned-test-topic-11";
         final String subscriptionName = "test-topic-sub-11";
 
         try {
@@ -410,27 +410,27 @@ public class BrokerServiceAutoTopicCreationTest extends BrokerTestBase{
     public void testAutoCreationOfSystemTopicTransactionBufferSnapshot() throws Exception {
         pulsar.getConfiguration().setAllowAutoTopicCreation(false);
 
-        final String topicString = "persistent://prop/ns-abc/" + SystemTopicNames.TRANSACTION_BUFFER_SNAPSHOT;
+        final String topicString = "persistent://tenant/ns-abc/" + SystemTopicNames.TRANSACTION_BUFFER_SNAPSHOT;
 
         pulsarClient.newProducer().topic(topicString).create();
 
-        assertTrue(admin.namespaces().getTopics("prop/ns-abc",
+        assertTrue(admin.namespaces().getTopics("tenant/ns-abc",
                 ListNamespaceTopicsOptions.builder().includeSystemTopic(true).build()).contains(topicString));
-        assertFalse(admin.topics().getPartitionedTopicList("prop/ns-abc").contains(topicString));
+        assertFalse(admin.topics().getPartitionedTopicList("tenant/ns-abc").contains(topicString));
     }
 
     @Test
     public void testAutoCreationOfSystemTopicNamespaceEvents() throws Exception {
         pulsar.getConfiguration().setAllowAutoTopicCreation(false);
 
-        final String topicString = "persistent://prop/ns-abc/" + SystemTopicNames.NAMESPACE_EVENTS_LOCAL_NAME;
+        final String topicString = "persistent://tenant/ns-abc/" + SystemTopicNames.NAMESPACE_EVENTS_LOCAL_NAME;
 
         @Cleanup
         Producer<byte[]> producer = pulsarClient.newProducer().topic(topicString).create();
 
-        assertTrue(admin.namespaces().getTopics("prop/ns-abc",
+        assertTrue(admin.namespaces().getTopics("tenant/ns-abc",
                 ListNamespaceTopicsOptions.builder().includeSystemTopic(true).build()).contains(topicString));
-        assertFalse(admin.topics().getPartitionedTopicList("prop/ns-abc").contains(topicString));
+        assertFalse(admin.topics().getPartitionedTopicList("tenant/ns-abc").contains(topicString));
     }
 
     @Test
@@ -438,7 +438,7 @@ public class BrokerServiceAutoTopicCreationTest extends BrokerTestBase{
         // test disable AllowAutoTopicCreation
         pulsar.getConfiguration().setAllowAutoTopicCreation(true);
         admin.brokers().updateDynamicConfiguration("allowAutoTopicCreation", "false");
-        final String namespaceName = "prop/ns-abc";
+        final String namespaceName = "tenant/ns-abc";
         final String topic = "persistent://" + namespaceName + "/test-dynamicConfiguration-topic-auto-creation-"
                 + UUID.randomUUID();
         Assert.assertThrows(PulsarClientException.NotFoundException.class,
@@ -450,7 +450,7 @@ public class BrokerServiceAutoTopicCreationTest extends BrokerTestBase{
             throws PulsarAdminException, PulsarClientException {
         pulsar.getConfiguration().setAllowAutoTopicCreation(false);
         pulsar.getConfiguration().setAllowAutoTopicCreationType(TopicType.PARTITIONED);
-        final String namespaceName = "prop/ns-abc";
+        final String namespaceName = "tenant/ns-abc";
         final String topic = "persistent://" + namespaceName + "/test-dynamicConfiguration-topic-auto-creation-"
                 + UUID.randomUUID();
         // test enable AllowAutoTopicCreation, non-partitioned
@@ -473,7 +473,7 @@ public class BrokerServiceAutoTopicCreationTest extends BrokerTestBase{
         pulsar.getConfiguration().setAllowAutoTopicCreation(false);
         pulsar.getConfiguration().setAllowAutoTopicCreationType(TopicType.NON_PARTITIONED);
         pulsar.getConfiguration().setMaxNumPartitionsPerPartitionedTopic(0);
-        final String namespaceName = "prop/ns-abc";
+        final String namespaceName = "tenant/ns-abc";
         final String topic = "persistent://" + namespaceName + "/test-dynamicConfiguration-topic-auto-creation-"
                 + UUID.randomUUID();
         // test enable AllowAutoTopicCreation, partitioned
@@ -507,7 +507,7 @@ public class BrokerServiceAutoTopicCreationTest extends BrokerTestBase{
         pulsar.getConfiguration().setAllowAutoTopicCreation(true);
         pulsar.getConfiguration().setAllowAutoTopicCreationType(TopicType.PARTITIONED);
         pulsar.getConfiguration().setMaxNumPartitionsPerPartitionedTopic(0);
-        final String namespaceName = "prop/ns-abc";
+        final String namespaceName = "tenant/ns-abc";
         String topic = "persistent://" + namespaceName + "/test-dynamicConfiguration-topic-auto-creation-"
                 + UUID.randomUUID();
         // test enable AllowAutoTopicCreation,
@@ -602,7 +602,7 @@ public class BrokerServiceAutoTopicCreationTest extends BrokerTestBase{
         pulsar.getConfiguration().setAllowAutoTopicCreationType(TopicType.PARTITIONED);
         pulsar.getConfiguration().setDefaultNumPartitions(3);
 
-        final String topicString = "persistent://prop/ns-abc/testTopic/1";
+        final String topicString = "persistent://tenant/ns-abc/testTopic/1";
         // When allowAutoTopicCreationWithLegacyNamingScheme as the default value is false,
         // four-paragraph topic cannot be created.
         pulsar.getConfiguration().setAllowAutoTopicCreationWithLegacyNamingScheme(false);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceBundlesCacheInvalidationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceBundlesCacheInvalidationTest.java
@@ -44,7 +44,7 @@ public class BrokerServiceBundlesCacheInvalidationTest extends BrokerTestBase {
 
     @Test
     public void testRecreateNamespace() throws Exception {
-        String namespace = "prop/test-" + System.nanoTime();
+        String namespace = "tenant/test-" + System.nanoTime();
         String topic = namespace + "/my-topic";
 
         // First create namespace with 20 bundles

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
@@ -82,6 +82,7 @@ import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.pulsar.broker.BrokerTestUtil;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.namespace.NamespaceService;
 import org.apache.pulsar.broker.service.BrokerServiceException.PersistenceException;
@@ -171,11 +172,11 @@ public class BrokerServiceTest extends BrokerTestBase {
         cleanup();
         conf.setDefaultNumberOfNamespaceBundles(bundleNum);
         setup();
-        final String topic = "persistent://prop/ns-abc/successTopic";
+        final String topic = "persistent://tenant/ns-abc/successTopic";
         admin.topics().createPartitionedTopic(topic, 12);
         Producer<byte[]> producer = pulsarClient.newProducer(Schema.BYTES).topic(topic).create();
 
-        BundlesData bundlesData = admin.namespaces().getBundles("prop/ns-abc");
+        BundlesData bundlesData = admin.namespaces().getBundles("tenant/ns-abc");
         assertEquals(bundlesData.getNumBundles(), bundleNum);
         List<String> list = admin.brokers().getActiveBrokers("test");
         assertEquals(list.size(), 1);
@@ -201,7 +202,7 @@ public class BrokerServiceTest extends BrokerTestBase {
 
     @Test
     public void testOwnedNsCheck() throws Exception {
-        final String topic = "persistent://prop/ns-abc/successTopic";
+        final String topic = "persistent://tenant/ns-abc/successTopic";
         BrokerService service = pulsar.getBrokerService();
 
         final CountDownLatch latch1 = new CountDownLatch(1);
@@ -238,7 +239,7 @@ public class BrokerServiceTest extends BrokerTestBase {
         // this test might fail if there are stats from other tests
         resetState();
 
-        final String topicName = "persistent://prop/ns-abc/successTopic";
+        final String topicName = "persistent://tenant/ns-abc/successTopic";
         final String subName = "successSub";
 
         TopicStats stats;
@@ -324,7 +325,7 @@ public class BrokerServiceTest extends BrokerTestBase {
         conf.setBrokerMaxConnections(3);
         conf.setBrokerMaxConnectionsPerIp(2);
         setup();
-        final String topicName = "persistent://prop/ns-abc/connection" + UUID.randomUUID();
+        final String topicName = "persistent://tenant/ns-abc/connection" + UUID.randomUUID();
         List<PulsarClient> clients = new ArrayList<>();
         ClientBuilder clientBuilder =
                 PulsarClient.builder().operationTimeout(1, TimeUnit.DAYS)
@@ -358,7 +359,7 @@ public class BrokerServiceTest extends BrokerTestBase {
         conf.setBrokerMaxConnections(0);
         conf.setBrokerMaxConnectionsPerIp(1);
         setup();
-        final String topicName = "persistent://prop/ns-abc/connection" + UUID.randomUUID();
+        final String topicName = "persistent://tenant/ns-abc/connection" + UUID.randomUUID();
         List<PulsarClient> clients = new ArrayList<>();
         ClientBuilder clientBuilder =
                 PulsarClient.builder().operationTimeout(1, TimeUnit.DAYS)
@@ -446,7 +447,7 @@ public class BrokerServiceTest extends BrokerTestBase {
 
     @Test
     public void testStatsOfStorageSizeWithSubscription() throws Exception {
-        final String topicName = "persistent://prop/ns-abc/no-subscription";
+        final String topicName = "persistent://tenant/ns-abc/no-subscription";
         Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
         PersistentTopic topicRef = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topicName).get();
 
@@ -465,7 +466,7 @@ public class BrokerServiceTest extends BrokerTestBase {
         // this test might fail if there are stats from other tests
         resetState();
 
-        final String topicName = "persistent://prop/ns-abc/successSharedTopic";
+        final String topicName = "persistent://tenant/ns-abc/successSharedTopic";
         final String subName = "successSharedSub";
 
         TopicStats stats;
@@ -554,7 +555,7 @@ public class BrokerServiceTest extends BrokerTestBase {
 
     @Test
     public void testBrokerStatsMetrics() throws Exception {
-        final String topicName = "persistent://prop/ns-abc/newTopic";
+        final String topicName = "persistent://tenant/ns-abc/newTopic";
         final String subName = "newSub";
         BrokerStats brokerStatsClient = admin.brokerStats();
 
@@ -586,10 +587,10 @@ public class BrokerServiceTest extends BrokerTestBase {
         for (int i = 0; i < metrics.size(); i++) {
             try {
                 String data = metrics.get(i).getAsJsonObject().get("dimensions").toString();
-                if (!namespaceDimensionFound && data.contains("prop/ns-abc")) {
+                if (!namespaceDimensionFound && data.contains("tenant/ns-abc")) {
                     namespaceDimensionFound = true;
                 }
-                if (!topicLoadTimesDimensionFound && data.contains("prop/ns-abc")) {
+                if (!topicLoadTimesDimensionFound && data.contains("tenant/ns-abc")) {
                     topicLoadTimesDimensionFound = true;
                 }
             } catch (Exception e) {
@@ -608,8 +609,8 @@ public class BrokerServiceTest extends BrokerTestBase {
         resetState();
 
         final int numBundles = 4;
-        final String ns1 = "prop/stats1";
-        final String ns2 = "prop/stats2";
+        final String ns1 = "tenant/stats1";
+        final String ns2 = "tenant/stats2";
 
         List<String> nsList = List.of(ns1, ns2);
         List<Producer<byte[]>> producerList = new ArrayList<>();
@@ -662,7 +663,7 @@ public class BrokerServiceTest extends BrokerTestBase {
 
     @Test
     public void testTlsDisabled() throws Exception {
-        final String topicName = "persistent://prop/ns-abc/newTopic";
+        final String topicName = "persistent://tenant/ns-abc/newTopic";
         final String subName = "newSub";
         PulsarClient pulsarClient = null;
 
@@ -702,7 +703,7 @@ public class BrokerServiceTest extends BrokerTestBase {
 
     @Test
     public void testTlsEnabled() throws Exception {
-        final String topicName = "persistent://prop/ns-abc/newTopic";
+        final String topicName = "persistent://tenant/ns-abc/newTopic";
         final String subName = "newSub";
 
         conf.setAuthenticationEnabled(false);
@@ -779,7 +780,7 @@ public class BrokerServiceTest extends BrokerTestBase {
 
     @Test
     public void testTlsEnabledWithoutNonTlsServicePorts() throws Exception {
-        final String topicName = "persistent://prop/ns-abc/newTopic";
+        final String topicName = "persistent://tenant/ns-abc/newTopic";
         final String subName = "newSub";
 
         conf.setAuthenticationEnabled(false);
@@ -815,7 +816,7 @@ public class BrokerServiceTest extends BrokerTestBase {
     @SuppressWarnings("deprecation")
     @Test
     public void testTlsAuthAllowInsecure() throws Exception {
-        final String topicName = "persistent://prop/ns-abc/newTopic";
+        final String topicName = "persistent://tenant/ns-abc/newTopic";
         final String subName = "newSub";
         Authentication auth;
 
@@ -878,7 +879,7 @@ public class BrokerServiceTest extends BrokerTestBase {
     @SuppressWarnings("deprecation")
     @Test
     public void testTlsAuthDisallowInsecure() throws Exception {
-        final String topicName = "persistent://prop/my-ns/newTopic";
+        final String topicName = "persistent://tenant/my-ns/newTopic";
         final String subName = "newSub";
         Authentication auth;
 
@@ -940,7 +941,7 @@ public class BrokerServiceTest extends BrokerTestBase {
     @SuppressWarnings("deprecation")
     @Test
     public void testTlsAuthUseTrustCert() throws Exception {
-        final String topicName = "persistent://prop/ns-abc/newTopic";
+        final String topicName = "persistent://tenant/ns-abc/newTopic";
         final String subName = "newSub";
         Authentication auth;
 
@@ -1005,7 +1006,7 @@ public class BrokerServiceTest extends BrokerTestBase {
      */
     @Test
     public void testLookupThrottlingForClientByClient() throws Exception {
-        final String topicName = "persistent://prop/ns-abc/newTopic";
+        final String topicName = "persistent://tenant/ns-abc/newTopic";
 
         PulsarServiceNameResolver resolver = new PulsarServiceNameResolver();
         resolver.updateServiceUrl(pulsar.getBrokerServiceUrl());
@@ -1163,7 +1164,7 @@ public class BrokerServiceTest extends BrokerTestBase {
 
     @Test
     public void testTopicLoadingOnDisableNamespaceBundle() throws Exception {
-        final String namespace = "prop/disableBundle";
+        final String namespace = "tenant/disableBundle";
         try {
             admin.namespaces().createNamespace(namespace);
         } catch (PulsarAdminException.ConflictException e) {
@@ -1199,7 +1200,7 @@ public class BrokerServiceTest extends BrokerTestBase {
     @Test
     public void testConcurrentLoadTopicExceedLimitShouldNotBeAutoCreated() throws Exception {
         boolean needDeleteTopic = false;
-        final String namespace = "prop/concurrentLoad";
+        final String namespace = "tenant/concurrentLoad";
         try {
             // set up broker disable auto create and set concurrent load to 1 qps.
             cleanup();
@@ -1260,7 +1261,7 @@ public class BrokerServiceTest extends BrokerTestBase {
 
     @Test
     public void testCheckInactiveSubscriptionsShouldNotDeleteCompactionCursor() throws Exception {
-        String namespace = "prop/test";
+        String namespace = "tenant/test";
 
         // set up broker set compaction threshold.
         cleanup();
@@ -1276,7 +1277,7 @@ public class BrokerServiceTest extends BrokerTestBase {
         // set enable subscription expiration.
         admin.namespaces().setSubscriptionExpirationTime(namespace, 1);
 
-        String compactionInactiveTestTopic = "persistent://prop/test/testCompactionCursorShouldNotDelete";
+        String compactionInactiveTestTopic = "persistent://tenant/test/testCompactionCursorShouldNotDelete";
 
         admin.topics().createNonPartitionedTopic(compactionInactiveTestTopic);
 
@@ -1323,7 +1324,7 @@ public class BrokerServiceTest extends BrokerTestBase {
 
     @Test
     public void testCheckInactiveSubscriptionWhenNoMessageToAck() throws Exception {
-        String namespace = "prop/testInactiveSubscriptionWhenNoMessageToAck";
+        String namespace = "tenant/testInactiveSubscriptionWhenNoMessageToAck";
 
         try {
             admin.namespaces().createNamespace(namespace);
@@ -1389,7 +1390,7 @@ public class BrokerServiceTest extends BrokerTestBase {
      */
     @Test(timeOut = 3000)
     public void testTopicFailureShouldNotHaveDeadLock() {
-        final String namespace = "prop/ns-abc";
+        final String namespace = "tenant/ns-abc";
         final String deadLockTestTopic = "persistent://" + namespace + "/deadLockTestTopic";
 
         // let this broker own this namespace bundle by creating a topic
@@ -1432,7 +1433,7 @@ public class BrokerServiceTest extends BrokerTestBase {
 
     @Test
     public void testLedgerOpenFailureShouldNotHaveDeadLock() throws Exception {
-        final String namespace = "prop/ns-abc";
+        final String namespace = "tenant/ns-abc";
         final String deadLockTestTopic = "persistent://" + namespace + "/deadLockTestTopic";
 
         // let this broker own this namespace bundle by creating a topic
@@ -1492,7 +1493,7 @@ public class BrokerServiceTest extends BrokerTestBase {
      */
     @Test
     public void testCreateNamespacePolicy() throws Exception {
-        final String namespace = "prop/testPolicy";
+        final String namespace = "tenant/testPolicy";
         final int totalBundle = 3;
         System.err.println("----------------");
         admin.namespaces().createNamespace(namespace, BundlesData.builder().numBundles(totalBundle).build());
@@ -1512,7 +1513,7 @@ public class BrokerServiceTest extends BrokerTestBase {
      */
     @Test
     public void testStuckTopicUnloading() throws Exception {
-        final String namespace = "prop/ns-abc";
+        final String namespace = "tenant/ns-abc";
         final String topicName = "persistent://" + namespace + "/unoadTopic";
         final String topicMlName = namespace + "/persistent/unoadTopic";
         Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName("my-subscriber-name")
@@ -1575,7 +1576,7 @@ public class BrokerServiceTest extends BrokerTestBase {
     public void shouldNotPreventCreatingTopicWhenNonexistingTopicIsCached() throws Exception {
         // run multiple iterations to increase the chance of reproducing a race condition in the topic cache
         for (int i = 0; i < 100; i++) {
-            final String topicName = "persistent://prop/ns-abc/topic-caching-test-topic" + i;
+            final String topicName = "persistent://tenant/ns-abc/topic-caching-test-topic" + i;
             CountDownLatch latch = new CountDownLatch(1);
             Thread getStatsThread = new Thread(() -> {
                 try {
@@ -1633,7 +1634,7 @@ public class BrokerServiceTest extends BrokerTestBase {
 
     @Test
     public void testGetTopic() throws Exception {
-        final String ns = "prop/ns-test";
+        final String ns = "tenant/ns-test";
         admin.namespaces().createNamespace(ns, 2);
         final String topicName = ns + "/topic-1";
         admin.topics().createNonPartitionedTopic(String.format("persistent://%s", topicName));
@@ -1680,7 +1681,7 @@ public class BrokerServiceTest extends BrokerTestBase {
 
     @Test
     public void testMetricsPersistentTopicLoadFails() throws Exception {
-        final String namespace = "prop/" + UUID.randomUUID().toString().replaceAll("-", "");
+        final String namespace = BrokerTestUtil.newUniqueName("tenant/ns");
         String topic = "persistent://" + namespace + "/topic1_" + UUID.randomUUID();
         admin.namespaces().createNamespace(namespace);
         admin.topics().createNonPartitionedTopic(topic);
@@ -1724,7 +1725,7 @@ public class BrokerServiceTest extends BrokerTestBase {
 
     @Test
     public void testMetricsNonPersistentTopicLoadFails() throws Exception {
-        final String namespace = "prop/" + UUID.randomUUID().toString().replaceAll("-", "");
+        final String namespace = BrokerTestUtil.newUniqueName("tenant/ns");
         String topic = "non-persistent://" + namespace + "/topic1_" + UUID.randomUUID();
         admin.namespaces().createNamespace(namespace);
 
@@ -1778,10 +1779,10 @@ public class BrokerServiceTest extends BrokerTestBase {
 
     @Test
     public void testDuplicateAcknowledgement() throws Exception {
-        final String ns = "prop/ns-test";
+        final String ns = "tenant/ns-test";
 
         admin.namespaces().createNamespace(ns, 2);
-        final String topicName = "persistent://prop/ns-test/duplicated-acknowledgement-test";
+        final String topicName = "persistent://tenant/ns-test/duplicated-acknowledgement-test";
         @Cleanup
         Producer<byte[]> producer = pulsarClient.newProducer()
                 .topic(topicName)
@@ -1804,11 +1805,11 @@ public class BrokerServiceTest extends BrokerTestBase {
 
     @Test
     public void testBlockedConsumerOnUnackedMsgs() throws Exception {
-        final String ns = "prop/ns-test";
+        final String ns = "tenant/ns-test";
         admin.namespaces().createNamespace(ns, 2);
         admin.namespaces().setMaxUnackedMessagesPerConsumer(ns, 1);
 
-        final String topicName = "persistent://prop/ns-test/testBlockedConsumerOnUnackedMsgs";
+        final String topicName = "persistent://tenant/ns-test/testBlockedConsumerOnUnackedMsgs";
         @Cleanup
         Producer<byte[]> producer = pulsarClient.newProducer()
                 .topic(topicName)
@@ -1845,7 +1846,7 @@ public class BrokerServiceTest extends BrokerTestBase {
 
     @Test
     public void testUnsubscribeNonDurableSub() throws Exception {
-        final String ns = "prop/ns-test";
+        final String ns = "tenant/ns-test";
         final String topic = ns + "/testUnsubscribeNonDurableSub";
 
         admin.namespaces().createNamespace(ns, 2);
@@ -1936,7 +1937,7 @@ public class BrokerServiceTest extends BrokerTestBase {
         };
 
         final BrokerService brokerService = pulsar.getBrokerService();
-        final String namespace = "prop/" + UUID.randomUUID();
+        final String namespace = BrokerTestUtil.newUniqueName("tenant/ns");
         admin.namespaces().createNamespace(namespace);
         admin.namespaces().setOffloadPolicies(namespace, offloadPolicies);
         Awaitility.await().untilAsserted(() -> {
@@ -1975,7 +1976,7 @@ public class BrokerServiceTest extends BrokerTestBase {
 
     @Test
     public void testTlsWithAuthParams() throws Exception {
-        final String topicName = "persistent://prop/ns-abc/newTopic";
+        final String topicName = "persistent://tenant/ns-abc/newTopic";
         final String subName = "newSub";
         Authentication auth;
 
@@ -2018,7 +2019,7 @@ public class BrokerServiceTest extends BrokerTestBase {
 
     @Test
     public void testPulsarMetadataEventSyncProducerCreation() throws Exception {
-        final String topicName = "persistent://prop/usw/my-ns/syncTopic";
+        final String topicName = "persistent://tenant/my-ns/syncTopic";
         pulsar.getConfiguration().setMetadataSyncEventTopic(topicName);
         PulsarMetadataEventSynchronizer sync = new PulsarMetadataEventSynchronizer(pulsar, topicName);
         // set invalid client for retry

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceThrottlingTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceThrottlingTest.java
@@ -120,7 +120,7 @@ public class BrokerServiceThrottlingTest extends BrokerTestBase {
     @Test
     public void testLookupThrottlingForClientByBroker0Permit() throws Exception {
 
-        final String topicName = "persistent://prop/ns-abc/newTopic";
+        final String topicName = "persistent://tenant/ns-abc/newTopic";
 
         @Cleanup
         PulsarClient pulsarClient = PulsarClient.builder()
@@ -163,7 +163,7 @@ public class BrokerServiceThrottlingTest extends BrokerTestBase {
      */
     @Test
     public void testLookupThrottlingForClientByBroker() throws Exception {
-        final String topicName = "persistent://prop/ns-abc/newTopic";
+        final String topicName = "persistent://tenant/ns-abc/newTopic";
 
         @Cleanup
         PulsarClient pulsarClient = PulsarClient.builder()
@@ -280,7 +280,7 @@ public class BrokerServiceThrottlingTest extends BrokerTestBase {
      */
     @Test
     public void testLookupThrottlingForClientByBrokerInternalRetry() throws Exception {
-        final String topicName = "persistent://prop/ns-abc/newTopic-" + UUID.randomUUID().toString();
+        final String topicName = "persistent://tenant/ns-abc/newTopic-" + UUID.randomUUID().toString();
 
         @Cleanup
         PulsarClient pulsarClient = PulsarClient.builder()

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerTestBase.java
@@ -51,10 +51,10 @@ public abstract class BrokerTestBase extends MockedPulsarServiceBaseTest {
 
     private void baseSetupCommon() throws Exception {
         admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(brokerUrl.toString()).build());
-        admin.tenants().createTenant("prop",
+        admin.tenants().createTenant("tenant",
                 new TenantInfoImpl(Sets.newHashSet("appid1"), Sets.newHashSet("test")));
-        admin.namespaces().createNamespace("prop/ns-abc");
-        admin.namespaces().setNamespaceReplicationClusters("prop/ns-abc", Sets.newHashSet("test"));
+        admin.namespaces().createNamespace("tenant/ns-abc");
+        admin.namespaces().setNamespaceReplicationClusters("tenant/ns-abc", Sets.newHashSet("test"));
     }
 
     protected void createTransactionCoordinatorAssign() throws MetadataStoreException {
@@ -103,7 +103,7 @@ public abstract class BrokerTestBase extends MockedPulsarServiceBaseTest {
     private static final Random random = new Random();
 
     protected String newTopicName() {
-        return "prop/ns-abc/topic-" + Long.toHexString(random.nextLong());
+        return "tenant/ns-abc/topic-" + Long.toHexString(random.nextLong());
     }
 
     private static final Logger LOG = LoggerFactory.getLogger(BrokerTestBase.class);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BusyWaitServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BusyWaitServiceTest.java
@@ -54,7 +54,7 @@ public class BusyWaitServiceTest extends BkEnsemblesTestBase {
                 .enableBusyWait(true)
                 .build();
 
-        String namespace = "prop/busy-wait";
+        String namespace = "tenant/busy-wait";
         admin.namespaces().createNamespace(namespace);
 
         String topic = namespace + "/my-topic-" + UUID.randomUUID();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ConsumedLedgersTrimTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ConsumedLedgersTrimTest.java
@@ -70,7 +70,7 @@ public class ConsumedLedgersTrimTest extends BrokerTestBase {
     public void testConsumedLedgersTrim() throws Exception {
         conf.setRetentionCheckIntervalInSeconds(1);
         super.baseSetup();
-        final String topicName = "persistent://prop/ns-abc/TestConsumedLedgersTrim";
+        final String topicName = "persistent://tenant/ns-abc/TestConsumedLedgersTrim";
         final String subscriptionName = "my-subscriber-name";
 
         @Cleanup
@@ -122,7 +122,7 @@ public class ConsumedLedgersTrimTest extends BrokerTestBase {
         conf.setRetentionCheckIntervalInSeconds(1);
         conf.setBrokerDeleteInactiveTopicsEnabled(false);
         super.baseSetup();
-        final String topicName = "persistent://prop/ns-abc/TestConsumedLedgersTrimNoSubscriptions";
+        final String topicName = "persistent://tenant/ns-abc/TestConsumedLedgersTrimNoSubscriptions";
 
         // write some messages
         @Cleanup
@@ -192,7 +192,7 @@ public class ConsumedLedgersTrimTest extends BrokerTestBase {
         conf.setRetentionCheckIntervalInSeconds(Integer.MAX_VALUE / 2);
         conf.setDefaultNumberOfNamespaceBundles(1);
         super.baseSetup();
-        final String topicName = "persistent://prop/ns-abc/TestAdminTrimLedgers" + UUID.randomUUID();
+        final String topicName = "persistent://tenant/ns-abc/TestAdminTrimLedgers" + UUID.randomUUID();
         final String subscriptionName = "my-sub";
         final int maxEntriesPerLedger = 2;
         final int partitionedNum = 3;
@@ -240,7 +240,7 @@ public class ConsumedLedgersTrimTest extends BrokerTestBase {
     @Test
     public void trimNonPersistentTopic() throws Exception {
         super.baseSetup();
-        String topicName = "non-persistent://prop/ns-abc/trimNonPersistentTopic" + UUID.randomUUID();
+        String topicName = "non-persistent://tenant/ns-abc/trimNonPersistentTopic" + UUID.randomUUID();
         int partitionedNum = 3;
         admin.topics().createPartitionedTopic(topicName, partitionedNum);
         @Cleanup

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/CurrentLedgerRolloverIfFullTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/CurrentLedgerRolloverIfFullTest.java
@@ -51,7 +51,7 @@ public class CurrentLedgerRolloverIfFullTest extends BrokerTestBase {
 
     @Test
     public void testCurrentLedgerRolloverIfFull() throws Exception {
-        final String topicName = "persistent://prop/ns-abc/CurrentLedgerRolloverIfFullTest";
+        final String topicName = "persistent://tenant/ns-abc/CurrentLedgerRolloverIfFullTest";
 
         @Cleanup
         Producer<byte[]> producer = pulsarClient.newProducer()

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/EnableProxyProtocolTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/EnableProxyProtocolTest.java
@@ -58,7 +58,7 @@ public class EnableProxyProtocolTest extends BrokerTestBase  {
 
     @Test
     public void testSimpleProduceAndConsume() throws Exception {
-        final String namespace = "prop/ns-abc";
+        final String namespace = "tenant/ns-abc";
         final String topicName = "persistent://" + namespace + "/testSimpleProduceAndConsume";
         final String subName = "my-subscriber-name";
         final int messages = 100;
@@ -94,7 +94,7 @@ public class EnableProxyProtocolTest extends BrokerTestBase  {
 
     @Test
     public void testProxyProtocol() throws Exception {
-        final String namespace = "prop/ns-abc";
+        final String namespace = "tenant/ns-abc";
         final String topicName = "persistent://" + namespace + "/testProxyProtocol";
         final String subName = "my-subscriber-name";
 
@@ -119,7 +119,7 @@ public class EnableProxyProtocolTest extends BrokerTestBase  {
 
     @Test(timeOut = 10000)
     public void testPubSubWhenSlowNetwork() throws Exception {
-        final String namespace = "prop/ns-abc";
+        final String namespace = "tenant/ns-abc";
         final String topicName = BrokerTestUtil.newUniqueName("persistent://" + namespace + "/tp");
         final String subName = "my-subscriber-name";
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/InactiveTopicDeleteTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/InactiveTopicDeleteTest.java
@@ -65,7 +65,7 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
         conf.setBrokerDeleteInactiveTopicsFrequencySeconds(1);
         super.baseSetup();
 
-        final String topic = "persistent://prop/ns-abc/testDeleteWhenNoSubscriptions";
+        final String topic = "persistent://tenant/ns-abc/testDeleteWhenNoSubscriptions";
 
         Producer<byte[]> producer = pulsarClient.newProducer()
             .topic(topic)
@@ -79,11 +79,11 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
         consumer.close();
         producer.close();
 
-        Awaitility.await().untilAsserted(() -> Assert.assertTrue(admin.topics().getList("prop/ns-abc")
+        Awaitility.await().untilAsserted(() -> Assert.assertTrue(admin.topics().getList("tenant/ns-abc")
                 .contains(topic)));
 
         admin.topics().deleteSubscription(topic, "sub");
-        Awaitility.await().untilAsserted(() -> Assert.assertFalse(admin.topics().getList("prop/ns-abc")
+        Awaitility.await().untilAsserted(() -> Assert.assertFalse(admin.topics().getList("tenant/ns-abc")
                 .contains(topic)));
     }
 
@@ -94,18 +94,18 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
         conf.setBrokerDeleteInactiveTopicsFrequencySeconds(1);
         super.baseSetup();
 
-        final String topic = "persistent://prop/ns-abc/testDeleteWhenNoSubscriptions";
+        final String topic = "persistent://tenant/ns-abc/testDeleteWhenNoSubscriptions";
         admin.topics().createPartitionedTopic(topic, 5);
         pulsarClient.newProducer().topic(topic).create().close();
         pulsarClient.newConsumer().topic(topic).subscriptionName("sub").subscribe().close();
 
         Awaitility.await()
-                .untilAsserted(() -> Assert.assertTrue(admin.topics().getPartitionedTopicList("prop/ns-abc")
+                .untilAsserted(() -> Assert.assertTrue(admin.topics().getPartitionedTopicList("tenant/ns-abc")
                 .contains(topic)));
 
         admin.topics().deleteSubscription(topic, "sub");
         Awaitility.await()
-                .untilAsserted(() -> Assert.assertFalse(admin.topics().getPartitionedTopicList("prop/ns-abc")
+                .untilAsserted(() -> Assert.assertFalse(admin.topics().getPartitionedTopicList("tenant/ns-abc")
                 .contains(topic)));
     }
 
@@ -116,7 +116,7 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
         conf.setBrokerDeleteInactiveTopicsFrequencySeconds(1);
         super.baseSetup();
 
-        final String topic = "persistent://prop/ns-abc/testDeleteWhenNoSubscriptions";
+        final String topic = "persistent://tenant/ns-abc/testDeleteWhenNoSubscriptions";
         final TopicName topicName = TopicName.get(topic);
         admin.topics().createPartitionedTopic(topic, 5);
         pulsarClient.newProducer().topic(topic).create().close();
@@ -125,12 +125,12 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
         Thread.sleep(2000);
 
         // Topic should not be deleted
-        Assert.assertTrue(admin.topics().getPartitionedTopicList("prop/ns-abc").contains(topic));
+        Assert.assertTrue(admin.topics().getPartitionedTopicList("tenant/ns-abc").contains(topic));
 
         admin.topics().deleteSubscription(topic, "sub");
         Awaitility.await().untilAsserted(() -> {
             // Now the topic should be deleted
-            Assert.assertFalse(admin.topics().getPartitionedTopicList("prop/ns-abc").contains(topic));
+            Assert.assertFalse(admin.topics().getPartitionedTopicList("tenant/ns-abc").contains(topic));
         });
     }
 
@@ -140,9 +140,9 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
         conf.setBrokerDeleteInactiveTopicsFrequencySeconds(1);
         conf.setBrokerDeleteInactiveTopicsEnabled(true);
         super.baseSetup();
-        final String namespace = "prop/ns-abc";
-        final String topic = "persistent://prop/ns-abc/testNotEnabledDeleteZkNode1";
-        final String topic2 = "persistent://prop/ns-abc/testNotEnabledDeleteZkNode2";
+        final String namespace = "tenant/ns-abc";
+        final String topic = "persistent://tenant/ns-abc/testNotEnabledDeleteZkNode1";
+        final String topic2 = "persistent://tenant/ns-abc/testNotEnabledDeleteZkNode2";
 
         admin.topics().createPartitionedTopic(topic, 5);
         admin.topics().createNonPartitionedTopic(topic2);
@@ -167,9 +167,9 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
 
     @Test(timeOut = 20000)
     public void testTopicPolicyUpdateAndClean() throws Exception {
-        final String namespace = "prop/ns-abc";
-        final String namespace2 = "prop/ns-abc2";
-        final String namespace3 = "prop/ns-abc3";
+        final String namespace = "tenant/ns-abc";
+        final String namespace2 = "tenant/ns-abc2";
+        final String namespace3 = "tenant/ns-abc3";
         List<String> namespaceList = Arrays.asList(namespace2, namespace3);
 
         conf.setBrokerDeleteInactiveTopicsEnabled(true);
@@ -186,9 +186,9 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
             admin.namespaces().setNamespaceReplicationClusters(ns, Sets.newHashSet("test"));
         }
 
-        final String topic = "persistent://prop/ns-abc/testDeletePolicyUpdate";
-        final String topic2 = "persistent://prop/ns-abc2/testDeletePolicyUpdate";
-        final String topic3 = "persistent://prop/ns-abc3/testDeletePolicyUpdate";
+        final String topic = "persistent://tenant/ns-abc/testDeletePolicyUpdate";
+        final String topic2 = "persistent://tenant/ns-abc2/testDeletePolicyUpdate";
+        final String topic3 = "persistent://tenant/ns-abc3/testDeletePolicyUpdate";
         List<String> topics = Arrays.asList(topic, topic2, topic3);
 
         for (String tp : topics) {
@@ -248,9 +248,9 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
 
     @Test(timeOut = 20000)
     public void testDeleteWhenNoSubscriptionsWithMultiConfig() throws Exception {
-        final String namespace = "prop/ns-abc";
-        final String namespace2 = "prop/ns-abc2";
-        final String namespace3 = "prop/ns-abc3";
+        final String namespace = "tenant/ns-abc";
+        final String namespace2 = "tenant/ns-abc2";
+        final String namespace3 = "tenant/ns-abc3";
         List<String> namespaceList = Arrays.asList(namespace2, namespace3);
         conf.setBrokerDeleteInactiveTopicsEnabled(true);
         conf.setBrokerDeleteInactiveTopicsFrequencySeconds(1);
@@ -261,9 +261,9 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
             admin.namespaces().setNamespaceReplicationClusters(ns, Sets.newHashSet("test"));
         }
 
-        final String topic = "persistent://prop/ns-abc/testDeleteWhenNoSubscriptionsWithMultiConfig";
-        final String topic2 = "persistent://prop/ns-abc2/testDeleteWhenNoSubscriptionsWithMultiConfig";
-        final String topic3 = "persistent://prop/ns-abc3/testDeleteWhenNoSubscriptionsWithMultiConfig";
+        final String topic = "persistent://tenant/ns-abc/testDeleteWhenNoSubscriptionsWithMultiConfig";
+        final String topic2 = "persistent://tenant/ns-abc2/testDeleteWhenNoSubscriptionsWithMultiConfig";
+        final String topic3 = "persistent://tenant/ns-abc3/testDeleteWhenNoSubscriptionsWithMultiConfig";
         List<String> topics = Arrays.asList(topic, topic2, topic3);
         //create producer/consumer and close
         Map<String, String> topicToSub = new HashMap<>();
@@ -320,8 +320,8 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
         conf.setBrokerDeleteInactiveTopicsFrequencySeconds(1);
         super.baseSetup();
 
-        final String topic = "persistent://prop/ns-abc/testDeleteWhenNoBacklogs";
-        final String topic2 = "persistent://prop/ns-abc/testDeleteWhenNoBacklogsB";
+        final String topic = "persistent://tenant/ns-abc/testDeleteWhenNoBacklogs";
+        final String topic2 = "persistent://tenant/ns-abc/testDeleteWhenNoBacklogsB";
         Producer<byte[]> producer = pulsarClient.newProducer()
             .topic(topic)
             .create();
@@ -335,7 +335,7 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
             .subscribe();
 
         Consumer<byte[]> consumer2 = pulsarClient.newConsumer()
-                .topicsPattern("persistent://prop/ns-abc/test.*")
+                .topicsPattern("persistent://tenant/ns-abc/test.*")
                 .subscriptionName("sub2")
                 .subscribe();
 
@@ -356,11 +356,11 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
         assertEquals(producedCount * 2, receivedCount);
 
         Thread.sleep(2000);
-        Assert.assertTrue(admin.topics().getList("prop/ns-abc").contains(topic));
+        Assert.assertTrue(admin.topics().getList("tenant/ns-abc").contains(topic));
 
         admin.topics().skipAllMessages(topic, "sub");
         Awaitility.await().untilAsserted(() -> {
-            final List<String> topics = admin.topics().getList("prop/ns-abc");
+            final List<String> topics = admin.topics().getList("tenant/ns-abc");
             Assert.assertFalse(topics.contains(topic));
             Assert.assertFalse(topics.contains(topic2));
         });
@@ -375,7 +375,7 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
         conf.setBrokerDeleteInactiveTopicsMaxInactiveDurationSeconds(5);
         super.baseSetup();
 
-        final String topic = "persistent://prop/ns-abc/testMaxInactiveDuration";
+        final String topic = "persistent://tenant/ns-abc/testMaxInactiveDuration";
 
         Producer<byte[]> producer = pulsarClient.newProducer()
             .topic(topic)
@@ -383,11 +383,11 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
 
         producer.close();
         Thread.sleep(2000);
-        Assert.assertTrue(admin.topics().getList("prop/ns-abc")
+        Assert.assertTrue(admin.topics().getList("tenant/ns-abc")
             .contains(topic));
 
         Thread.sleep(4000);
-        Assert.assertFalse(admin.topics().getList("prop/ns-abc")
+        Assert.assertFalse(admin.topics().getList("tenant/ns-abc")
             .contains(topic));
 
         super.internalCleanup();
@@ -396,7 +396,7 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
     @Test(timeOut = 20000)
     public void testTopicLevelInActiveTopicApi() throws Exception {
         super.baseSetup();
-        final String topicName = "persistent://prop/ns-abc/testMaxInactiveDuration-" + UUID.randomUUID().toString();
+        final String topicName = "persistent://tenant/ns-abc/testMaxInactiveDuration-" + UUID.randomUUID().toString();
         admin.topics().createPartitionedTopic(topicName, 3);
         pulsarClient.newConsumer().topic(topicName).subscriptionName("my-sub").subscribe().close();
         TopicName topic = TopicName.get(topicName);
@@ -429,10 +429,10 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
                 , 1000, true);
 
         super.baseSetup();
-        final String namespace = "prop/ns-abc";
-        final String topic = "persistent://prop/ns-abc/testTopicLevelInactivePolicy" + UUID.randomUUID().toString();
-        final String topic2 = "persistent://prop/ns-abc/testTopicLevelInactivePolicy" + UUID.randomUUID().toString();
-        final String topic3 = "persistent://prop/ns-abc/testTopicLevelInactivePolicy" + UUID.randomUUID().toString();
+        final String namespace = "tenant/ns-abc";
+        final String topic = "persistent://tenant/ns-abc/testTopicLevelInactivePolicy" + UUID.randomUUID().toString();
+        final String topic2 = "persistent://tenant/ns-abc/testTopicLevelInactivePolicy" + UUID.randomUUID().toString();
+        final String topic3 = "persistent://tenant/ns-abc/testTopicLevelInactivePolicy" + UUID.randomUUID().toString();
         List<String> topics = Arrays.asList(topic, topic2, topic3);
 
         for (String tp : topics) {
@@ -499,13 +499,13 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
 
     @Test(timeOut = 30000)
     public void testDeleteWhenNoSubscriptionsWithTopicLevelPolicies() throws Exception {
-        final String namespace = "prop/ns-abc";
+        final String namespace = "tenant/ns-abc";
         conf.setBrokerDeleteInactiveTopicsEnabled(true);
         conf.setBrokerDeleteInactiveTopicsFrequencySeconds(1);
         super.baseSetup();
-        final String topic = "persistent://prop/ns-abc/test-" + UUID.randomUUID();
-        final String topic2 = "persistent://prop/ns-abc/test-" + UUID.randomUUID();
-        final String topic3 = "persistent://prop/ns-abc/test-" + UUID.randomUUID();
+        final String topic = "persistent://tenant/ns-abc/test-" + UUID.randomUUID();
+        final String topic2 = "persistent://tenant/ns-abc/test-" + UUID.randomUUID();
+        final String topic3 = "persistent://tenant/ns-abc/test-" + UUID.randomUUID();
         List<String> topics = Arrays.asList(topic, topic2, topic3);
         //create producer/consumer and close
         Map<String, String> topicToSub = new HashMap<>();
@@ -555,8 +555,8 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
     public void testInactiveTopicApplied() throws Exception {
         super.baseSetup();
 
-        final String namespace = "prop/ns-abc";
-        final String topic = "persistent://prop/ns-abc/test-" + UUID.randomUUID();
+        final String namespace = "tenant/ns-abc";
+        final String topic = "persistent://tenant/ns-abc/test-" + UUID.randomUUID();
         pulsarClient.newProducer().topic(topic).create().close();
         //namespace-level default value is null
         assertNull(admin.namespaces().getInactiveTopicPolicies(namespace));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/KeyValueTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/KeyValueTest.java
@@ -59,7 +59,7 @@ public class KeyValueTest extends BrokerTestBase {
 
     @Test
     public void keyValueAutoConsumeTest()  throws Exception {
-        String topic = "persistent://prop/ns-abc/kv-record";
+        String topic = "persistent://tenant/ns-abc/kv-record";
         admin.topics().createNonPartitionedTopic(topic);
 
         RecordSchemaBuilder builder = SchemaBuilder

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/MessagePublishBufferThrottleTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/MessagePublishBufferThrottleTest.java
@@ -59,7 +59,7 @@ public class MessagePublishBufferThrottleTest extends BrokerTestBase {
     public void testMessagePublishBufferThrottleDisabled() throws Exception {
         conf.setMaxMessagePublishBufferSizeInMB(-1);
         super.baseSetup();
-        final String topic = "persistent://prop/ns-abc/testMessagePublishBufferThrottleDisabled";
+        final String topic = "persistent://tenant/ns-abc/testMessagePublishBufferThrottleDisabled";
         Producer<byte[]> producer = pulsarClient.newProducer()
                 .topic(topic)
                 .producerName("producer-name")
@@ -85,7 +85,7 @@ public class MessagePublishBufferThrottleTest extends BrokerTestBase {
         conf.setMaxMessagePublishBufferSizeInMB(1);
         super.baseSetup();
 
-        final String topic = "persistent://prop/ns-abc/testMessagePublishBufferThrottleEnable";
+        final String topic = "persistent://tenant/ns-abc/testMessagePublishBufferThrottleEnable";
         Producer<byte[]> producer = pulsarClient.newProducer()
                 .topic(topic)
                 .producerName("producer-name")
@@ -122,7 +122,7 @@ public class MessagePublishBufferThrottleTest extends BrokerTestBase {
         assertRateLimitCounter(ConnectionRateLimitOperationName.PAUSED, 0);
         assertRateLimitCounter(ConnectionRateLimitOperationName.RESUMED, 0);
 
-        final String topic = "persistent://prop/ns-abc/testBlockByPublishRateLimiting";
+        final String topic = "persistent://tenant/ns-abc/testBlockByPublishRateLimiting";
         Producer<byte[]> producer = pulsarClient.newProducer()
                 .topic(topic)
                 .producerName("producer-name")
@@ -168,7 +168,7 @@ public class MessagePublishBufferThrottleTest extends BrokerTestBase {
     public void testConnectionThrottled() throws Exception {
         super.baseSetup();
 
-        var topic = BrokerTestUtil.newUniqueName("persistent://prop/ns-abc/testSendThrottled");
+        var topic = BrokerTestUtil.newUniqueName("persistent://tenant/ns-abc/testSendThrottled");
 
         assertRateLimitCounter(ConnectionRateLimitOperationName.THROTTLED, 0);
         assertRateLimitCounter(ConnectionRateLimitOperationName.UNTHROTTLED, 0);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/MessageTTLTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/MessageTTLTest.java
@@ -74,7 +74,7 @@ public class MessageTTLTest extends BrokerTestBase {
     @Test
     public void testMessageExpiryAfterTopicUnload() throws Exception {
         int numMsgs = 50;
-        final String topicName = "persistent://prop/ns-abc/testttl";
+        final String topicName = "persistent://tenant/ns-abc/testttl";
         final String subscriptionName = "ttl-sub-1";
 
         pulsarClient.newConsumer()
@@ -124,7 +124,7 @@ public class MessageTTLTest extends BrokerTestBase {
 
     @Test
     public void testTTLPoliciesUpdate() throws Exception {
-        final String namespace = "prop/ns-abc";
+        final String namespace = "tenant/ns-abc";
         final String topicName = "persistent://" + namespace + "/testTTLPoliciesUpdate";
 
         @Cleanup
@@ -148,7 +148,7 @@ public class MessageTTLTest extends BrokerTestBase {
 
     @Test
     public void testTtlFilteredByIgnoreSubscriptions() throws Exception {
-        String topicName = "persistent://prop/ns-abc/testTTLFilteredByIgnoreSubscriptions";
+        String topicName = "persistent://tenant/ns-abc/testTTLFilteredByIgnoreSubscriptions";
         String subName = "__SUB_FILTER";
         cleanup();
         Set<String> ignoredSubscriptions = new HashSet<>();
@@ -194,7 +194,7 @@ public class MessageTTLTest extends BrokerTestBase {
 
     @Test
     public void testTtlWithoutIgnoreSubscriptions() throws Exception {
-        String topicName = "persistent://prop/ns-abc/testTTLWithoutIgnoreSubscriptions";
+        String topicName = "persistent://tenant/ns-abc/testTTLWithoutIgnoreSubscriptions";
         String subName = "__SUB_FILTER";
         cleanup();
         int defaultTtl = 5;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/NonPersistentTopicE2ETest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/NonPersistentTopicE2ETest.java
@@ -82,7 +82,7 @@ public class NonPersistentTopicE2ETest extends BrokerTestBase {
     @Test(groups = "broker")
     public void testGCWillDeleteSchema() throws Exception {
         // 1. Simple successful GC
-        final String topicName = "non-persistent://prop/ns-abc/topic-1";
+        final String topicName = "non-persistent://tenant/ns-abc/topic-1";
         Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
         producer.close();
 
@@ -105,7 +105,7 @@ public class NonPersistentTopicE2ETest extends BrokerTestBase {
         assertFalse(topicHasSchema(topicName));
 
         // 1a. Topic that add/removes subscription can be GC'd
-        final String topicName2 = "non-persistent://prop/ns-abc/topic-1a";
+        final String topicName2 = "non-persistent://tenant/ns-abc/topic-1a";
         String subName = "sub1";
         Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName2).subscriptionName(subName).subscribe();
         topic = getTopic(topicName2);
@@ -123,7 +123,7 @@ public class NonPersistentTopicE2ETest extends BrokerTestBase {
         assertFalse(topicHasSchema(topicName2));
 
         // 2. Topic is not GCed with live connection
-        final String topicName3 = "non-persistent://prop/ns-abc/topic-2";
+        final String topicName3 = "non-persistent://tenant/ns-abc/topic-2";
         String subName2 = "sub1";
         consumer = pulsarClient.newConsumer().topic(topicName3).subscriptionName(subName2).subscribe();
         topic = getTopic(topicName3);
@@ -150,7 +150,7 @@ public class NonPersistentTopicE2ETest extends BrokerTestBase {
     @Test
     public void testCloseConsumerWillDeleteSchema() throws Exception {
         // 1. Simple successful GC
-        final String topicName = "non-persistent://prop/ns-abc/topic-1";
+        final String topicName = "non-persistent://tenant/ns-abc/topic-1";
         Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
         producer.close();
 
@@ -165,7 +165,7 @@ public class NonPersistentTopicE2ETest extends BrokerTestBase {
                 .user("foo").build();
         topic.get().addSchema(schemaData).join();
 
-        final String topicName3 = "non-persistent://prop/ns-abc/topic-2";
+        final String topicName3 = "non-persistent://tenant/ns-abc/topic-2";
         String subName = "sub1";
         Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName3).subscriptionName(subName).subscribe();
         topic = getTopic(topicName3);
@@ -187,9 +187,9 @@ public class NonPersistentTopicE2ETest extends BrokerTestBase {
     }
     @Test(groups = "broker")
     public void testPatternTopic() throws PulsarClientException, InterruptedException {
-        final String topic1 = "non-persistent://prop/ns-abc/testPatternTopic1-" + UUID.randomUUID().toString();
-        final String topic2 = "non-persistent://prop/ns-abc/testPatternTopic2-" + UUID.randomUUID().toString();
-        Pattern pattern = Pattern.compile("prop/ns-abc/test.*");
+        final String topic1 = "non-persistent://tenant/ns-abc/testPatternTopic1-" + UUID.randomUUID().toString();
+        final String topic2 = "non-persistent://tenant/ns-abc/testPatternTopic2-" + UUID.randomUUID().toString();
+        Pattern pattern = Pattern.compile("tenant/ns-abc/test.*");
         Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING)
                 .topicsPattern(pattern)
                 .subscriptionName("my-sub")
@@ -225,7 +225,7 @@ public class NonPersistentTopicE2ETest extends BrokerTestBase {
     @Test(groups = "broker")
     public void testGC() throws Exception {
         // 1. Simple successful GC
-        String topicName = "non-persistent://prop/ns-abc/topic-10";
+        String topicName = "non-persistent://tenant/ns-abc/topic-10";
         Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
         producer.close();
 
@@ -262,7 +262,7 @@ public class NonPersistentTopicE2ETest extends BrokerTestBase {
         assertTrue(pulsar.getBrokerService().getTopicReference(topicName).isPresent());
 
         // 5. Test for partitioned topic to delete the partitioned metadata
-        String topicGc = "non-persistent://prop/ns-abc/topic-gc";
+        String topicGc = "non-persistent://tenant/ns-abc/topic-gc";
         int partitions = 5;
         admin.topics().createPartitionedTopic(topicGc, partitions);
         Producer<byte[]> producer3 = pulsarClient.newProducer().topic(topicGc).create();
@@ -278,7 +278,7 @@ public class NonPersistentTopicE2ETest extends BrokerTestBase {
     @Test
     public void testCloseConsumerThenRunGC() throws Exception {
         // 1. Simple successful GC
-        String topicName = "non-persistent://prop/ns-abc/topic-10";
+        String topicName = "non-persistent://tenant/ns-abc/topic-10";
         Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
         producer.close();
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/NullValueTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/NullValueTest.java
@@ -61,8 +61,8 @@ public class NullValueTest extends BrokerTestBase {
     @DataProvider(name = "topics")
     public static Object[][] topics() {
         return new Object[][]{
-                {"persistent://prop/ns-abc/null-value-test-0", 1},
-                {"persistent://prop/ns-abc/null-value-test-1", 3},
+                {"persistent://tenant/ns-abc/null-value-test-0", 1},
+                {"persistent://tenant/ns-abc/null-value-test-1", 3},
         };
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OpportunisticStripingTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OpportunisticStripingTest.java
@@ -62,7 +62,7 @@ public class OpportunisticStripingTest extends BkEnsemblesTestBase {
                 .statsInterval(0, TimeUnit.SECONDS)
                 .build();) {
 
-            final String ns1 = "prop/usc/opportunistic1";
+            final String ns1 = "tenant/opportunistic1";
             admin.namespaces().createNamespace(ns1);
 
             final String topic1 = "persistent://" + ns1 + "/my-topic";

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PartitionKeyTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PartitionKeyTest.java
@@ -43,7 +43,7 @@ public class PartitionKeyTest extends BrokerTestBase {
 
     @Test(timeOut = 10000)
     public void testPartitionKey() throws Exception {
-        final String topicName = "persistent://prop/use/ns-abc/testPartitionKey";
+        final String topicName = "persistent://tenant/ns-abc/testPartitionKey";
 
         org.apache.pulsar.client.api.Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName)
                 .subscriptionName("my-subscription").subscribe();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentFailoverE2ETest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentFailoverE2ETest.java
@@ -169,7 +169,7 @@ public class PersistentFailoverE2ETest extends BrokerTestBase {
 
     @Test
     public void testSimpleConsumerEventsWithoutPartition() throws Exception {
-        final String topicName = "persistent://prop/use/ns-abc/failover-topic1-" + System.currentTimeMillis();
+        final String topicName = "persistent://tenant/ns-abc/failover-topic1-" + System.currentTimeMillis();
         final String subName = "sub1";
         final int numMsgs = 100;
 
@@ -314,7 +314,7 @@ public class PersistentFailoverE2ETest extends BrokerTestBase {
         int numPartitions = 4;
 
         final String topicName = BrokerTestUtil.newUniqueName(
-                "persistent://prop/use/ns-abc/testSimpleConsumerEventsWithPartition");
+                "persistent://tenant/ns-abc/testSimpleConsumerEventsWithPartition");
         final TopicName destName = TopicName.get(topicName);
         final String subName = "sub1";
         final int numMsgs = 100;
@@ -501,7 +501,7 @@ public class PersistentFailoverE2ETest extends BrokerTestBase {
 
     @Test
     public void testActiveConsumerFailoverWithDelay() throws Exception {
-        final String topicName = "persistent://prop/use/ns-abc/failover-topic3";
+        final String topicName = "persistent://tenant/ns-abc/failover-topic3";
         final String subName = "sub1";
         final int numMsgs = 100;
         List<Message<byte[]>> receivedMessages = new ArrayList<>();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentQueueE2ETest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentQueueE2ETest.java
@@ -85,7 +85,7 @@ public class PersistentQueueE2ETest extends BrokerTestBase {
 
     @Test
     public void testSimpleConsumerEvents() throws Exception {
-        final String topicName = "persistent://prop/use/ns-abc/shared-topic1";
+        final String topicName = "persistent://tenant/ns-abc/shared-topic1";
         final String subName = "sub1";
         final int numMsgs = 100;
 
@@ -186,7 +186,7 @@ public class PersistentQueueE2ETest extends BrokerTestBase {
 
     @Test
     public void testReplayOnConsumerDisconnect() throws Exception {
-        final String topicName = "persistent://prop/use/ns-abc/shared-topic3";
+        final String topicName = "persistent://tenant/ns-abc/shared-topic3";
         final String subName = "sub3";
         final int numMsgs = 100;
 
@@ -240,7 +240,7 @@ public class PersistentQueueE2ETest extends BrokerTestBase {
     // how the round robin distribution algorithm is behaving
     @Test(enabled = false)
     public void testRoundRobinBatchDistribution() throws Exception {
-        final String topicName = "persistent://prop/use/ns-abc/shared-topic5";
+        final String topicName = "persistent://tenant/ns-abc/shared-topic5";
         final String subName = "sub5";
         final int numMsgs = 137; /* some random number different than default batch size of 100 */
 
@@ -312,7 +312,7 @@ public class PersistentQueueE2ETest extends BrokerTestBase {
     @Test(timeOut = 300000)
     public void testSharedSingleAckedNormalTopic() throws Exception {
         String key = "test1";
-        final String topicName = "persistent://prop/use/ns-abc/topic-" + key;
+        final String topicName = "persistent://tenant/ns-abc/topic-" + key;
         final String subscriptionName = "my-shared-subscription-" + key;
         final String messagePredicate = "my-message-" + key + "-";
         final int totalMessages = 50;
@@ -383,7 +383,7 @@ public class PersistentQueueE2ETest extends BrokerTestBase {
     @Test(timeOut = 60000)
     public void testCancelReadRequestOnLastDisconnect() throws Exception {
         String key = "testCancelReadRequestOnLastDisconnect";
-        final String topicName = "persistent://prop/use/ns-abc/topic-" + key;
+        final String topicName = "persistent://tenant/ns-abc/topic-" + key;
         final String subscriptionName = "my-shared-subscription-" + key;
         final String messagePredicate = "my-message-" + key + "-";
         final int totalMessages = 10;
@@ -459,7 +459,7 @@ public class PersistentQueueE2ETest extends BrokerTestBase {
 
     @Test
     public void testUnackedCountWithRedeliveries() throws Exception {
-        final String topicName = "persistent://prop/use/ns-abc/testUnackedCountWithRedeliveries";
+        final String topicName = "persistent://tenant/ns-abc/testUnackedCountWithRedeliveries";
         final String subName = "sub3";
         final int numMsgs = 10;
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicConcurrentTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicConcurrentTest.java
@@ -69,7 +69,7 @@ public class PersistentTopicConcurrentTest extends MockedBookKeeperTestCase {
     @SuppressWarnings("unused")
     private ManagedCursor cursorMock;
 
-    final String successTopicName = "persistent://prop/use/ns-abc/successTopic";
+    final String successTopicName = "persistent://tenant/ns-abc/successTopic";
     final String successSubName = "successSub";
     private static final Logger log = LoggerFactory.getLogger(PersistentTopicTest.class);
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicE2ETest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicE2ETest.java
@@ -142,7 +142,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
 
     @Test
     public void testSimpleProducerEvents() throws Exception {
-        final String topicName = "persistent://prop/ns-abc/topic0";
+        final String topicName = "persistent://tenant/ns-abc/topic0";
 
         // 1. producer connect
         Producer<byte[]> producer = pulsarClient.newProducer()
@@ -173,7 +173,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
 
     @Test
     public void testSimpleConsumerEvents() throws Exception {
-        final String topicName = "persistent://prop/ns-abc/topic1";
+        final String topicName = "persistent://tenant/ns-abc/topic1";
         final String subName = "sub1";
         final int numMsgs = 10;
 
@@ -260,7 +260,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
 
     @Test
     public void testConsumerFlowControl() throws Exception {
-        final String topicName = "persistent://prop/ns-abc/topic2";
+        final String topicName = "persistent://tenant/ns-abc/topic2";
         final String subName = "sub2";
 
         Message<byte[]> msg;
@@ -307,7 +307,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
      */
     @Test
     public void testActiveSubscriptionWithCache() throws Exception {
-        final String topicName = "persistent://prop/ns-abc/topic2";
+        final String topicName = "persistent://tenant/ns-abc/topic2";
         final String subName = "sub2";
 
         Message<byte[]> msg;
@@ -363,7 +363,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
     @Test(enabled = false)
     public void testConcurrentConsumerThreads() throws Exception {
         // test concurrent consumer threads on same consumerId
-        final String topicName = "persistent://prop/ns-abc/topic3";
+        final String topicName = "persistent://tenant/ns-abc/topic3";
         final String subName = "sub3";
 
         final int recvQueueSize = 100;
@@ -417,7 +417,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
     @Test(enabled = false)
     // TODO: enable this after java client supports graceful close
     public void testGracefulClose() throws Exception {
-        final String topicName = "persistent://prop/ns-abc/topic4";
+        final String topicName = "persistent://tenant/ns-abc/topic4";
         final String subName = "sub4";
 
         Producer<byte[]> producer = pulsarClient.newProducer()
@@ -482,7 +482,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
 
     @Test
     public void testSimpleCloseTopic() throws Exception {
-        final String topicName = "persistent://prop/ns-abc/topic5";
+        final String topicName = "persistent://tenant/ns-abc/topic5";
         final String subName = "sub5";
 
         Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName(subName).subscribe();
@@ -514,7 +514,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
 
     @Test
     public void testSingleClientMultipleSubscriptions() throws Exception {
-        final String topicName = "persistent://prop/ns-abc/topic6";
+        final String topicName = "persistent://tenant/ns-abc/topic6";
         final String subName = "sub6";
 
         pulsarClient.newConsumer().topic(topicName).subscriptionName(subName).subscribe();
@@ -533,7 +533,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
 
     @Test
     public void testMultipleClientsMultipleSubscriptions() throws Exception {
-        final String topicName = "persistent://prop/ns-abc/topic7";
+        final String topicName = "persistent://tenant/ns-abc/topic7";
         final String subName = "sub7";
 
         @Cleanup("shutdown")
@@ -556,7 +556,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
 
     @Test
     public void testTopicDeleteWithDisconnectedSubscription() throws Exception {
-        final String topicName = "persistent://prop/ns-abc/topic8";
+        final String topicName = "persistent://tenant/ns-abc/topic8";
         final String subName = "sub1";
 
         // 1. client connect
@@ -588,7 +588,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
 
     @Test(enabled = false)
     public void testUnloadNamespace() throws Exception {
-        String topic = "persistent://prop/ns-abc/topic-9";
+        String topic = "persistent://tenant/ns-abc/topic-9";
         TopicName topicName = TopicName.get(topic);
         pulsarClient.newProducer().topic(topic).create();
         pulsarClient.close();
@@ -597,7 +597,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         assertTrue(((ManagedLedgerFactoryImpl) pulsar.getDefaultManagedLedgerFactory()).getManagedLedgers()
                 .containsKey(topicName.getPersistenceNamingEncoding()));
 
-        admin.namespaces().unload("prop/ns-abc");
+        admin.namespaces().unload("tenant/ns-abc");
 
         int i = 0;
         for (i = 0; i < 30; i++) {
@@ -618,7 +618,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
     @Test
     public void testGC() throws Exception {
         // 1. Simple successful GC
-        String topicName = "persistent://prop/ns-abc/topic-10";
+        String topicName = "persistent://tenant/ns-abc/topic-10";
         Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
         producer.close();
 
@@ -652,7 +652,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         assertTrue(pulsar.getBrokerService().getTopicReference(topicName).isPresent());
 
         // 6. Test for partitioned topic to delete the partitioned metadata
-        String topicGc = "persistent://prop/ns-abc/topic-gc";
+        String topicGc = "persistent://tenant/ns-abc/topic-gc";
         int partitions = 5;
         admin.topics().createPartitionedTopic(topicGc, partitions);
         Producer<byte[]> producer3 = pulsarClient.newProducer().topic(topicGc).create();
@@ -688,7 +688,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
     @Test
     public void testGCWillDeleteSchema() throws Exception {
         // 1. Simple successful GC
-        String topicName = "persistent://prop/ns-abc/topic-1";
+        String topicName = "persistent://tenant/ns-abc/topic-1";
         Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
         producer.close();
 
@@ -710,7 +710,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         assertFalse(topicHasSchema(topicName));
 
         // 2. Topic is not GCed with live connection
-        topicName = "persistent://prop/ns-abc/topic-2";
+        topicName = "persistent://tenant/ns-abc/topic-2";
         String subName = "sub1";
         Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName(subName).subscribe();
         topic = getTopic(topicName);
@@ -749,7 +749,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         LookupService binaryLookupService = binaryProtocolClient.getLookup();
         LookupService httpLookupService = httpProtocolClient.getLookup();
 
-        String topicName = "persistent://prop/ns-abc/topic-1";
+        String topicName = "persistent://tenant/ns-abc/topic-1";
         //Topic is not GCed with live connection
         @Cleanup
         Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
@@ -785,9 +785,9 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
 
     @Test
     public void testConcurrentlyDeleteSchema() throws Exception {
-        String topic = "persistent://prop/ns-delete-schema/concurrently-delete-schema-test";
+        String topic = "persistent://tenant/ns-delete-schema/concurrently-delete-schema-test";
         int partitions = 50;
-        admin.namespaces().createNamespace("prop/ns-delete-schema", 3);
+        admin.namespaces().createNamespace("tenant/ns-delete-schema", 3);
         admin.topics().createPartitionedTopic(topic, partitions);
 
         Producer producer = pulsarClient
@@ -817,10 +817,10 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
     public void testGcAndRetentionPolicy() throws Exception {
 
         // Retain data for at-least 10min
-        admin.namespaces().setRetention("prop/ns-abc", new RetentionPolicies(10, 10));
+        admin.namespaces().setRetention("tenant/ns-abc", new RetentionPolicies(10, 10));
 
         // 1. Simple successful GC
-        String topicName = "persistent://prop/ns-abc/topic-10";
+        String topicName = "persistent://tenant/ns-abc/topic-10";
         Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
         producer.close();
 
@@ -830,7 +830,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         assertNotNull(pulsar.getBrokerService().getTopicReference(topicName));
 
         // Remove retention
-        admin.namespaces().setRetention("prop/ns-abc", new RetentionPolicies());
+        admin.namespaces().setRetention("tenant/ns-abc", new RetentionPolicies());
         Thread.sleep(300);
 
         // 2. Topic is not GCed with live connection
@@ -860,10 +860,10 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
     @Test
     public void testInfiniteRetentionPolicy() throws Exception {
         // Retain data forever
-        admin.namespaces().setRetention("prop/ns-abc", new RetentionPolicies(-1, -1));
+        admin.namespaces().setRetention("tenant/ns-abc", new RetentionPolicies(-1, -1));
 
         // 1. Simple successful GC
-        String topicName = "persistent://prop/ns-abc/topic-10";
+        String topicName = "persistent://tenant/ns-abc/topic-10";
         Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
         producer.close();
 
@@ -873,7 +873,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         assertNotNull(pulsar.getBrokerService().getTopicReference(topicName));
 
         // Remove retention
-        admin.namespaces().setRetention("prop/ns-abc", new RetentionPolicies());
+        admin.namespaces().setRetention("tenant/ns-abc", new RetentionPolicies());
         Thread.sleep(300);
 
         // 2. Topic is not GCed with live connection
@@ -906,11 +906,11 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         pulsar.getConfiguration().setDefaultRetentionSizeInMB(-1);
         pulsar.getConfiguration().setDefaultRetentionTimeInMinutes(-1);
 
-        String namespaceName = "prop/ns-default-retention-policy";
+        String namespaceName = "tenant/ns-default-retention-policy";
         admin.namespaces().createNamespace(namespaceName);
 
         // 1. Simple successful GC
-        String topicName = "persistent://prop/ns-abc/topic-10";
+        String topicName = "persistent://tenant/ns-abc/topic-10";
         Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
         producer.close();
 
@@ -920,7 +920,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         assertTrue(pulsar.getBrokerService().getTopicReference(topicName).isPresent());
 
         // Remove retention
-        admin.namespaces().setRetention("prop/ns-abc", new RetentionPolicies());
+        admin.namespaces().setRetention("tenant/ns-abc", new RetentionPolicies());
         Thread.sleep(300);
 
         // 2. Topic is not GCed with live connection
@@ -946,13 +946,13 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
     @Test
     public void testMessageExpiry() throws Exception {
         int messageTTLSecs = 1;
-        String namespaceName = "prop/expiry-check";
+        String namespaceName = "tenant/expiry-check";
 
         admin.namespaces().createNamespace(namespaceName);
         admin.namespaces().setNamespaceReplicationClusters(namespaceName, Sets.newHashSet("test"));
         admin.namespaces().setNamespaceMessageTTL(namespaceName, messageTTLSecs);
 
-        final String topicName = "persistent://prop/expiry-check/topic1";
+        final String topicName = "persistent://tenant/expiry-check/topic1";
         final String subName = "sub1";
         final int numMsgs = 10;
 
@@ -995,7 +995,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
     public void testMessageExpiryWithTopicMessageTTL() throws Exception {
         int namespaceMessageTTLSecs = 10;
         int topicMessageTTLSecs = 2;
-        String namespaceName = "prop/expiry-check-2";
+        String namespaceName = "tenant/expiry-check-2";
 
         cleanup();
         this.conf.setForceDeleteNamespaceAllowed(true);
@@ -1005,7 +1005,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         admin.namespaces().setNamespaceReplicationClusters(namespaceName, Sets.newHashSet("test"));
         admin.namespaces().setNamespaceMessageTTL(namespaceName, namespaceMessageTTLSecs);
 
-        final String topicName = "persistent://prop/expiry-check-2/topic2";
+        final String topicName = "persistent://tenant/expiry-check-2/topic2";
         final String subName = "sub1";
         final int numMsgs = 10;
 
@@ -1089,13 +1089,13 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
     @Test
     public void testMessageExpiryWithFewExpiredBacklog() throws Exception {
         int messageTTLSecs = 10;
-        String namespaceName = "prop/expiry-check-1";
+        String namespaceName = "tenant/expiry-check-1";
 
         admin.namespaces().createNamespace(namespaceName);
         admin.namespaces().setNamespaceReplicationClusters(namespaceName, Sets.newHashSet("test"));
         admin.namespaces().setNamespaceMessageTTL(namespaceName, messageTTLSecs);
 
-        final String topicName = "persistent://prop/expiry-check-1/topic1";
+        final String topicName = "persistent://tenant/expiry-check-1/topic1";
         final String subName = "sub1";
         final int numMsgs = 10;
 
@@ -1132,7 +1132,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
 
     @Test
     public void testSubscriptionTypeTransitions() throws Exception {
-        final String topicName = "persistent://prop/ns-abc/shared-topic2";
+        final String topicName = "persistent://tenant/ns-abc/shared-topic2";
         final String subName = "sub2";
 
         Consumer<byte[]> consumer1 = pulsarClient.newConsumer().topic(topicName).subscriptionName(subName)
@@ -1218,7 +1218,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
 
     @Test
     public void testReceiveWithTimeout() throws Exception {
-        final String topicName = "persistent://prop/ns-abc/topic-receive-timeout";
+        final String topicName = "persistent://tenant/ns-abc/topic-receive-timeout";
         final String subName = "sub";
 
         ConsumerImpl<byte[]> consumer = (ConsumerImpl<byte[]>) pulsarClient.newConsumer().topic(topicName)
@@ -1251,7 +1251,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
 
     @Test
     public void testProducerReturnedMessageId() throws Exception {
-        final String topicName = "persistent://prop/ns-abc/topic-xyz";
+        final String topicName = "persistent://tenant/ns-abc/topic-xyz";
 
         // 1. producer connect
         Producer<byte[]> producer = pulsarClient.newProducer()
@@ -1300,7 +1300,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
 
     @Test
     public void testProducerQueueFullBlocking() throws Exception {
-        final String topicName = "persistent://prop/ns-abc/topic-xyzx";
+        final String topicName = "persistent://tenant/ns-abc/topic-xyzx";
         final int messages = 10;
 
         @Cleanup
@@ -1348,7 +1348,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
 
     @Test
     public void testProducerQueueFullBlockingWithPartitionedTopic() throws Exception {
-        final String topicName = "persistent://prop/ns-abc/topic-xyzx2";
+        final String topicName = "persistent://tenant/ns-abc/topic-xyzx2";
         admin.topics().createPartitionedTopic(topicName, 2);
 
         @Cleanup
@@ -1391,7 +1391,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
 
     @Test
     public void testProducerQueueFullNonBlocking() throws Exception {
-        final String topicName = "persistent://prop/ns-abc/topic-xyzx";
+        final String topicName = "persistent://tenant/ns-abc/topic-xyzx";
         final int messages = 10;
 
         // 1. Producer connect
@@ -1446,12 +1446,12 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
 
         // 1. producers connect
         Producer<byte[]> producer1 = pulsarClient.newProducer()
-            .topic("persistent://prop/ns-abc/topic-1")
+            .topic("persistent://tenant/ns-abc/topic-1")
             .enableBatching(false)
             .messageRoutingMode(MessageRoutingMode.SinglePartition)
             .create();
         /* Producer<byte[]> producer2 = */ pulsarClient.newProducer()
-            .topic("persistent://prop/ns-abc/topic-2")
+            .topic("persistent://tenant/ns-abc/topic-2")
             .enableBatching(false)
             .messageRoutingMode(MessageRoutingMode.SinglePartition)
             .create();
@@ -1460,22 +1460,22 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
 
         Map<String, NamespaceBundleStats> bundleStatsMap = brokerService.getBundleStats();
         assertEquals(bundleStatsMap.size(), 1);
-        NamespaceBundleStats bundleStats = bundleStatsMap.get("prop/ns-abc/0x00000000_0xffffffff");
+        NamespaceBundleStats bundleStats = bundleStatsMap.get("tenant/ns-abc/0x00000000_0xffffffff");
         assertNotNull(bundleStats);
 
         producer1.close();
-        admin.topics().delete("persistent://prop/ns-abc/topic-1");
+        admin.topics().delete("persistent://tenant/ns-abc/topic-1");
 
         brokerService.updateRates();
 
         bundleStatsMap = brokerService.getBundleStats();
         assertEquals(bundleStatsMap.size(), 1);
-        bundleStats = bundleStatsMap.get("prop/ns-abc/0x00000000_0xffffffff");
+        bundleStats = bundleStatsMap.get("tenant/ns-abc/0x00000000_0xffffffff");
         assertNotNull(bundleStats);
 
         // // Delete 2nd topic as well
         // producer2.close();
-        // admin.topics().delete("persistent://prop/ns-abc/topic-2");
+        // admin.topics().delete("persistent://tenant/ns-abc/topic-2");
         //
         // brokerService.updateRates();
         //
@@ -1490,7 +1490,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
 
     @Test(dataProvider = "codec")
     public void testCompression(CompressionType compressionType) throws Exception {
-        final String topicName = "persistent://prop/ns-abc/topic0" + compressionType;
+        final String topicName = "persistent://tenant/ns-abc/topic0" + compressionType;
 
         // 1. producer connect
         Producer<byte[]> producer = pulsarClient.newProducer()
@@ -1532,7 +1532,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         // disable statsUpdate to calculate rates explicitly
         statsUpdater.shutdownNow();
 
-        final String namespace = "prop/ns-abc";
+        final String namespace = "tenant/ns-abc";
         Producer<byte[]> producer = pulsarClient.newProducer()
             .topic("persistent://" + namespace + "/topic0")
             .enableBatching(false)
@@ -1574,7 +1574,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         setup();
         BrokerService brokerService = this.pulsar.getBrokerService();
 
-        final String namespace = "prop/ns-abc";
+        final String namespace = "tenant/ns-abc";
         Producer<byte[]> producer = pulsarClient.newProducer()
                 .topic("persistent://" + namespace + "/topic0")
                 .create();
@@ -1687,7 +1687,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
 
     @Test
     public void testPayloadCorruptionDetection() throws Exception {
-        final String topicName = "persistent://prop/ns-abc/topic1";
+        final String topicName = "persistent://tenant/ns-abc/topic1";
 
         // 1. producer connect
         Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName)
@@ -1743,7 +1743,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
      */
     @Test
     public void testMessageRedelivery() throws Exception {
-        final String topicName = "persistent://prop/ns-abc/topic2";
+        final String topicName = "persistent://tenant/ns-abc/topic2";
         final String subName = "sub2";
 
         Message<String> msg;
@@ -1801,7 +1801,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
 
     @Test
     public void testCreateProducerWithSameName() throws Exception {
-        String topic = "persistent://prop/ns-abc/testCreateProducerWithSameName";
+        String topic = "persistent://tenant/ns-abc/testCreateProducerWithSameName";
 
         ProducerBuilder<byte[]> producerBuilder = pulsarClient.newProducer()
             .topic(topic)
@@ -1827,7 +1827,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
 
     @Test
     public void testGetOrCreateTopic() throws Exception {
-        String topicName = "persistent://prop/ns-abc/testGetOrCreateTopic";
+        String topicName = "persistent://tenant/ns-abc/testGetOrCreateTopic";
 
         admin.lookups().lookupTopic(topicName);
         Topic topic = pulsar.getBrokerService().getOrCreateTopic(topicName).get();
@@ -1839,7 +1839,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
 
     @Test
     public void testGetTopicIfExists() throws Exception {
-        String topicName = "persistent://prop/ns-abc/testGetTopicIfExists";
+        String topicName = "persistent://tenant/ns-abc/testGetTopicIfExists";
         admin.lookups().lookupTopic(topicName);
         Optional<Topic> topic = pulsar.getBrokerService().getTopicIfExists(topicName).join();
         assertFalse(topic.isPresent());
@@ -1850,7 +1850,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
 
     @Test
     public void testWithEventTime() throws Exception {
-        final String topicName = "prop/ns-abc/topic-event-time";
+        final String topicName = "tenant/ns-abc/topic-event-time";
         final String subName = "sub";
 
         Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING).topic(topicName).subscriptionName(subName)
@@ -1866,7 +1866,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
 
     @Test
     public void testProducerBusy() throws Exception {
-        final String topicName = "prop/ns-abc/producer-busy-" + System.nanoTime();
+        final String topicName = "tenant/ns-abc/producer-busy-" + System.nanoTime();
 
         @Cleanup
         Producer<String> producer = pulsarClient.newProducer(Schema.STRING)
@@ -1972,7 +1972,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         conf.setTopicFactoryClassName(MyTopicFactory.class.getName());
         restartBroker();
 
-        final String topicName = (isPersistent ? "persistent" : "non-persistent") + "://prop/ns-abc/factoryTopic"
+        final String topicName = (isPersistent ? "persistent" : "non-persistent") + "://tenant/ns-abc/factoryTopic"
                 + isPersistent;
         MyTopicFactory.count.set(0);
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
@@ -160,9 +160,9 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
     private ManagedLedger ledgerMock;
     private ManagedCursor cursorMock;
 
-    final String successTopicName = "persistent://prop/use/ns-abc/successTopic";
-    final String successPartitionTopicName = "persistent://prop/use/ns-abc/successTopic-partition-0";
-    final String failTopicName = "persistent://prop/use/ns-abc/failTopic";
+    final String successTopicName = "persistent://tenant/ns-abc/successTopic";
+    final String successPartitionTopicName = "persistent://tenant/ns-abc/successTopic-partition-0";
+    final String failTopicName = "persistent://tenant/ns-abc/failTopic";
     final String successSubName = "successSub";
     final String successSubName2 = "successSub2";
     private static final Logger log = LoggerFactory.getLogger(PersistentTopicTest.class);
@@ -250,7 +250,7 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
         doReturn(new ManagedLedgerConfig()).when(ledgerMock).getConfig();
         doReturn(new ArrayList<>()).when(ledgerMock).getCursors();
 
-        final String topicName = "persistent://prop/use/ns-abc/topic1";
+        final String topicName = "persistent://tenant/ns-abc/topic1";
         doAnswer(invocationOnMock -> {
             ((OpenLedgerCallback) invocationOnMock.getArguments()[2]).openLedgerComplete(ledgerMock, null);
             return null;
@@ -274,7 +274,7 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
 
     @Test
     public void testCreateTopicMLFailure() {
-        final String jinxedTopicName = "persistent://prop/use/ns-abc/topic3";
+        final String jinxedTopicName = "persistent://tenant/ns-abc/topic3";
         doAnswer(invocationOnMock -> {
             new Thread(() -> ((OpenLedgerCallback) invocationOnMock.getArguments()[2])
                     .openLedgerFailed(new ManagedLedgerException("Managed ledger failure"), null)).start();
@@ -372,7 +372,7 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
 
     @Test
     public void testPublishMessageMLFailure() throws Exception {
-        final String successTopicName = "persistent://prop/use/ns-abc/successTopic";
+        final String successTopicName = "persistent://tenant/ns-abc/successTopic";
 
         final ManagedLedger ledgerMock = mock(ManagedLedger.class);
         doReturn(new ManagedLedgerConfig()).when(ledgerMock).getConfig();
@@ -1662,7 +1662,7 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
      */
     @Test
     public void testAtomicReplicationRemoval() throws Exception {
-        final String globalTopicName = "persistent://prop/global/ns-abc/successTopic";
+        final String globalTopicName = "persistent://tenant/global/ns-abc/successTopic";
         String localCluster = "local";
         String remoteCluster = "remote";
         final ManagedLedger ledgerMock = mock(ManagedLedger.class);
@@ -1722,7 +1722,7 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
     @SuppressWarnings("unchecked")
     @Test
     public void testClosingReplicationProducerTwice() throws Exception {
-        final String globalTopicName = "persistent://prop/global/ns/testClosingReplicationProducerTwice";
+        final String globalTopicName = "persistent://tenant/global/ns/testClosingReplicationProducerTwice";
         String localCluster = "local";
         String remoteCluster = "remote";
         final ManagedLedger ledgerMock = mock(ManagedLedger.class);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ResendRequestTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ResendRequestTest.java
@@ -65,7 +65,7 @@ public class ResendRequestTest extends BrokerTestBase {
     @Test(timeOut = testTimeout)
     public void testExclusiveSingleAckedNormalTopic() throws Exception {
         String key = "testExclusiveSingleAckedNormalTopic";
-        final String topicName = "persistent://prop/use/ns-abc/topic-" + key;
+        final String topicName = "persistent://tenant/ns-abc/topic-" + key;
         final String subscriptionName = "my-ex-subscription-" + key;
         final String messagePredicate = "my-message-" + key + "-";
         final int totalMessages = 10;
@@ -158,7 +158,7 @@ public class ResendRequestTest extends BrokerTestBase {
     @Test(timeOut = testTimeout)
     public void testSharedSingleAckedNormalTopic() throws Exception {
         String key = "testSharedSingleAckedNormalTopic";
-        final String topicName = "persistent://prop/use/ns-abc/topic-" + key;
+        final String topicName = "persistent://tenant/ns-abc/topic-" + key;
         final String subscriptionName = "my-shared-subscription-" + key;
         final String messagePredicate = "my-message-" + key + "-";
         final int totalMessages = 10;
@@ -245,7 +245,7 @@ public class ResendRequestTest extends BrokerTestBase {
     @Test(timeOut = testTimeout)
     public void testFailoverSingleAckedNormalTopic() throws Exception {
         String key = "testFailoverSingleAckedNormalTopic";
-        final String topicName = "persistent://prop/use/ns-abc/topic-" + key;
+        final String topicName = "persistent://tenant/ns-abc/topic-" + key;
         final String subscriptionName = "my-failover-subscription-" + key;
         final String messagePredicate = "my-message-" + key + "-";
         final int totalMessages = 10;
@@ -363,7 +363,7 @@ public class ResendRequestTest extends BrokerTestBase {
     @Test(timeOut = testTimeout)
     public void testExclusiveCumulativeAckedNormalTopic() throws Exception {
         String key = "testExclusiveCumulativeAckedNormalTopic";
-        final String topicName = "persistent://prop/use/ns-abc/topic-" + key;
+        final String topicName = "persistent://tenant/ns-abc/topic-" + key;
         final String subscriptionName = "my-ex-subscription-" + key;
         final String messagePredicate = "my-message-" + key + "-";
         final int totalMessages = 10;
@@ -420,13 +420,13 @@ public class ResendRequestTest extends BrokerTestBase {
     @Test(timeOut = testTimeout)
     public void testExclusiveSingleAckedPartitionedTopic() throws Exception {
         String key = "testExclusiveSingleAckedPartitionedTopic";
-        final String topicName = "persistent://prop/use/ns-abc/topic-" + key;
+        final String topicName = "persistent://tenant/ns-abc/topic-" + key;
         final String subscriptionName = "my-ex-subscription-" + key;
         final String messagePredicate = "my-message-" + key + "-";
         final int totalMessages = 10;
         final int numberOfPartitions = 4;
         TenantInfoImpl tenantInfo = createDefaultTenantInfo();
-        admin.tenants().createTenant("prop", tenantInfo);
+        admin.tenants().createTenant("tenant", tenantInfo);
         admin.topics().createPartitionedTopic(topicName, numberOfPartitions);
         // Special step to create partitioned topic
 
@@ -476,13 +476,13 @@ public class ResendRequestTest extends BrokerTestBase {
     @Test(timeOut = testTimeout)
     public void testSharedSingleAckedPartitionedTopic() throws Exception {
         String key = "testSharedSingleAckedPartitionedTopic";
-        final String topicName = "persistent://prop/use/ns-abc/topic-" + key;
+        final String topicName = "persistent://tenant/ns-abc/topic-" + key;
         final String subscriptionName = "my-shared-subscription-" + key;
         final String messagePredicate = "my-message-" + key + "-";
         final int totalMessages = 10;
         final int numberOfPartitions = 3;
         TenantInfoImpl tenantInfo = createDefaultTenantInfo();
-        admin.tenants().createTenant("prop", tenantInfo);
+        admin.tenants().createTenant("tenant", tenantInfo);
         admin.topics().createPartitionedTopic(topicName, numberOfPartitions);
         Random rn = new Random();
         // Special step to create partitioned topic
@@ -577,13 +577,13 @@ public class ResendRequestTest extends BrokerTestBase {
     @Test(timeOut = testTimeout)
     public void testFailoverSingleAckedPartitionedTopic() throws Exception {
         String key = "testFailoverSingleAckedPartitionedTopic";
-        final String topicName = "persistent://prop/use/ns-abc/topic-" + key;
+        final String topicName = "persistent://tenant/ns-abc/topic-" + key;
         final String subscriptionName = "my-failover-subscription-" + key;
         final String messagePredicate = "my-message-" + key + "-";
         final int totalMessages = 10;
         final int numberOfPartitions = 3;
         TenantInfoImpl tenantInfo = createDefaultTenantInfo();
-        admin.tenants().createTenant("prop", tenantInfo);
+        admin.tenants().createTenant("tenant", tenantInfo);
         admin.topics().createPartitionedTopic(topicName, numberOfPartitions);
         Random rn = new Random();
         // Special step to create partitioned topic
@@ -668,7 +668,7 @@ public class ResendRequestTest extends BrokerTestBase {
     @Test(timeOut = testTimeout)
     public void testFailoverInactiveConsumer() throws Exception {
         String key = "testFailoverInactiveConsumer";
-        final String topicName = "persistent://prop/use/ns-abc/topic-" + key;
+        final String topicName = "persistent://tenant/ns-abc/topic-" + key;
         final String subscriptionName = "my-failover-subscription-" + key;
         final String messagePredicate = "my-message-" + key + "-";
         final int totalMessages = 10;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
@@ -195,13 +195,13 @@ public class ServerCnxTest {
             "persistent://nonexistent-tenant/nonexistent-cluster/nonexistent-namespace/successNonExistentTopic";
     private final String topicWithNonLocalCluster = "persistent://tenant/ns-abc/successTopic";
     private final List<String> matchingTopics = Arrays.asList(
-            "persistent://use/ns-abc/topic-1",
-            "persistent://use/ns-abc/topic-2");
+            "persistent://tenant/ns-abc/topic-1",
+            "persistent://tenant/ns-abc/topic-2");
 
     private final List<String> topics = Arrays.asList(
-            "persistent://use/ns-abc/topic-1",
-            "persistent://use/ns-abc/topic-2",
-            "persistent://use/ns-abc/topic");
+            "persistent://tenant/ns-abc/topic-1",
+            "persistent://tenant/ns-abc/topic-2",
+            "persistent://tenant/ns-abc/topic");
 
     private ManagedLedger ledgerMock;
     private ManagedCursor cursorMock;
@@ -217,7 +217,7 @@ public class ServerCnxTest {
         svcConfig.setLoadBalancerOverrideBrokerNicSpeedGbps(Optional.of(1.0d));
         svcConfig.setKeepAliveIntervalSeconds(inSec(1, TimeUnit.SECONDS));
         svcConfig.setBacklogQuotaCheckEnabled(false);
-        svcConfig.setClusterName("use");
+        svcConfig.setClusterName("test");
         pulsarTestContext = PulsarTestContext.builderForNonStartableContext()
                 .config(svcConfig)
                 .spyByDefault()
@@ -234,11 +234,11 @@ public class ServerCnxTest {
         doReturn(true).when(namespaceService).isServiceUnitActive(any());
         doReturn(CompletableFuture.completedFuture(true)).when(namespaceService).isServiceUnitActiveAsync(any());
         doReturn(CompletableFuture.completedFuture(topics)).when(namespaceService).getListOfTopics(
-                NamespaceName.get("use", "ns-abc"), CommandGetTopicsOfNamespace.Mode.ALL);
+                NamespaceName.get("tenant", "ns-abc"), CommandGetTopicsOfNamespace.Mode.ALL);
         doReturn(CompletableFuture.completedFuture(topics)).when(namespaceService).getListOfUserTopics(
-                NamespaceName.get("use", "ns-abc"), CommandGetTopicsOfNamespace.Mode.ALL);
+                NamespaceName.get("tenant", "ns-abc"), CommandGetTopicsOfNamespace.Mode.ALL);
         doReturn(CompletableFuture.completedFuture(topics)).when(namespaceService).getListOfPersistentTopics(
-                NamespaceName.get("use", "ns-abc"));
+                NamespaceName.get("tenant", "ns-abc"));
 
         setupMLAsyncCallbackMocks();
 
@@ -3141,7 +3141,7 @@ public class ServerCnxTest {
         resetChannel();
         setChannelConnected();
         ByteBuf clientCommand = Commands.newGetTopicsOfNamespaceRequest(
-                "use/ns-abc", 1, CommandGetTopicsOfNamespace.Mode.ALL, null, null);
+                "tenant/ns-abc", 1, CommandGetTopicsOfNamespace.Mode.ALL, null, null);
         channel.writeInbound(clientCommand);
         CommandGetTopicsOfNamespaceResponse response = (CommandGetTopicsOfNamespaceResponse) getResponse();
 
@@ -3159,8 +3159,8 @@ public class ServerCnxTest {
         resetChannel();
         setChannelConnected();
         ByteBuf clientCommand = Commands.newGetTopicsOfNamespaceRequest(
-                "use/ns-abc", 1, CommandGetTopicsOfNamespace.Mode.ALL,
-                "use/ns-abc/topic-.*", null);
+                "tenant/ns-abc", 1, CommandGetTopicsOfNamespace.Mode.ALL,
+                "tenant/ns-abc/topic-.*", null);
         channel.writeInbound(clientCommand);
         CommandGetTopicsOfNamespaceResponse response = (CommandGetTopicsOfNamespaceResponse) getResponse();
 
@@ -3179,8 +3179,8 @@ public class ServerCnxTest {
         resetChannel();
         setChannelConnected();
         ByteBuf clientCommand = Commands.newGetTopicsOfNamespaceRequest(
-                "use/ns-abc", 1, CommandGetTopicsOfNamespace.Mode.ALL,
-                "use/ns-abc/(t|o|to|p|i|c)+-?)+!", null);
+                "tenant/ns-abc", 1, CommandGetTopicsOfNamespace.Mode.ALL,
+                "tenant/ns-abc/(t|o|to|p|i|c)+-?)+!", null);
         channel.writeInbound(clientCommand);
         CommandGetTopicsOfNamespaceResponse response = (CommandGetTopicsOfNamespaceResponse) getResponse();
 
@@ -3198,8 +3198,8 @@ public class ServerCnxTest {
         resetChannel();
         setChannelConnected();
         ByteBuf clientCommand = Commands.newGetTopicsOfNamespaceRequest(
-                "use/ns-abc", 1, CommandGetTopicsOfNamespace.Mode.ALL,
-                "use/ns-abc/topic-.*", "SOME_HASH");
+                "tenant/ns-abc", 1, CommandGetTopicsOfNamespace.Mode.ALL,
+                "tenant/ns-abc/topic-.*", "SOME_HASH");
         channel.writeInbound(clientCommand);
         CommandGetTopicsOfNamespaceResponse response = (CommandGetTopicsOfNamespaceResponse) getResponse();
 
@@ -3217,8 +3217,8 @@ public class ServerCnxTest {
         resetChannel();
         setChannelConnected();
         ByteBuf clientCommand = Commands.newGetTopicsOfNamespaceRequest(
-                "use/ns-abc", 1, CommandGetTopicsOfNamespace.Mode.ALL,
-                "use/ns-abc/topic-.*", TopicList.calculateHash(matchingTopics));
+                "tenant/ns-abc", 1, CommandGetTopicsOfNamespace.Mode.ALL,
+                "tenant/ns-abc/topic-.*", TopicList.calculateHash(matchingTopics));
         channel.writeInbound(clientCommand);
         CommandGetTopicsOfNamespaceResponse response = (CommandGetTopicsOfNamespaceResponse) getResponse();
 
@@ -3235,7 +3235,7 @@ public class ServerCnxTest {
         svcConfig.setEnableBrokerSideSubscriptionPatternEvaluation(true);
         resetChannel();
         setChannelConnected();
-        BaseCommand command = Commands.newWatchTopicList(1, 3, "use/ns-abc", "use/ns-abc/topic-.*", null);
+        BaseCommand command = Commands.newWatchTopicList(1, 3, "tenant/ns-abc", "tenant/ns-abc/topic-.*", null);
         ByteBuf serializedCommand = Commands.serializeWithSize(command);
 
         channel.writeInbound(serializedCommand);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
@@ -186,14 +186,14 @@ public class ServerCnxTest {
     private final int currentProtocolVersion = ProtocolVersion.values()[ProtocolVersion.values().length - 1]
             .getValue();
 
-    protected final String successTopicName = "persistent://prop/use/ns-abc/successTopic";
-    private final String failTopicName = "persistent://prop/use/ns-abc/failTopic";
-    private final String nonOwnedTopicName = "persistent://prop/use/ns-abc/success-not-owned-topic";
-    private final String encryptionRequiredTopicName = "persistent://prop/use/ns-abc/successEncryptionRequiredTopic";
+    protected final String successTopicName = "persistent://tenant/ns-abc/successTopic";
+    private final String failTopicName = "persistent://tenant/ns-abc/failTopic";
+    private final String nonOwnedTopicName = "persistent://tenant/ns-abc/success-not-owned-topic";
+    private final String encryptionRequiredTopicName = "persistent://tenant/ns-abc/successEncryptionRequiredTopic";
     private final String successSubName = "successSub";
     private final String nonExistentTopicName =
-            "persistent://nonexistent-prop/nonexistent-cluster/nonexistent-namespace/successNonExistentTopic";
-    private final String topicWithNonLocalCluster = "persistent://prop/usw/ns-abc/successTopic";
+            "persistent://nonexistent-tenant/nonexistent-cluster/nonexistent-namespace/successNonExistentTopic";
+    private final String topicWithNonLocalCluster = "persistent://tenant/ns-abc/successTopic";
     private final List<String> matchingTopics = Arrays.asList(
             "persistent://use/ns-abc/topic-1",
             "persistent://use/ns-abc/topic-2");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SubscribeRateTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SubscribeRateTest.java
@@ -49,7 +49,7 @@ public class SubscribeRateTest extends BrokerTestBase {
 
     @Test
     public void testBrokerLevelSubscribeRateDynamicUpdate() throws Exception {
-        final String topic = "persistent://prop/ns-abc/testBrokerLevelSubscribeRateDynamicUpdate";
+        final String topic = "persistent://tenant/ns-abc/testBrokerLevelSubscribeRateDynamicUpdate";
         Producer<byte[]> producer = pulsarClient.newProducer()
             .topic(topic)
             .producerName("producer-name")
@@ -90,7 +90,7 @@ public class SubscribeRateTest extends BrokerTestBase {
     @Test
     public void testUpdateSubscribeRateLimiter() throws Exception {
 
-        final String topic = "persistent://prop/ns-abc/testUpdateSubscribeRateLimiter";
+        final String topic = "persistent://tenant/ns-abc/testUpdateSubscribeRateLimiter";
 
         @Cleanup
         Producer<byte[]> producer = pulsarClient.newProducer()

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SubscriptionConsumerCompatibilityTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SubscriptionConsumerCompatibilityTest.java
@@ -49,7 +49,7 @@ public class SubscriptionConsumerCompatibilityTest {
     private PulsarTestContext pulsarTestContext;
     private ManagedLedger ledgerMock;
     private ManagedCursorImpl cursorMock;
-    private final String successTopicName = "persistent://prop/use/ns-abc/successTopic";
+    private final String successTopicName = "persistent://tenant/ns-abc/successTopic";
     private final String subName = "subscriptionName";
 
     @BeforeMethod

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SubscriptionSeekTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SubscriptionSeekTest.java
@@ -102,7 +102,7 @@ public class SubscriptionSeekTest extends BrokerTestBase {
 
     @Test
     public void testSeek() throws Exception {
-        final String topicName = "persistent://prop/use/ns-abc/testSeek";
+        final String topicName = "persistent://tenant/ns-abc/testSeek";
 
         @Cleanup
         Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
@@ -158,7 +158,7 @@ public class SubscriptionSeekTest extends BrokerTestBase {
 
     @Test
     public void testSeekIsByReceive() throws PulsarClientException {
-        final String topicName = "persistent://prop/use/ns-abc/testSeekIsByReceive";
+        final String topicName = "persistent://tenant/ns-abc/testSeekIsByReceive";
 
         @Cleanup
         Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
@@ -183,7 +183,7 @@ public class SubscriptionSeekTest extends BrokerTestBase {
 
     @Test
     public void testSeekForBatch() throws Exception {
-        final String topicName = "persistent://prop/use/ns-abcd/testSeekForBatch";
+        final String topicName = "persistent://tenant/ns-abcd/testSeekForBatch";
         String subscriptionName = "my-subscription-batch";
 
         @Cleanup
@@ -241,7 +241,7 @@ public class SubscriptionSeekTest extends BrokerTestBase {
 
     @Test
     public void testSeekForBatchMessageAndSpecifiedBatchIndex() throws Exception {
-        final String topicName = "persistent://prop/use/ns-abcd/testSeekForBatchMessageAndSpecifiedBatchIndex";
+        final String topicName = "persistent://tenant/ns-abcd/testSeekForBatchMessageAndSpecifiedBatchIndex";
         String subscriptionName = "my-subscription-batch";
 
         @Cleanup
@@ -324,7 +324,7 @@ public class SubscriptionSeekTest extends BrokerTestBase {
     @Test
     public void testSeekForBatchByAdmin() throws PulsarClientException, ExecutionException,
             InterruptedException, PulsarAdminException {
-        final String topicName = "persistent://prop/use/ns-abcd/testSeekForBatchByAdmin-"
+        final String topicName = "persistent://tenant/ns-abcd/testSeekForBatchByAdmin-"
                 + UUID.randomUUID().toString();
         String subscriptionName = "my-subscription-batch";
 
@@ -408,7 +408,7 @@ public class SubscriptionSeekTest extends BrokerTestBase {
 
     @Test
     public void testConcurrentResetCursor() throws Exception {
-        final String topicName = "persistent://prop/use/ns-abc/testConcurrentReset_" + System.currentTimeMillis();
+        final String topicName = "persistent://tenant/ns-abc/testConcurrentReset_" + System.currentTimeMillis();
         final String subscriptionName = "test-sub-name";
 
         @Cleanup
@@ -458,7 +458,7 @@ public class SubscriptionSeekTest extends BrokerTestBase {
 
     @Test
     public void testSeekOnPartitionedTopic() throws Exception {
-        final String topicName = "persistent://prop/use/ns-abc/testSeekPartitions";
+        final String topicName = "persistent://tenant/ns-abc/testSeekPartitions";
 
         admin.topics().createPartitionedTopic(topicName, 2);
         @Cleanup
@@ -474,7 +474,7 @@ public class SubscriptionSeekTest extends BrokerTestBase {
 
     @Test
     public void testSeekWithNonOwnerTopicMessage() throws Exception {
-        final String topicName = "persistent://prop/use/ns-abc/testNonOwnerTopicMessage";
+        final String topicName = "persistent://tenant/ns-abc/testNonOwnerTopicMessage";
 
         admin.topics().createPartitionedTopic(topicName, 2);
         @Cleanup
@@ -490,7 +490,7 @@ public class SubscriptionSeekTest extends BrokerTestBase {
 
     @Test
     public void testSeekTime() throws Exception {
-        final String topicName = "persistent://prop/use/ns-abc/testSeekTime";
+        final String topicName = "persistent://tenant/ns-abc/testSeekTime";
         String resetTimeStr = "100s";
         long resetTimeInMillis = TimeUnit.SECONDS
                 .toMillis(RelativeTimeUtil.parseRelativeTimeInSeconds(resetTimeStr));
@@ -528,7 +528,7 @@ public class SubscriptionSeekTest extends BrokerTestBase {
 
     @Test(timeOut = 30_000)
     public void testSeekByTimestamp() throws Exception {
-        String topicName = "persistent://prop/use/ns-abc/testSeekByTimestamp";
+        String topicName = "persistent://tenant/ns-abc/testSeekByTimestamp";
         admin.topics().createNonPartitionedTopic(topicName);
         admin.topics().createSubscription(topicName, "my-sub", MessageId.earliest);
 
@@ -573,7 +573,7 @@ public class SubscriptionSeekTest extends BrokerTestBase {
 
     @Test(timeOut = 30_000)
     public void testSeekByTimestampWithSkipNonRecoverableData() throws Exception {
-        String topicName = "persistent://prop/use/ns-abc/testSeekByTimestampWithSkipNonRecoverableData";
+        String topicName = "persistent://tenant/ns-abc/testSeekByTimestampWithSkipNonRecoverableData";
         admin.topics().createNonPartitionedTopic(topicName);
         admin.topics().createSubscription(topicName, "my-sub", MessageId.earliest);
 
@@ -656,7 +656,7 @@ public class SubscriptionSeekTest extends BrokerTestBase {
 
     @Test(timeOut = 30_000)
     public void testSeekByTimestampWithLedgerTrim() throws Exception {
-        String topicName = "persistent://prop/use/ns-abc/testSeekByTimestampWithLedgerTrim";
+        String topicName = "persistent://tenant/ns-abc/testSeekByTimestampWithLedgerTrim";
         admin.topics().createNonPartitionedTopic(topicName);
         admin.topics().createSubscription(topicName, "my-sub", MessageId.earliest);
 
@@ -720,7 +720,7 @@ public class SubscriptionSeekTest extends BrokerTestBase {
 
     @Test
     public void testSeekTimeByFunction() throws Exception {
-        final String topicName = "persistent://prop/use/ns-abc/test" + UUID.randomUUID();
+        final String topicName = "persistent://tenant/ns-abc/test" + UUID.randomUUID();
         int partitionNum = 4;
         int msgNum = 20;
         admin.topics().createPartitionedTopic(topicName, partitionNum);
@@ -767,7 +767,7 @@ public class SubscriptionSeekTest extends BrokerTestBase {
 
     @Test
     public void testSeekTimeOnPartitionedTopic() throws Exception {
-        final String topicName = "persistent://prop/use/ns-abc/testSeekTimePartitions";
+        final String topicName = "persistent://tenant/ns-abc/testSeekTimePartitions";
         final String resetTimeStr = "100s";
         final int partitions = 2;
         long resetTimeInMillis = TimeUnit.SECONDS
@@ -825,7 +825,7 @@ public class SubscriptionSeekTest extends BrokerTestBase {
 
     @Test
     public void testShouldCloseAllConsumersForMultipleConsumerDispatcherWhenSeek() throws Exception {
-        final String topicName = "persistent://prop/use/ns-abc/testShouldCloseAllConsumersFor"
+        final String topicName = "persistent://tenant/ns-abc/testShouldCloseAllConsumersFor"
                 + "MultipleConsumerDispatcherWhenSeek";
         // Disable pre-fetch in consumer to track the messages received
         @Cleanup
@@ -866,7 +866,7 @@ public class SubscriptionSeekTest extends BrokerTestBase {
 
     @Test
     public void testOnlyCloseActiveConsumerForSingleActiveConsumerDispatcherWhenSeek() throws Exception {
-        final String topicName = "persistent://prop/use/ns-abc/testOnlyCloseActiveConsumer"
+        final String topicName = "persistent://tenant/ns-abc/testOnlyCloseActiveConsumer"
                 + "ForSingleActiveConsumerDispatcherWhenSeek";
         // Disable pre-fetch in consumer to track the messages received
         @Cleanup
@@ -911,7 +911,7 @@ public class SubscriptionSeekTest extends BrokerTestBase {
 
     @Test
     public void testSeekByFunction() throws Exception {
-        final String topicName = "persistent://prop/use/ns-abc/test" + UUID.randomUUID();
+        final String topicName = "persistent://tenant/ns-abc/test" + UUID.randomUUID();
         int partitionNum = 4;
         int msgNum = 160;
         admin.topics().createPartitionedTopic(topicName, partitionNum);
@@ -989,8 +989,8 @@ public class SubscriptionSeekTest extends BrokerTestBase {
 
     @Test
     public void testSeekByFunctionAndMultiTopic() throws Exception {
-        final String topicName = "persistent://prop/use/ns-abc/test" + UUID.randomUUID();
-        final String topicName2 = "persistent://prop/use/ns-abc/test" + UUID.randomUUID();
+        final String topicName = "persistent://tenant/ns-abc/test" + UUID.randomUUID();
+        final String topicName2 = "persistent://tenant/ns-abc/test" + UUID.randomUUID();
         int partitionNum = 3;
         int msgNum = 15;
         admin.topics().createPartitionedTopic(topicName, partitionNum);
@@ -1039,7 +1039,7 @@ public class SubscriptionSeekTest extends BrokerTestBase {
 
     @Test
     public void testSeekWillNotEncounteredFencedError() throws Exception {
-        String topicName = "persistent://prop/ns-abc/my-topic2";
+        String topicName = "persistent://tenant/ns-abc/my-topic2";
         admin.topics().createNonPartitionedTopic(topicName);
         admin.topicPolicies().setRetention(topicName, new RetentionPolicies(3600, -1));
         // Create a pulsar client with a subscription fenced counter.
@@ -1074,7 +1074,7 @@ public class SubscriptionSeekTest extends BrokerTestBase {
 
         // Inject a delay for reset-cursor.
         mockZooKeeper.delay(3000, (op, path) -> {
-            if (path.equals("/managed-ledgers/prop/ns-abc/persistent/my-topic2/s1")) {
+            if (path.equals("/managed-ledgers/tenant/ns-abc/persistent/my-topic2/s1")) {
                 return op.toString().equalsIgnoreCase("SET");
             }
             return false;
@@ -1101,7 +1101,7 @@ public class SubscriptionSeekTest extends BrokerTestBase {
 
     @Test
     public void testExceptionBySeekFunction() throws Exception {
-        final String topicName = "persistent://prop/use/ns-abc/test" + UUID.randomUUID();
+        final String topicName = "persistent://tenant/ns-abc/test" + UUID.randomUUID();
         creatProducerAndSendMsg(topicName, 10);
         @Cleanup
         org.apache.pulsar.client.api.Consumer consumer = pulsarClient

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TopicDispatchRateLimiterTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TopicDispatchRateLimiterTest.java
@@ -113,12 +113,12 @@ public class TopicDispatchRateLimiterTest extends BrokerTestBase {
             .dispatchThrottlingRateInMsg(100)
             .dispatchThrottlingRateInByte(1000L)
             .build();
-        admin.namespaces().setDispatchRate("prop/ns-abc", dispatchRate);
+        admin.namespaces().setDispatchRate("tenant/ns-abc", dispatchRate);
 
         Awaitility.await().untilAsserted(() -> {
-            assertNotNull(admin.namespaces().getDispatchRate("prop/ns-abc"));
-            assertEquals(admin.namespaces().getDispatchRate("prop/ns-abc").getDispatchThrottlingRateInMsg(), 100);
-            assertEquals(admin.namespaces().getDispatchRate("prop/ns-abc").getDispatchThrottlingRateInByte(), 1000L);
+            assertNotNull(admin.namespaces().getDispatchRate("tenant/ns-abc"));
+            assertEquals(admin.namespaces().getDispatchRate("tenant/ns-abc").getDispatchThrottlingRateInMsg(), 100);
+            assertEquals(admin.namespaces().getDispatchRate("tenant/ns-abc").getDispatchThrottlingRateInByte(), 1000L);
         });
 
         Awaitility.await().untilAsserted(() -> assertTrue(topic.getDispatchRateLimiter().isPresent()));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TopicPublishRateThrottleTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TopicPublishRateThrottleTest.java
@@ -49,8 +49,8 @@ public class TopicPublishRateThrottleTest extends BrokerTestBase{
         PublishRate publishRate = new PublishRate(1, 10);
         conf.setMaxPendingPublishRequestsPerConnection(0);
         super.baseSetup();
-        admin.namespaces().setPublishRate("prop/ns-abc", publishRate);
-        final String topic = "persistent://prop/ns-abc/testPrecisTopicPublishRateLimiting";
+        admin.namespaces().setPublishRate("tenant/ns-abc", publishRate);
+        final String topic = "persistent://tenant/ns-abc/testPrecisTopicPublishRateLimiting";
         org.apache.pulsar.client.api.Producer<byte[]> producer = pulsarClient.newProducer()
                 .topic(topic)
                 .producerName("producer-name")
@@ -77,15 +77,15 @@ public class TopicPublishRateThrottleTest extends BrokerTestBase{
     public void testSystemTopicPublishNonBlock() throws Exception {
         super.baseSetup();
         PublishRate publishRate = new PublishRate(1, 10);
-        admin.namespaces().setPublishRate("prop/ns-abc", publishRate);
-        final String topic = BrokerTestUtil.newUniqueName("persistent://prop/ns-abc/tp");
+        admin.namespaces().setPublishRate("tenant/ns-abc", publishRate);
+        final String topic = BrokerTestUtil.newUniqueName("persistent://tenant/ns-abc/tp");
         PulsarAdmin admin1 = PulsarAdmin.builder().serviceHttpUrl(brokerUrl != null
             ? brokerUrl.toString() : brokerUrlTls.toString()).readTimeout(5, TimeUnit.SECONDS).build();
         admin1.topics().createNonPartitionedTopic(topic);
         admin1.topicPolicies().setDeduplicationStatus(topic, true);
         admin1.topicPolicies().setDeduplicationStatus(topic, false);
         // cleanup.
-        admin.namespaces().removePublishRate("prop/ns-abc");
+        admin.namespaces().removePublishRate("tenant/ns-abc");
         admin1.close();
     }
 
@@ -94,8 +94,8 @@ public class TopicPublishRateThrottleTest extends BrokerTestBase{
         PublishRate publishRate = new PublishRate(1, 10);
         conf.setMaxPendingPublishRequestsPerConnection(0);
         super.baseSetup();
-        admin.namespaces().setPublishRate("prop/ns-abc", publishRate);
-        final String topic = "persistent://prop/ns-abc/testPrecisTopicPublishRateLimiting";
+        admin.namespaces().setPublishRate("tenant/ns-abc", publishRate);
+        final String topic = "persistent://tenant/ns-abc/testPrecisTopicPublishRateLimiting";
         org.apache.pulsar.client.api.Producer<byte[]> producer = pulsarClient.newProducer()
                 .topic(topic)
                 .producerName("producer-name")
@@ -129,7 +129,7 @@ public class TopicPublishRateThrottleTest extends BrokerTestBase{
     public void testBrokerLevelPublishRateDynamicUpdate() throws Exception{
         conf.setMaxPendingPublishRequestsPerConnection(0);
         super.baseSetup();
-        final String topic = "persistent://prop/ns-abc/testMultiLevelPublishRate";
+        final String topic = "persistent://tenant/ns-abc/testMultiLevelPublishRate";
         org.apache.pulsar.client.api.Producer<byte[]> producer = pulsarClient.newProducer()
             .topic(topic)
             .producerName("producer-name")

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TopicTerminationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TopicTerminationTest.java
@@ -65,7 +65,7 @@ public class TopicTerminationTest extends BrokerTestBase {
         super.internalCleanup();
     }
 
-    private final String topicName = "persistent://prop/ns-abc/topic0";
+    private final String topicName = "persistent://tenant/ns-abc/topic0";
 
     @Test
     public void testSimpleTermination() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopicTest.java
@@ -64,7 +64,7 @@ public class NonPersistentTopicTest extends BrokerTestBase {
 
     @Test
     public void testAccumulativeStats() throws Exception {
-        final String topicName = "non-persistent://prop/ns-abc/aTopic";
+        final String topicName = "non-persistent://tenant/ns-abc/aTopic";
         final String sharedSubName = "shared";
         final String failoverSubName = "failOver";
 
@@ -113,7 +113,7 @@ public class NonPersistentTopicTest extends BrokerTestBase {
 
     @Test
     public void testCreateNonExistentPartitions() throws PulsarAdminException {
-        final String topicName = "non-persistent://prop/ns-abc/testCreateNonExistentPartitions";
+        final String topicName = "non-persistent://tenant/ns-abc/testCreateNonExistentPartitions";
         admin.topics().createPartitionedTopic(topicName, 4);
         TopicName partition = TopicName.get(topicName).getPartition(4);
         assertThrows(PulsarClientException.NotAllowedException.class, () -> {
@@ -128,7 +128,7 @@ public class NonPersistentTopicTest extends BrokerTestBase {
 
     @Test
     public void testSubscriptionsOnNonPersistentTopic() throws Exception {
-        final String topicName = "non-persistent://prop/ns-abc/topic_" + UUID.randomUUID();
+        final String topicName = "non-persistent://tenant/ns-abc/topic_" + UUID.randomUUID();
         final String exclusiveSubName = "exclusive";
         final String failoverSubName = "failover";
         final String sharedSubName = "shared";
@@ -251,7 +251,7 @@ public class NonPersistentTopicTest extends BrokerTestBase {
 
     @Test
     public void testRemoveProducerOnNonPersistentTopic() throws Exception {
-        final String topicName = "non-persistent://prop/ns-abc/topic_" + UUID.randomUUID();
+        final String topicName = "non-persistent://tenant/ns-abc/topic_" + UUID.randomUUID();
 
         Producer<byte[]> producer = pulsarClient.newProducer()
                 .topic(topicName)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/ChecksumTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/ChecksumTest.java
@@ -52,7 +52,7 @@ public class ChecksumTest extends BrokerTestBase {
 
     @Test
     public void verifyChecksumStoredInManagedLedger() throws Exception {
-        final String topicName = "persistent://prop/use/ns-abc/topic0";
+        final String topicName = "persistent://tenant/ns-abc/topic0";
 
         Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
 
@@ -79,7 +79,7 @@ public class ChecksumTest extends BrokerTestBase {
 
     @Test
     public void verifyChecksumSentToConsumer() throws Exception {
-        final String topicName = "persistent://prop/use/ns-abc/topic-1";
+        final String topicName = "persistent://tenant/ns-abc/topic-1";
 
         Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
         RawReader reader = RawReader.create(pulsarClient, topicName, "sub").get();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/MessageDuplicationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/MessageDuplicationTest.java
@@ -497,7 +497,7 @@ public class MessageDuplicationTest extends BrokerTestBase {
 
     @Test
     public void testMessageDeduplication() throws Exception {
-        String topicName = "persistent://prop/ns-abc/testMessageDeduplication";
+        String topicName = "persistent://tenant/ns-abc/testMessageDeduplication";
         String producerName = "test-producer";
         Producer<String> producer = pulsarClient
                 .newProducer(Schema.STRING)
@@ -526,7 +526,7 @@ public class MessageDuplicationTest extends BrokerTestBase {
     @Test
     public void testMessageDeduplicationShouldNotWorkForSystemTopic() throws PulsarAdminException {
         final String localName = UUID.randomUUID().toString();
-        final String namespace = "prop/ns-abc";
+        final String namespace = "tenant/ns-abc";
         final String prefix = "persistent://%s/".formatted(namespace);
         final String topic = prefix + localName;
         admin.topics().createNonPartitionedTopic(topic);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentSubscriptionTest.java
@@ -76,7 +76,7 @@ public class PersistentSubscriptionTest {
     private Consumer consumerMock;
     private ManagedLedgerConfig managedLedgerConfigMock;
 
-    final String successTopicName = "persistent://prop/use/ns-abc/successTopic";
+    final String successTopicName = "persistent://tenant/ns-abc/successTopic";
     final String subName = "subscriptionName";
 
     final TxnID txnID1 = new TxnID(1, 1);
@@ -164,7 +164,7 @@ public class PersistentSubscriptionTest {
             persistentSubscription.transactionIndividualAcknowledge(txnID2, positionsPair).get();
             fail("Single acknowledge for transaction2 should fail. ");
         } catch (ExecutionException e) {
-            assertEquals(e.getCause().getMessage(), "[persistent://prop/use/ns-abc/successTopic][subscriptionName] "
+            assertEquals(e.getCause().getMessage(), "[persistent://tenant/ns-abc/successTopic][subscriptionName] "
                     + "Transaction:(1,2) try to ack message:2:1 in pending ack status.");
         }
 
@@ -177,7 +177,7 @@ public class PersistentSubscriptionTest {
             fail("Cumulative acknowledge for transaction2 should fail. ");
         } catch (ExecutionException e) {
             assertTrue(e.getCause() instanceof TransactionConflictException);
-            assertEquals(e.getCause().getMessage(), "[persistent://prop/use/ns-abc/successTopic]"
+            assertEquals(e.getCause().getMessage(), "[persistent://tenant/ns-abc/successTopic]"
                     + "[subscriptionName] Transaction:(1,2) try to cumulative batch ack position: "
                     + "2:50 within range of current currentPosition: 1:100");
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicTest.java
@@ -132,7 +132,7 @@ public class PersistentTopicTest extends BrokerTestBase {
      */
     @Test
     public void testCleanFailedUnloadTopic() throws Exception {
-        final String topicName = "persistent://prop/ns-abc/failedUnload";
+        final String topicName = "persistent://tenant/ns-abc/failedUnload";
 
         // 1. producer connect
         Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).enableBatching(false)
@@ -164,7 +164,7 @@ public class PersistentTopicTest extends BrokerTestBase {
      */
     @Test
     public void testUnblockStuckSubscription() throws Exception {
-        final String topicName = "persistent://prop/ns-abc/stuckSubscriptionTopic";
+        final String topicName = "persistent://tenant/ns-abc/stuckSubscriptionTopic";
         final String sharedSubName = "shared";
         final String failoverSubName = "failOver";
 
@@ -231,7 +231,7 @@ public class PersistentTopicTest extends BrokerTestBase {
     @Test
     public void testDeleteNamespaceInfiniteRetry() throws Exception {
         //init namespace
-        final String myNamespace = "prop/ns" + UUID.randomUUID();
+        final String myNamespace = "tenant/ns" + UUID.randomUUID();
         admin.namespaces().createNamespace(myNamespace, Sets.newHashSet("test"));
         final String topic = "persistent://" + myNamespace + "/testDeleteNamespaceInfiniteRetry";
         conf.setForceDeleteNamespaceAllowed(true);
@@ -256,7 +256,7 @@ public class PersistentTopicTest extends BrokerTestBase {
 
     @Test
     public void testAccumulativeStats() throws Exception {
-        final String topicName = "persistent://prop/ns-abc/aTopic";
+        final String topicName = "persistent://tenant/ns-abc/aTopic";
         final String sharedSubName = "shared";
         final String failoverSubName = "failOver";
 
@@ -305,8 +305,8 @@ public class PersistentTopicTest extends BrokerTestBase {
 
     @Test
     public void testPersistentPartitionedTopicUnload() throws Exception {
-        final String topicName = "persistent://prop/ns/failedUnload";
-        final String ns = "prop/ns";
+        final String topicName = "persistent://tenant/ns/failedUnload";
+        final String ns = "tenant/ns";
         final int partitions = 5;
         final int producers = 1;
         // ensure that the number of bundle is greater than 1
@@ -346,8 +346,8 @@ public class PersistentTopicTest extends BrokerTestBase {
 
     @Test(dataProvider = "closeWithoutWaitingClientDisconnectInFirstBatch")
     public void testConcurrentClose(boolean closeWithoutWaitingClientDisconnectInFirstBatch) throws Exception {
-        final String topicName = "persistent://prop/ns/concurrentClose";
-        final String ns = "prop/ns";
+        final String topicName = "persistent://tenant/ns/concurrentClose";
+        final String ns = "tenant/ns";
         admin.namespaces().createNamespace(ns, 1);
         admin.topics().createNonPartitionedTopic(topicName);
         final Topic topic = pulsar.getBrokerService().getTopicIfExists(topicName).get().get();
@@ -417,8 +417,8 @@ public class PersistentTopicTest extends BrokerTestBase {
     @DataProvider(name = "topicAndMetricsLevel")
     public Object[][] indexPatternTestData() {
         return new Object[][]{
-                new Object[] {"persistent://prop/autoNs/test_delayed_message_metric", true},
-                new Object[] {"persistent://prop/autoNs/test_delayed_message_metric", false},
+                new Object[] {"persistent://tenant/autoNs/test_delayed_message_metric", true},
+                new Object[] {"persistent://tenant/autoNs/test_delayed_message_metric", false},
         };
     }
 
@@ -510,7 +510,7 @@ public class PersistentTopicTest extends BrokerTestBase {
 
     @Test
     public void testUpdateCursorLastActive() throws Exception {
-        final String topicName = "persistent://prop/ns-abc/aTopic";
+        final String topicName = "persistent://tenant/ns-abc/aTopic";
         final String sharedSubName = "shared";
         final String failoverSubName = "failOver";
 
@@ -566,7 +566,7 @@ public class PersistentTopicTest extends BrokerTestBase {
 
     @Test
     public void testCreateNonExistentPartitions() throws PulsarAdminException, PulsarClientException {
-        final String topicName = "persistent://prop/ns-abc/testCreateNonExistentPartitions";
+        final String topicName = "persistent://tenant/ns-abc/testCreateNonExistentPartitions";
         admin.topics().createPartitionedTopic(topicName, 4);
         TopicName partition = TopicName.get(topicName).getPartition(4);
         try {
@@ -582,7 +582,7 @@ public class PersistentTopicTest extends BrokerTestBase {
 
     @Test
     public void testDeleteTopicFail() throws Exception {
-        final String fullyTopicName = "persistent://prop/ns-abc/" + "tp_"
+        final String fullyTopicName = "persistent://tenant/ns-abc/" + "tp_"
                 + UUID.randomUUID().toString().replaceAll("-", "");
         // Mock topic.
         BrokerService brokerService = spy(pulsar.getBrokerService());
@@ -635,7 +635,7 @@ public class PersistentTopicTest extends BrokerTestBase {
 
     @Test(dataProvider = "topicLevelPolicy")
     public void testCreateTopicWithZombieReplicatorCursor(boolean topicLevelPolicy) throws Exception {
-        final String namespace = "prop/ns-abc";
+        final String namespace = "tenant/ns-abc";
         final String topicName = "persistent://" + namespace
                 + "/testCreateTopicWithZombieReplicatorCursor" + topicLevelPolicy;
         final String remoteCluster = "remote";
@@ -647,9 +647,9 @@ public class PersistentTopicTest extends BrokerTestBase {
                 .serviceUrl("http://localhost:11112")
                 .brokerServiceUrl("pulsar://localhost:11111")
                 .build());
-        TenantInfo tenantInfo = admin.tenants().getTenantInfo("prop");
+        TenantInfo tenantInfo = admin.tenants().getTenantInfo("tenant");
         tenantInfo.getAllowedClusters().add(remoteCluster);
-        admin.tenants().updateTenant("prop", tenantInfo);
+        admin.tenants().updateTenant("tenant", tenantInfo);
 
         if (topicLevelPolicy) {
             admin.topics().setReplicationClusters(topicName, Arrays.asList("test", remoteCluster));
@@ -696,7 +696,7 @@ public class PersistentTopicTest extends BrokerTestBase {
 
     @Test
     public void testCheckPersistencePolicies() throws Exception {
-        final String myNamespace = "prop/ns";
+        final String myNamespace = "tenant/ns";
         admin.namespaces().createNamespace(myNamespace, Sets.newHashSet("test"));
         final String topic = "persistent://" + myNamespace + "/testConfig" + UUID.randomUUID();
         conf.setForceDeleteNamespaceAllowed(true);
@@ -730,7 +730,7 @@ public class PersistentTopicTest extends BrokerTestBase {
     @Test
     public void testDynamicConfigurationAutoSkipNonRecoverableData() throws Exception {
         pulsar.getConfiguration().setAutoSkipNonRecoverableData(false);
-        final String topicName = "persistent://prop/ns-abc/testAutoSkipNonRecoverableData";
+        final String topicName = "persistent://tenant/ns-abc/testAutoSkipNonRecoverableData";
         final String subName = "test_sub";
 
         Consumer<byte[]> subscribe = pulsarClient.newConsumer().topic(topicName).subscriptionName(subName).subscribe();
@@ -755,7 +755,7 @@ public class PersistentTopicTest extends BrokerTestBase {
 
     @Test
     public void testCursorGetConfigAfterTopicPoliciesChanged() throws Exception {
-        final String topicName = "persistent://prop/ns-abc/" + UUID.randomUUID();
+        final String topicName = "persistent://tenant/ns-abc/" + UUID.randomUUID();
         final String subName = "test_sub";
 
         @Cleanup
@@ -779,9 +779,9 @@ public class PersistentTopicTest extends BrokerTestBase {
 
     @Test
     public void testAddWaitingCursorsForNonDurable() throws Exception {
-        final String ns = "prop/ns-test";
+        final String ns = "tenant/ns-test";
         admin.namespaces().createNamespace(ns, 2);
-        final String topicName = "persistent://prop/ns-test/testAddWaitingCursors";
+        final String topicName = "persistent://tenant/ns-test/testAddWaitingCursors";
         admin.topics().createNonPartitionedTopic(topicName);
         final Optional<Topic> topic = pulsar.getBrokerService().getTopic(topicName, false).join();
         assertNotNull(topic.get());
@@ -819,9 +819,9 @@ public class PersistentTopicTest extends BrokerTestBase {
 
     @Test
     public void testAddWaitingCursorsForNonDurable2() throws Exception {
-        final String ns = "prop/ns-test";
+        final String ns = "tenant/ns-test";
         admin.namespaces().createNamespace(ns, 2);
-        final String topicName = "persistent://prop/ns-test/testAddWaitingCursors2";
+        final String topicName = "persistent://tenant/ns-test/testAddWaitingCursors2";
         admin.topics().createNonPartitionedTopic(topicName);
         pulsarClient.newConsumer(Schema.STRING).topic(topicName)
                 .subscriptionMode(SubscriptionMode.Durable)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/ShadowTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/ShadowTopicTest.java
@@ -78,7 +78,7 @@ public class ShadowTopicTest extends BrokerTestBase {
         Assert.assertEquals(admin.topics().getShadowSource(shadowTopic), sourceTopic);
 
         //2. test shadow topic could be properly loaded after unload.
-        admin.namespaces().unload("prop/ns-abc");
+        admin.namespaces().unload("tenant/ns-abc");
         Assert.assertTrue(pulsar.getBrokerService().getTopicReference(shadowTopic).isEmpty());
         Assert.assertEquals(admin.topics().getShadowSource(shadowTopic), sourceTopic);
         brokerShadowTopic = (PersistentTopic) pulsar.getBrokerService().getTopicIfExists(shadowTopic).get().get();
@@ -105,7 +105,7 @@ public class ShadowTopicTest extends BrokerTestBase {
         Assert.assertEquals(admin.topics().getShadowSource(shadowTopic), sourceTopic);
 
         //2. test shadow topic could be properly loaded after unload.
-        admin.namespaces().unload("prop/ns-abc");
+        admin.namespaces().unload("tenant/ns-abc");
         Assert.assertTrue(pulsar.getBrokerService().getTopicReference(shadowTopic).isEmpty());
 
         Assert.assertEquals(admin.topics().getShadowSource(shadowTopic), sourceTopic);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/plugin/FilterEntryTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/plugin/FilterEntryTest.java
@@ -94,7 +94,7 @@ public class FilterEntryTest extends BrokerTestBase {
     @Test
     public void testOverride() throws Exception {
         conf.setAllowOverrideEntryFilters(true);
-        String topic = "persistent://prop/ns-abc/topic" + UUID.randomUUID();
+        String topic = "persistent://tenant/ns-abc/topic" + UUID.randomUUID();
         String subName = "sub";
         Producer<String> producer = pulsarClient.newProducer(Schema.STRING)
                 .enableBatching(false).topic(topic).create();
@@ -158,7 +158,7 @@ public class FilterEntryTest extends BrokerTestBase {
     @Test
     public void testEntryFilterWithCompactor() throws Exception {
         conf.setAllowOverrideEntryFilters(true);
-        String topic = "persistent://prop/ns-abc/topic" + UUID.randomUUID();
+        String topic = "persistent://tenant/ns-abc/topic" + UUID.randomUUID();
 
         List<String> messages = new ArrayList<>();
         Producer<String> producer = pulsarClient.newProducer(Schema.STRING)
@@ -223,7 +223,7 @@ public class FilterEntryTest extends BrokerTestBase {
         Map<String, String> map = new HashMap<>();
         map.put("1", "1");
         map.put("2", "2");
-        String topic = "persistent://prop/ns-abc/topic" + UUID.randomUUID();
+        String topic = "persistent://tenant/ns-abc/topic" + UUID.randomUUID();
         String subName = "sub";
         Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING).topic(topic)
                 .subscriptionProperties(map)
@@ -349,8 +349,8 @@ public class FilterEntryTest extends BrokerTestBase {
     @DataProvider(name = "topicProvider")
     public Object[][] topicProvider() {
         return new Object[][]{
-                {"persistent://prop/ns-abc/topic" + UUID.randomUUID()},
-                {"non-persistent://prop/ns-abc/topic" + UUID.randomUUID()},
+                {"persistent://tenant/ns-abc/topic" + UUID.randomUUID()},
+                {"non-persistent://tenant/ns-abc/topic" + UUID.randomUUID()},
         };
     }
 
@@ -426,7 +426,7 @@ public class FilterEntryTest extends BrokerTestBase {
     public void testEntryFilterRescheduleMessageDependingOnConsumerSharedSubscription() throws Throwable {
         assertTrue(pulsar.getConfiguration().isSubscriptionRedeliveryTrackerEnabled());
 
-        String topic = "persistent://prop/ns-abc/topic" + UUID.randomUUID();
+        String topic = "persistent://tenant/ns-abc/topic" + UUID.randomUUID();
         String subName = "sub";
 
         Map<String, String> metadataConsumer1 = new HashMap<>();
@@ -574,7 +574,7 @@ public class FilterEntryTest extends BrokerTestBase {
     @Test(dataProvider = "overrideBrokerEntryFilters")
     public void testExecuteInOrder(boolean overrideBrokerEntryFilters) throws Exception {
         conf.setAllowOverrideEntryFilters(true);
-        String topic = "persistent://prop/ns-abc/topic" + UUID.randomUUID();
+        String topic = "persistent://tenant/ns-abc/topic" + UUID.randomUUID();
         String subName = "sub";
         Producer<String> producer = pulsarClient.newProducer(Schema.STRING)
                 .enableBatching(false).topic(topic).create();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/schema/PartitionedTopicsSchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/schema/PartitionedTopicsSchemaTest.java
@@ -42,9 +42,9 @@ public class PartitionedTopicsSchemaTest extends BkEnsemblesTestBase {
      */
     @Test
     public void partitionedTopicWithSchema() throws Exception {
-        admin.namespaces().createNamespace("prop/my-test", Collections.singleton("usc"));
+        admin.namespaces().createNamespace("tenant/my-test", Collections.singleton("usc"));
 
-        String topicName = "prop/my-test/my-topic";
+        String topicName = "tenant/my-test/my-topic";
 
         admin.topics().createPartitionedTopic(topicName, 16);
 
@@ -75,7 +75,7 @@ public class PartitionedTopicsSchemaTest extends BkEnsemblesTestBase {
         producer.close();
 
         // Force topic reloading to re-open the schema multiple times in parallel
-        admin.namespaces().unload("prop/my-test");
+        admin.namespaces().unload("tenant/my-test");
 
         producerFuture = client.newProducer(Schema.STRING)
             .topic(topicName)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/LedgerOffloaderMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/LedgerOffloaderMetricsTest.java
@@ -57,13 +57,13 @@ public class LedgerOffloaderMetricsTest extends BrokerTestBase {
         conf.setExposeTopicLevelMetricsInPrometheus(true);
         super.baseSetup();
 
-        String ns1 = "prop/ns-abc1";
+        String ns1 = "tenant/ns-abc1";
         admin.namespaces().createNamespace(ns1);
         String[] topics = new String[3];
 
         LedgerOffloaderStatsImpl offloaderStats = (LedgerOffloaderStatsImpl) pulsar.getOffloaderStats();
         for (int i = 0; i < 3; i++) {
-            String topicName = "persistent://prop/ns-abc1/testMetrics" + UUID.randomUUID();
+            String topicName = "persistent://tenant/ns-abc1/testMetrics" + UUID.randomUUID();
             topics[i] = topicName;
             offloaderStats.recordOffloadError(topicName);
             offloaderStats.recordOffloadError(topicName);
@@ -93,8 +93,8 @@ public class LedgerOffloaderMetricsTest extends BrokerTestBase {
         conf.setExposeTopicLevelMetricsInPrometheus(false);
         super.baseSetup();
 
-        String ns1 = "prop/ns-abc1";
-        String ns2 = "prop/ns-abc2";
+        String ns1 = "tenant/ns-abc1";
+        String ns2 = "tenant/ns-abc2";
 
         LedgerOffloaderStatsImpl offloaderStats = (LedgerOffloaderStatsImpl) pulsar.getOffloaderStats();
         Map<String, List<String>> namespace2Topics = new HashMap<>();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/MetadataStoreStatsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/MetadataStoreStatsTest.java
@@ -75,10 +75,10 @@ public class MetadataStoreStatsTest extends BrokerTestBase {
 
     @Test
     public void testMetadataStoreStats() throws Exception {
-        String ns = "prop/ns-abc1";
+        String ns = "tenant/ns-abc1";
         admin.namespaces().createNamespace(ns);
 
-        String topic = "persistent://prop/ns-abc1/metadata-store-" + UUID.randomUUID();
+        String topic = "persistent://tenant/ns-abc1/metadata-store-" + UUID.randomUUID();
         String subName = "my-sub1";
 
         @Cleanup
@@ -165,10 +165,10 @@ public class MetadataStoreStatsTest extends BrokerTestBase {
 
     @Test
     public void testBatchMetadataStoreMetrics() throws Exception {
-        String ns = "prop/ns-abc1";
+        String ns = "tenant/ns-abc1";
         admin.namespaces().createNamespace(ns);
 
-        String topic = "persistent://prop/ns-abc1/metadata-store-" + UUID.randomUUID();
+        String topic = "persistent://tenant/ns-abc1/metadata-store-" + UUID.randomUUID();
         String subName = "my-sub1";
 
         @Cleanup

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/OpenTelemetryConsumerStatsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/OpenTelemetryConsumerStatsTest.java
@@ -56,7 +56,7 @@ public class OpenTelemetryConsumerStatsTest extends BrokerTestBase {
 
     @Test(timeOut = 30_000)
     public void testMessagingMetrics() throws Exception {
-        var topicName = BrokerTestUtil.newUniqueName("persistent://prop/ns-abc/testConsumerMessagingMetrics");
+        var topicName = BrokerTestUtil.newUniqueName("persistent://tenant/ns-abc/testConsumerMessagingMetrics");
         admin.topics().createNonPartitionedTopic(topicName);
 
         var messageCount = 5;
@@ -89,8 +89,8 @@ public class OpenTelemetryConsumerStatsTest extends BrokerTestBase {
 
         var attributes = Attributes.builder()
                 .put(OpenTelemetryAttributes.PULSAR_DOMAIN, "persistent")
-                .put(OpenTelemetryAttributes.PULSAR_TENANT, "prop")
-                .put(OpenTelemetryAttributes.PULSAR_NAMESPACE, "prop/ns-abc")
+                .put(OpenTelemetryAttributes.PULSAR_TENANT, "tenant")
+                .put(OpenTelemetryAttributes.PULSAR_NAMESPACE, "tenant/ns-abc")
                 .put(OpenTelemetryAttributes.PULSAR_TOPIC, topicName)
                 .put(OpenTelemetryAttributes.PULSAR_SUBSCRIPTION_NAME, subscriptionName)
                 .put(OpenTelemetryAttributes.PULSAR_SUBSCRIPTION_TYPE, SubscriptionType.Shared.toString())

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/OpenTelemetryManagedLedgerCacheStatsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/OpenTelemetryManagedLedgerCacheStatsTest.java
@@ -65,7 +65,7 @@ public class OpenTelemetryManagedLedgerCacheStatsTest extends BrokerTestBase {
 
     @Test
     public void testManagedLedgerCacheStats() throws Exception {
-        var topicName = BrokerTestUtil.newUniqueName("persistent://prop/ns-abc/testManagedLedgerCacheStats");
+        var topicName = BrokerTestUtil.newUniqueName("persistent://tenant/ns-abc/testManagedLedgerCacheStats");
 
         @Cleanup
         var producer = pulsarClient.newProducer().topic(topicName).create();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/OpenTelemetryProducerStatsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/OpenTelemetryProducerStatsTest.java
@@ -53,7 +53,7 @@ public class OpenTelemetryProducerStatsTest extends BrokerTestBase {
 
     @Test(timeOut = 30_000)
     public void testMessagingMetrics() throws Exception {
-        var topicName = BrokerTestUtil.newUniqueName("persistent://prop/ns-abc/testProducerMessagingMetrics");
+        var topicName = BrokerTestUtil.newUniqueName("persistent://tenant/ns-abc/testProducerMessagingMetrics");
         admin.topics().createNonPartitionedTopic(topicName);
 
         var messageCount = 5;
@@ -70,8 +70,8 @@ public class OpenTelemetryProducerStatsTest extends BrokerTestBase {
 
         var attributes = Attributes.builder()
                 .put(OpenTelemetryAttributes.PULSAR_DOMAIN, "persistent")
-                .put(OpenTelemetryAttributes.PULSAR_TENANT, "prop")
-                .put(OpenTelemetryAttributes.PULSAR_NAMESPACE, "prop/ns-abc")
+                .put(OpenTelemetryAttributes.PULSAR_TENANT, "tenant")
+                .put(OpenTelemetryAttributes.PULSAR_NAMESPACE, "tenant/ns-abc")
                 .put(OpenTelemetryAttributes.PULSAR_TOPIC, topicName)
                 .put(OpenTelemetryAttributes.PULSAR_PRODUCER_NAME, producerName)
                 .put(OpenTelemetryAttributes.PULSAR_PRODUCER_ID, 0)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/OpenTelemetryTopicStatsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/OpenTelemetryTopicStatsTest.java
@@ -59,7 +59,7 @@ public class OpenTelemetryTopicStatsTest extends BrokerTestBase {
 
     @Test(timeOut = 30_000)
     public void testMessagingMetrics() throws Exception {
-        var topicName = BrokerTestUtil.newUniqueName("persistent://prop/ns-abc/testMessagingMetrics");
+        var topicName = BrokerTestUtil.newUniqueName("persistent://tenant/ns-abc/testMessagingMetrics");
         admin.topics().createNonPartitionedTopic(topicName);
 
         var producerCount = 5;
@@ -90,8 +90,8 @@ public class OpenTelemetryTopicStatsTest extends BrokerTestBase {
 
         var attributes = Attributes.builder()
                 .put(OpenTelemetryAttributes.PULSAR_DOMAIN, "persistent")
-                .put(OpenTelemetryAttributes.PULSAR_TENANT, "prop")
-                .put(OpenTelemetryAttributes.PULSAR_NAMESPACE, "prop/ns-abc")
+                .put(OpenTelemetryAttributes.PULSAR_TENANT, "tenant")
+                .put(OpenTelemetryAttributes.PULSAR_NAMESPACE, "tenant/ns-abc")
                 .put(OpenTelemetryAttributes.PULSAR_TOPIC, topicName)
                 .build();
 
@@ -121,7 +121,7 @@ public class OpenTelemetryTopicStatsTest extends BrokerTestBase {
 
     @Test(timeOut = 30_000)
     public void testPublishRateLimitMetric() throws Exception {
-        var topicName = BrokerTestUtil.newUniqueName("persistent://prop/ns-abc/testPublishRateLimitMetric");
+        var topicName = BrokerTestUtil.newUniqueName("persistent://tenant/ns-abc/testPublishRateLimitMetric");
         admin.topics().createNonPartitionedTopic(topicName);
 
         var publishRate = new PublishRate(1, -1);
@@ -134,8 +134,8 @@ public class OpenTelemetryTopicStatsTest extends BrokerTestBase {
 
         var attributes = Attributes.builder()
                 .put(OpenTelemetryAttributes.PULSAR_DOMAIN, "persistent")
-                .put(OpenTelemetryAttributes.PULSAR_TENANT, "prop")
-                .put(OpenTelemetryAttributes.PULSAR_NAMESPACE, "prop/ns-abc")
+                .put(OpenTelemetryAttributes.PULSAR_TENANT, "tenant")
+                .put(OpenTelemetryAttributes.PULSAR_NAMESPACE, "tenant/ns-abc")
                 .put(OpenTelemetryAttributes.PULSAR_TOPIC, topicName)
                 .build();
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
@@ -141,7 +141,7 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         conf.setBrokerPublisherThrottlingMaxByteRate(10000000);
         conf.setStatsUpdateFrequencyInSecs(100000000);
         setup();
-        String ns1 = "prop/ns-abc1" + UUID.randomUUID();
+        String ns1 = "tenant/ns-abc1" + UUID.randomUUID();
         admin.namespaces().createNamespace(ns1, 1);
         String topicName = "persistent://" + ns1 + "/metrics" + UUID.randomUUID();
         String topicName2 = "persistent://" + ns1 + "/metrics" + UUID.randomUUID();
@@ -319,8 +319,8 @@ public class PrometheusMetricsTest extends BrokerTestBase {
 
     @Test
     public void testMetricsTopicCount() throws Exception {
-        String ns1 = "prop/ns-abc1";
-        String ns2 = "prop/ns-abc2";
+        String ns1 = "tenant/ns-abc1";
+        String ns2 = "tenant/ns-abc2";
         admin.namespaces().createNamespace(ns1);
         admin.namespaces().createNamespace(ns2);
         String baseTopic1 = "persistent://" + ns1 + "/testMetricsTopicCount";
@@ -358,7 +358,7 @@ public class PrometheusMetricsTest extends BrokerTestBase {
 
     @Test
     public void testMetricsAvgMsgSize2() throws Exception {
-        String ns1 = "prop/ns-abc1";
+        String ns1 = "tenant/ns-abc1";
         admin.namespaces().createNamespace(ns1, 1);
         String baseTopic1 = "persistent://" + ns1 + "/testMetricsTopicCount";
         String topicName = baseTopic1 + UUID.randomUUID();
@@ -673,7 +673,7 @@ public class PrometheusMetricsTest extends BrokerTestBase {
             conf.setManagedLedgerCacheSizeMB(0);
         }
         setup();
-        String ns = "prop/ns-abc1";
+        String ns = "tenant/ns-abc1";
         admin.namespaces().createNamespace(ns);
         String topic = "persistent://" + ns + "/testStorageReadCacheMissesRate" + UUID.randomUUID();
 
@@ -774,7 +774,7 @@ public class PrometheusMetricsTest extends BrokerTestBase {
 
     @Test
     public void testPerTopicExpiredStat() throws Exception {
-        String ns = "prop/ns-abc1";
+        String ns = "tenant/ns-abc1";
         admin.namespaces().createNamespace(ns);
         String topic1 = "persistent://" + ns + "/testPerTopicExpiredStat1";
         String topic2 = "persistent://" + ns + "/testPerTopicExpiredStat2";
@@ -1954,8 +1954,8 @@ public class PrometheusMetricsTest extends BrokerTestBase {
 
     @Test
     public void testSplitTopicAndPartitionLabel() throws Exception {
-        String ns1 = "prop/ns-abc1";
-        String ns2 = "prop/ns-abc2";
+        String ns1 = "tenant/ns-abc1";
+        String ns2 = "tenant/ns-abc2";
         admin.namespaces().createNamespace(ns1);
         admin.namespaces().createNamespace(ns2);
         String baseTopic1 = "persistent://" + ns1 + "/testMetricsTopicCount";
@@ -2055,7 +2055,7 @@ public class PrometheusMetricsTest extends BrokerTestBase {
 
     @Test
     public void testEscapeLabelValue() throws Exception {
-        String ns1 = "prop/ns-abc1";
+        String ns1 = "tenant/ns-abc1";
         admin.namespaces().createNamespace(ns1);
         String topic = "persistent://" + ns1 + "/\"mytopic";
         admin.topics().createNonPartitionedTopic(topic);
@@ -2076,8 +2076,8 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         System.out.println(subCountLines);
         assertEquals(subCountLines.size(), 1);
         assertEquals(subCountLines.get(0),
-                "pulsar_subscriptions_count{cluster=\"test\",namespace=\"prop/ns-abc1\","
-                        + "topic=\"persistent://prop/ns-abc1/\\\"mytopic\"} 1");
+                "pulsar_subscriptions_count{cluster=\"test\",namespace=\"tenant/ns-abc1\","
+                        + "topic=\"persistent://tenant/ns-abc1/\\\"mytopic\"} 1");
     }
 
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/TransactionMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/TransactionMetricsTest.java
@@ -135,7 +135,7 @@ public class TransactionMetricsTest extends BrokerTestBase {
     @Test
     public void testTransactionCoordinatorRateMetrics() throws Exception {
         int txnCount = 120;
-        String ns1 = "prop/ns-abc1";
+        String ns1 = "tenant/ns-abc1";
         admin.namespaces().createNamespace(ns1);
         String topic = "persistent://" + ns1 + "/test_coordinator_metrics";
         String subName = "test_coordinator_metrics";
@@ -243,7 +243,7 @@ public class TransactionMetricsTest extends BrokerTestBase {
         serviceConfiguration.setTransactionCoordinatorEnabled(true);
         super.baseSetup(serviceConfiguration);
 
-        String ns1 = "prop/ns-abc1";
+        String ns1 = "tenant/ns-abc1";
         admin.namespaces().createNamespace(ns1);
         String topic = "persistent://" + ns1 + "/test_managed_ledger_metrics";
         String subName = "test_managed_ledger_metrics";
@@ -303,7 +303,7 @@ public class TransactionMetricsTest extends BrokerTestBase {
 
     @Test
     public void testManagedLedgerMetricsWhenPendingAckNotInit() throws Exception {
-        String ns1 = "prop/ns-abc1";
+        String ns1 = "tenant/ns-abc1";
         admin.namespaces().createNamespace(ns1);
         String topic = "persistent://" + ns1 + "/testManagedLedgerMetricsWhenPendingAckNotInit";
         String subName = "test_managed_ledger_metrics";

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/systopic/PartitionedSystemTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/systopic/PartitionedSystemTopicTest.java
@@ -95,7 +95,7 @@ public class PartitionedSystemTopicTest extends BrokerTestBase {
 
     @Test
     public void testAutoCreatedPartitionedSystemTopic() throws Exception {
-        final String ns = "prop/ns-test";
+        final String ns = "tenant/ns-test";
         admin.namespaces().createNamespace(ns, 2);
         NamespaceEventsSystemTopicFactory systemTopicFactory = new NamespaceEventsSystemTopicFactory(pulsarClient);
         TopicPoliciesSystemTopicClient systemTopicClientForNamespace = systemTopicFactory
@@ -253,7 +253,7 @@ public class PartitionedSystemTopicTest extends BrokerTestBase {
 
     @Test
     public void testSetBacklogCausedCreatingProducerFailure() throws Exception {
-        final String ns = "prop/ns-test";
+        final String ns = "tenant/ns-test";
         final String topic = ns + "/topic-1";
 
         admin.namespaces().createNamespace(ns, 2);
@@ -315,7 +315,7 @@ public class PartitionedSystemTopicTest extends BrokerTestBase {
 
     @Test
     public void testSystemTopicNotCheckExceed() throws Exception {
-        final String ns = "prop/ns-test";
+        final String ns = "tenant/ns-test";
         final String topic = ns + "/topic-1";
 
         admin.namespaces().createNamespace(ns, 2);
@@ -356,9 +356,9 @@ public class PartitionedSystemTopicTest extends BrokerTestBase {
 
     @Test
     public void testDeleteTopicSchemaAndPolicyWhenTopicIsNotLoaded() throws Exception {
-        final String ns = "prop/ns-test";
+        final String ns = "tenant/ns-test";
         admin.namespaces().createNamespace(ns, 2);
-        final String topicName = "persistent://prop/ns-test/testDeleteTopicSchemaAndPolicyWhenTopicIsNotLoaded";
+        final String topicName = "persistent://tenant/ns-test/testDeleteTopicSchemaAndPolicyWhenTopicIsNotLoaded";
         admin.topics().createNonPartitionedTopic(topicName);
         pulsarClient.newProducer(Schema.STRING).topic(topicName).create().close();
         admin.topicPolicies().setMaxConsumers(topicName, 2);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/web/WebServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/web/WebServiceTest.java
@@ -313,7 +313,7 @@ public class WebServiceTest {
 
     @Test
     public void testSplitPath() {
-        String result = PulsarWebResource.splitPath("prop/cluster/ns/topic1", 4);
+        String result = PulsarWebResource.splitPath("tenant/ns/topic1", 3);
         Assert.assertEquals(result, "topic1");
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/AuthorizationProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/AuthorizationProducerConsumerTest.java
@@ -660,7 +660,7 @@ public class AuthorizationProducerConsumerTest extends ProducerConsumerBase {
         setup();
 
         AuthorizationService authorizationService = new AuthorizationService(conf, null);
-        TopicName topicName = TopicName.get("persistent://prop/cluster/ns/t1");
+        TopicName topicName = TopicName.get("persistent://tenant/ns/t1");
         String role = "test-role";
         Assert.assertFalse(authorizationService.canProduce(topicName, role, null));
         Assert.assertFalse(authorizationService.canConsume(topicName, role, null, "sub1"));
@@ -736,7 +736,7 @@ public class AuthorizationProducerConsumerTest extends ProducerConsumerBase {
         setup();
 
         AuthorizationService authorizationService = new AuthorizationService(conf, null);
-        TopicName topicName = TopicName.get("persistent://prop/cluster/ns/t1");
+        TopicName topicName = TopicName.get("persistent://tenant/ns/t1");
         String role = "test-role";
         authorizationService.grantPermissionAsync(topicName, null, role, "auth-json").get();
         Assert.assertEquals(TestAuthorizationProviderWithGrantPermission.authDataJson, "auth-json");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ClientErrorsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ClientErrorsTest.java
@@ -70,10 +70,10 @@ public class ClientErrorsTest {
         @Cleanup
         PulsarClient client = PulsarClient.builder().serviceUrl(mockBrokerService.getBrokerAddress()).build();
         try {
-            Consumer<byte[]> consumer = client.newConsumer().topic("persistent://prop/use/ns/t1")
+            Consumer<byte[]> consumer = client.newConsumer().topic("persistent://tenant/ns/t1")
                     .subscriptionName("sub1").subscribe();
 
-            Producer<byte[]> producer = client.newProducer().topic("persistent://prop/use/ns/t1").create();
+            Producer<byte[]> producer = client.newProducer().topic("persistent://tenant/ns/t1").create();
             Thread.sleep(ASYNC_EVENT_COMPLETION_WAIT);
             producer.send("message".getBytes());
             Thread.sleep(ASYNC_EVENT_COMPLETION_WAIT);
@@ -89,12 +89,12 @@ public class ClientErrorsTest {
 
     @Test
     public void testProducerCreateFailWithoutRetry() throws Exception {
-        producerCreateFailWithoutRetry("persistent://prop/use/ns/t1");
+        producerCreateFailWithoutRetry("persistent://tenant/ns/t1");
     }
 
     @Test
     public void testPartitionedProducerCreateFailWithoutRetry() throws Exception {
-        producerCreateFailWithoutRetry("persistent://prop/use/ns/part-t1");
+        producerCreateFailWithoutRetry("persistent://tenant/ns/part-t1");
     }
 
     private void producerCreateFailWithoutRetry(String topic) throws Exception {
@@ -125,12 +125,12 @@ public class ClientErrorsTest {
 
     @Test
     public void testProducerCreateSuccessAfterRetry() throws Exception {
-        producerCreateSuccessAfterRetry("persistent://prop/use/ns/t1");
+        producerCreateSuccessAfterRetry("persistent://tenant/ns/t1");
     }
 
     @Test
     public void testPartitionedProducerCreateSuccessAfterRetry() throws Exception {
-        producerCreateSuccessAfterRetry("persistent://prop/use/ns/part-t1");
+        producerCreateSuccessAfterRetry("persistent://tenant/ns/part-t1");
     }
 
     private void producerCreateSuccessAfterRetry(String topic) throws Exception {
@@ -158,12 +158,12 @@ public class ClientErrorsTest {
 
     @Test
     public void testProducerCreateFailAfterRetryTimeout() throws Exception {
-        producerCreateFailAfterRetryTimeout("persistent://prop/use/ns/t1");
+        producerCreateFailAfterRetryTimeout("persistent://tenant/ns/t1");
     }
 
     @Test
     public void testPartitionedProducerCreateFailAfterRetryTimeout() throws Exception {
-        producerCreateFailAfterRetryTimeout("persistent://prop/use/ns/part-t1");
+        producerCreateFailAfterRetryTimeout("persistent://tenant/ns/part-t1");
     }
 
     private void producerCreateFailAfterRetryTimeout(String topic) throws Exception {
@@ -204,12 +204,12 @@ public class ClientErrorsTest {
 
     @Test
     public void testCreatedProducerSendsCloseProducerAfterTimeout() throws Exception {
-        producerCreatedThenFailsRetryTimeout("persistent://prop/use/ns/t1");
+        producerCreatedThenFailsRetryTimeout("persistent://tenant/ns/t1");
     }
 
     @Test
     public void testCreatedPartitionedProducerSendsCloseProducerAfterTimeout() throws Exception {
-        producerCreatedThenFailsRetryTimeout("persistent://prop/use/ns/part-t1");
+        producerCreatedThenFailsRetryTimeout("persistent://tenant/ns/part-t1");
     }
 
     private void producerCreatedThenFailsRetryTimeout(String topic) throws Exception {
@@ -251,12 +251,12 @@ public class ClientErrorsTest {
 
     @Test
     public void testCreatedConsumerSendsCloseConsumerAfterTimeout() throws Exception {
-        consumerCreatedThenFailsRetryTimeout("persistent://prop/use/ns/t1");
+        consumerCreatedThenFailsRetryTimeout("persistent://tenant/ns/t1");
     }
 
     @Test
     public void testCreatedPartitionedConsumerSendsCloseConsumerAfterTimeout() throws Exception {
-        consumerCreatedThenFailsRetryTimeout("persistent://prop/use/ns/part-t1");
+        consumerCreatedThenFailsRetryTimeout("persistent://tenant/ns/part-t1");
     }
 
     private void consumerCreatedThenFailsRetryTimeout(String topic) throws Exception {
@@ -296,12 +296,12 @@ public class ClientErrorsTest {
 
     @Test
     public void testProducerFailDoesNotFailOtherProducer() throws Exception {
-        producerFailDoesNotFailOtherProducer("persistent://prop/use/ns/t1", "persistent://prop/use/ns/t2");
+        producerFailDoesNotFailOtherProducer("persistent://tenant/ns/t1", "persistent://tenant/ns/t2");
     }
 
     @Test
     public void testPartitionedProducerFailDoesNotFailOtherProducer() throws Exception {
-        producerFailDoesNotFailOtherProducer("persistent://prop/use/ns/part-t1", "persistent://prop/use/ns/part-t2");
+        producerFailDoesNotFailOtherProducer("persistent://tenant/ns/part-t1", "persistent://tenant/ns/part-t2");
     }
 
     private void producerFailDoesNotFailOtherProducer(String topic1, String topic2) throws Exception {
@@ -338,12 +338,12 @@ public class ClientErrorsTest {
 
     @Test
     public void testProducerContinuousRetryAfterSendFail() throws Exception {
-        producerContinuousRetryAfterSendFail("persistent://prop/use/ns/t1");
+        producerContinuousRetryAfterSendFail("persistent://tenant/ns/t1");
     }
 
     @Test
     public void testPartitionedProducerContinuousRetryAfterSendFail() throws Exception {
-        producerContinuousRetryAfterSendFail("persistent://prop/use/ns/part-t1");
+        producerContinuousRetryAfterSendFail("persistent://tenant/ns/part-t1");
     }
 
     private void producerContinuousRetryAfterSendFail(String topic) throws Exception {
@@ -385,12 +385,12 @@ public class ClientErrorsTest {
 
     @Test
     public void testSubscribeFailWithoutRetry() throws Exception {
-        subscribeFailWithoutRetry("persistent://prop/use/ns/t1");
+        subscribeFailWithoutRetry("persistent://tenant/ns/t1");
     }
 
     @Test
     public void testPartitionedSubscribeFailWithoutRetry() throws Exception {
-        subscribeFailWithoutRetry("persistent://prop/use/ns/part-t1");
+        subscribeFailWithoutRetry("persistent://tenant/ns/part-t1");
     }
 
     @Test
@@ -398,7 +398,7 @@ public class ClientErrorsTest {
         @Cleanup
         PulsarClient client = PulsarClient.builder().serviceUrl(mockBrokerService.getBrokerAddress()).build();
         final AtomicInteger counter = new AtomicInteger(0);
-        String topic = "persistent://prop/use/ns/t1";
+        String topic = "persistent://tenant/ns/t1";
 
         mockBrokerService.setHandlePartitionLookup((ctx, lookup) -> {
             ctx.writeAndFlush(Commands.newPartitionMetadataResponse(0, lookup.getRequestId()));
@@ -457,12 +457,12 @@ public class ClientErrorsTest {
 
     @Test
     public void testSubscribeSuccessAfterRetry() throws Exception {
-        subscribeSuccessAfterRetry("persistent://prop/use/ns/t1");
+        subscribeSuccessAfterRetry("persistent://tenant/ns/t1");
     }
 
     @Test
     public void testPartitionedSubscribeSuccessAfterRetry() throws Exception {
-        subscribeSuccessAfterRetry("persistent://prop/use/ns/part-t1");
+        subscribeSuccessAfterRetry("persistent://tenant/ns/part-t1");
     }
 
     private void subscribeSuccessAfterRetry(String topic) throws Exception {
@@ -489,12 +489,12 @@ public class ClientErrorsTest {
 
     @Test
     public void testSubscribeFailAfterRetryTimeout() throws Exception {
-        subscribeFailAfterRetryTimeout("persistent://prop/use/ns/t1");
+        subscribeFailAfterRetryTimeout("persistent://tenant/ns/t1");
     }
 
     @Test
     public void testPartitionedSubscribeFailAfterRetryTimeout() throws Exception {
-        subscribeFailAfterRetryTimeout("persistent://prop/use/ns/part-t1");
+        subscribeFailAfterRetryTimeout("persistent://tenant/ns/part-t1");
     }
 
     private void subscribeFailAfterRetryTimeout(String topic) throws Exception {
@@ -527,12 +527,12 @@ public class ClientErrorsTest {
 
     @Test
     public void testSubscribeFailDoesNotFailOtherConsumer() throws Exception {
-        subscribeFailDoesNotFailOtherConsumer("persistent://prop/use/ns/t1", "persistent://prop/use/ns/t2");
+        subscribeFailDoesNotFailOtherConsumer("persistent://tenant/ns/t1", "persistent://tenant/ns/t2");
     }
 
     @Test
     public void testPartitionedSubscribeFailDoesNotFailOtherConsumer() throws Exception {
-        subscribeFailDoesNotFailOtherConsumer("persistent://prop/use/ns/part-t1", "persistent://prop/use/ns/part-t2");
+        subscribeFailDoesNotFailOtherConsumer("persistent://tenant/ns/part-t1", "persistent://tenant/ns/part-t2");
     }
 
     private void subscribeFailDoesNotFailOtherConsumer(String topic1, String topic2) throws Exception {
@@ -587,7 +587,7 @@ public class ClientErrorsTest {
             client.newProducer()
                     .enableLazyStartPartitionedProducers(true)
                     .accessMode(ProducerAccessMode.Shared)
-                    .topic("persistent://prop/use/ns/multi-part-t1").create();
+                    .topic("persistent://tenant/ns/multi-part-t1").create();
             fail("Should have failed with an authorization error");
         } catch (Exception e) {
             assertTrue(e instanceof PulsarClientException.AuthorizationException);
@@ -605,7 +605,7 @@ public class ClientErrorsTest {
         PulsarClient client = PulsarClient.builder().serviceUrl(mockBrokerService.getHttpAddress()).build();
         final AtomicInteger producerCounter = new AtomicInteger(0);
         final AtomicInteger closeCounter = new AtomicInteger(0);
-        final String topicName = "persistent://prop/use/ns/multi-part-t1";
+        final String topicName = "persistent://tenant/ns/multi-part-t1";
 
         mockBrokerService.setHandleProducer((ctx, producer) -> {
             if (producerCounter.incrementAndGet() == 2) {
@@ -684,7 +684,7 @@ public class ClientErrorsTest {
         });
 
         try {
-            client.newProducer().topic("persistent://prop/use/ns/multi-part-t1").create();
+            client.newProducer().topic("persistent://tenant/ns/multi-part-t1").create();
             fail("Should have failed with an authorization error");
         } catch (Exception e) {
             assertTrue(e instanceof PulsarClientException.AuthorizationException);
@@ -720,7 +720,7 @@ public class ClientErrorsTest {
         });
 
         try {
-            client.newConsumer().topic("persistent://prop/use/ns/multi-part-t1").subscriptionName("sub1").subscribe();
+            client.newConsumer().topic("persistent://tenant/ns/multi-part-t1").subscriptionName("sub1").subscribe();
             fail("Should have failed with an authorization error");
         } catch (PulsarClientException.AuthorizationException e) {
         }
@@ -752,7 +752,7 @@ public class ClientErrorsTest {
             }
         });
 
-        client.newConsumer().topic("persistent://prop/use/ns/multi-part-t1").subscriptionName("sub1").subscribe();
+        client.newConsumer().topic("persistent://tenant/ns/multi-part-t1").subscriptionName("sub1").subscribe();
 
         if (fail.get()) {
             fail("Flow command should have been sent after all 4 partitions subscribe successfully");
@@ -789,7 +789,7 @@ public class ClientErrorsTest {
 
         @Cleanup
         PulsarClient client = PulsarClient.builder().serviceUrl(mockBrokerService.getBrokerAddress()).build();
-        Producer<byte[]> producer = client.newProducer().topic("persistent://prop/use/ns/t1").create();
+        Producer<byte[]> producer = client.newProducer().topic("persistent://tenant/ns/t1").create();
 
         // close the cnx after creating the producer
         channelCtx.get().channel().close().get();
@@ -827,7 +827,7 @@ public class ClientErrorsTest {
 
         @Cleanup
         PulsarClient client = PulsarClient.builder().serviceUrl(mockBrokerService.getBrokerAddress()).build();
-        client.newConsumer().topic("persistent://prop/use/ns/t1").subscriptionName("sub1").subscribe();
+        client.newConsumer().topic("persistent://tenant/ns/t1").subscriptionName("sub1").subscribe();
 
         // close the cnx after creating the producer
         channelCtx.get().channel().close();
@@ -853,7 +853,7 @@ public class ClientErrorsTest {
         });
 
         try {
-            client.newProducer().topic("persistent://prop/use/ns/t1").create();
+            client.newProducer().topic("persistent://tenant/ns/t1").create();
             fail();
         } catch (Exception e) {
             assertTrue(e instanceof PulsarClientException.AuthorizationException);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/DispatcherBlockConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/DispatcherBlockConsumerTest.java
@@ -520,7 +520,7 @@ public class DispatcherBlockConsumerTest extends ProducerConsumerBase {
 
         int orginalDispatcherLimit = conf.getMaxUnackedMessagesPerSubscription();
         try {
-            final String topicName = "persistent://prop/use/ns-abc/blockDispatch";
+            final String topicName = "persistent://tenant/ns-abc/blockDispatch";
             final String subName = "blockDispatch";
             final int timeWaitToSync = 100;
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/BrokerClientIntegrationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/BrokerClientIntegrationTest.java
@@ -529,7 +529,7 @@ public class BrokerClientIntegrationTest extends ProducerConsumerBase {
      */
     @Test
     public void testMaxConcurrentTopicLoading() throws Exception {
-        final String topicName = "persistent://prop/usw/my-ns/cocurrentLoadingTopic";
+        final String topicName = "persistent://tenant/my-ns/cocurrentLoadingTopic";
         int concurrentTopic = pulsar.getConfiguration().getMaxConcurrentTopicLoadRequest();
         final int concurrentLookupRequests = 20;
         @Cleanup("shutdownNow")
@@ -588,7 +588,7 @@ public class BrokerClientIntegrationTest extends ProducerConsumerBase {
     @Test
     public void testCloseConnectionOnInternalServerError() throws Exception {
 
-        final String topicName = "persistent://prop/usw/my-ns/newTopic";
+        final String topicName = "persistent://tenant/my-ns/newTopic";
 
         @Cleanup
         final PulsarClient pulsarClient = PulsarClient.builder()

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessageChecksumTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessageChecksumTest.java
@@ -116,7 +116,7 @@ public class MessageChecksumTest extends BrokerTestBase {
             throws Exception {
         // GIVEN
         final String topicName =
-                "persistent://prop/use/ns-abc/testChecksumBackwardsCompatibilityWithOldBrokerWithoutChecksumHandling";
+                "persistent://tenant/ns-abc/testChecksumBackwardsCompatibilityWithOldBrokerWithoutChecksumHandling";
 
         if (mixedVersionScenario == MixedVersionScenario.CONNECTED_TO_OLD_THEN_NEW_VERSION) {
             // Given, the client thinks it's connected to a broker that doesn't support message checksums
@@ -220,7 +220,7 @@ public class MessageChecksumTest extends BrokerTestBase {
     public void testTamperingMessageIsDetected() throws Exception {
         // GIVEN
         ProducerImpl<byte[]> producer = (ProducerImpl<byte[]>) pulsarClient.newProducer()
-                .topic("persistent://prop/use/ns-abc/testTamperingMessageIsDetected")
+                .topic("persistent://tenant/ns-abc/testTamperingMessageIsDetected")
                 .enableBatching(false)
                 .messageRoutingMode(MessageRoutingMode.SinglePartition)
                 .create();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessageChunkingTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessageChunkingTest.java
@@ -474,7 +474,7 @@ public class MessageChunkingTest extends ProducerConsumerBase {
 
     @Test
     public void testExpireIncompleteChunkMessage() throws Exception{
-        final String topicName = "persistent://prop/use/ns-abc/expireMsg";
+        final String topicName = "persistent://tenant/ns-abc/expireMsg";
 
         // 1. producer connect
         ProducerImpl<byte[]> producer = (ProducerImpl<byte[]>) pulsarClient.newProducer()

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessageIdTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessageIdTest.java
@@ -62,7 +62,7 @@ public class MessageIdTest extends BrokerTestBase {
     public void producerSendAsync(TopicType topicType) throws PulsarClientException, PulsarAdminException {
         // Given
         String key = "producerSendAsync-" + topicType;
-        final String topicName = "persistent://prop/cluster/namespace/topic-" + key;
+        final String topicName = "persistent://tenant/namespace/topic-" + key;
         final String subscriptionName = "my-subscription-" + key;
         final String messagePrefix = "my-message-" + key + "-";
         final int numberOfMessages = 30;
@@ -129,7 +129,7 @@ public class MessageIdTest extends BrokerTestBase {
     public void producerSend(TopicType topicType) throws PulsarClientException, PulsarAdminException {
         // Given
         String key = "producerSend-" + topicType;
-        final String topicName = "persistent://prop/cluster/namespace/topic-" + key;
+        final String topicName = "persistent://tenant/namespace/topic-" + key;
         final String subscriptionName = "my-subscription-" + key;
         final String messagePrefix = "my-message-" + key + "-";
         final int numberOfMessages = 30;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/PatternTopicsConsumerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/PatternTopicsConsumerImplTest.java
@@ -101,7 +101,7 @@ public class PatternTopicsConsumerImplTest extends ProducerConsumerBase {
         Pattern pattern = Pattern.compile(patternString);
 
         TenantInfoImpl tenantInfo = createDefaultTenantInfo();
-        admin.tenants().createTenant("prop", tenantInfo);
+        admin.tenants().createTenant("tenant", tenantInfo);
         admin.topics().createPartitionedTopic(topicName2, 2);
         admin.topics().createPartitionedTopic(topicName3, 3);
 
@@ -186,7 +186,7 @@ public class PatternTopicsConsumerImplTest extends ProducerConsumerBase {
 
         // 1. create partition
         TenantInfoImpl tenantInfo = createDefaultTenantInfo();
-        admin.tenants().createTenant("prop", tenantInfo);
+        admin.tenants().createTenant("tenant", tenantInfo);
         admin.topics().createPartitionedTopic(topicName2, 2);
         admin.topics().createPartitionedTopic(topicName3, 3);
 
@@ -283,7 +283,7 @@ public class PatternTopicsConsumerImplTest extends ProducerConsumerBase {
 
         // 1. create partition
         TenantInfoImpl tenantInfo = createDefaultTenantInfo();
-        admin.tenants().createTenant("prop", tenantInfo);
+        admin.tenants().createTenant("tenant", tenantInfo);
         admin.topics().createPartitionedTopic(topicName1, 1);
         admin.topics().createPartitionedTopic(topicName2, 2);
         admin.topics().createPartitionedTopic(topicName3, 3);
@@ -354,7 +354,7 @@ public class PatternTopicsConsumerImplTest extends ProducerConsumerBase {
 
         // 1. create partition
         TenantInfoImpl tenantInfo = createDefaultTenantInfo();
-        admin.tenants().createTenant("prop", tenantInfo);
+        admin.tenants().createTenant("tenant", tenantInfo);
         admin.topics().createPartitionedTopic(topicName2, 2);
         admin.topics().createPartitionedTopic(topicName3, 3);
 
@@ -452,7 +452,7 @@ public class PatternTopicsConsumerImplTest extends ProducerConsumerBase {
 
         // 1. create partition
         TenantInfoImpl tenantInfo = createDefaultTenantInfo();
-        admin.tenants().createTenant("prop", tenantInfo);
+        admin.tenants().createTenant("tenant", tenantInfo);
         admin.topics().createPartitionedTopic(topicName2, 2);
         admin.topics().createPartitionedTopic(topicName3, 3);
 
@@ -549,7 +549,7 @@ public class PatternTopicsConsumerImplTest extends ProducerConsumerBase {
 
         // 1. create partition
         TenantInfoImpl tenantInfo = createDefaultTenantInfo();
-        admin.tenants().createTenant("prop", tenantInfo);
+        admin.tenants().createTenant("tenant", tenantInfo);
         admin.topics().createPartitionedTopic(topicName2, 2);
         admin.topics().createPartitionedTopic(topicName3, 3);
 
@@ -660,7 +660,7 @@ public class PatternTopicsConsumerImplTest extends ProducerConsumerBase {
         // 1. create partition
         String topicName = "persistent://my-property/my-ns/pattern-topic-1-" + key;
         TenantInfoImpl tenantInfo = createDefaultTenantInfo();
-        admin.tenants().createTenant("prop", tenantInfo);
+        admin.tenants().createTenant("tenant", tenantInfo);
         admin.topics().createPartitionedTopic(topicName, 4);
 
         // 2. verify consumer get methods. There is no need to trigger discovery, because the broker will push the
@@ -941,7 +941,7 @@ public class PatternTopicsConsumerImplTest extends ProducerConsumerBase {
 
         // 1. create partition
         TenantInfoImpl tenantInfo = createDefaultTenantInfo();
-        admin.tenants().createTenant("prop", tenantInfo);
+        admin.tenants().createTenant("tenant", tenantInfo);
         admin.topics().createPartitionedTopic(topicName2, 2);
         admin.topics().createPartitionedTopic(topicName3, 3);
 
@@ -1056,7 +1056,7 @@ public class PatternTopicsConsumerImplTest extends ProducerConsumerBase {
 
         // 1. create partition
         TenantInfoImpl tenantInfo = createDefaultTenantInfo();
-        admin.tenants().createTenant("prop", tenantInfo);
+        admin.tenants().createTenant("tenant", tenantInfo);
         admin.topics().createPartitionedTopic(topicName2, 2);
         admin.topics().createPartitionedTopic(topicName3, 3);
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/PerMessageUnAcknowledgedRedeliveryTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/PerMessageUnAcknowledgedRedeliveryTest.java
@@ -27,7 +27,6 @@ import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageRoutingMode;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.SubscriptionType;
-import org.apache.pulsar.common.policies.data.TenantInfoImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterMethod;
@@ -43,7 +42,7 @@ public class PerMessageUnAcknowledgedRedeliveryTest extends BrokerTestBase {
     @Override
     @BeforeMethod
     public void setup() throws Exception {
-        super.internalSetup();
+        baseSetup();
     }
 
     @Override
@@ -402,8 +401,6 @@ public class PerMessageUnAcknowledgedRedeliveryTest extends BrokerTestBase {
         final String messagePredicate = "my-message-" + key + "-";
         final int totalMessages = 15;
         final int numberOfPartitions = 3;
-        TenantInfoImpl tenantInfo = createDefaultTenantInfo();
-        admin.tenants().createTenant("tenant", tenantInfo);
         admin.topics().createPartitionedTopic(topicName, numberOfPartitions);
 
         // 1. producer connect

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/PerMessageUnAcknowledgedRedeliveryTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/PerMessageUnAcknowledgedRedeliveryTest.java
@@ -55,7 +55,7 @@ public class PerMessageUnAcknowledgedRedeliveryTest extends BrokerTestBase {
     @Test(timeOut = testTimeout)
     public void testSharedAckedNormalTopic() throws Exception {
         String key = "testSharedAckedNormalTopic";
-        final String topicName = "persistent://prop/use/ns-abc/topic-" + key;
+        final String topicName = "persistent://tenant/ns-abc/topic-" + key;
         final String subscriptionName = "my-ex-subscription-" + key;
         final String messagePredicate = "my-message-" + key + "-";
         final int totalMessages = 15;
@@ -153,7 +153,7 @@ public class PerMessageUnAcknowledgedRedeliveryTest extends BrokerTestBase {
     @Test(timeOut = testTimeout)
     public void testUnAckedMessageTrackerSize() throws Exception {
         String key = "testUnAckedMessageTrackerSize";
-        final String topicName = "persistent://prop/use/ns-abc/topic-" + key;
+        final String topicName = "persistent://tenant/ns-abc/topic-" + key;
         final String subscriptionName = "my-ex-subscription-" + key;
         final String messagePredicate = "my-message-" + key + "-";
         final int totalMessages = 15;
@@ -195,7 +195,7 @@ public class PerMessageUnAcknowledgedRedeliveryTest extends BrokerTestBase {
     @Test(timeOut = testTimeout)
     public void testExclusiveAckedNormalTopic() throws Exception {
         String key = "testExclusiveAckedNormalTopic";
-        final String topicName = "persistent://prop/use/ns-abc/topic-" + key;
+        final String topicName = "persistent://tenant/ns-abc/topic-" + key;
         final String subscriptionName = "my-ex-subscription-" + key;
         final String messagePredicate = "my-message-" + key + "-";
         final int totalMessages = 15;
@@ -293,7 +293,7 @@ public class PerMessageUnAcknowledgedRedeliveryTest extends BrokerTestBase {
     @Test(timeOut = testTimeout)
     public void testFailoverAckedNormalTopic() throws Exception {
         String key = "testFailoverAckedNormalTopic";
-        final String topicName = "persistent://prop/use/ns-abc/topic-" + key;
+        final String topicName = "persistent://tenant/ns-abc/topic-" + key;
         final String subscriptionName = "my-ex-subscription-" + key;
         final String messagePredicate = "my-message-" + key + "-";
         final int totalMessages = 15;
@@ -397,13 +397,13 @@ public class PerMessageUnAcknowledgedRedeliveryTest extends BrokerTestBase {
     @Test(timeOut = testTimeout)
     public void testSharedAckedPartitionedTopic() throws Exception {
         String key = "testSharedAckedPartitionedTopic";
-        final String topicName = "persistent://prop/use/ns-abc/topic-" + key;
+        final String topicName = "persistent://tenant/ns-abc/topic-" + key;
         final String subscriptionName = "my-ex-subscription-" + key;
         final String messagePredicate = "my-message-" + key + "-";
         final int totalMessages = 15;
         final int numberOfPartitions = 3;
         TenantInfoImpl tenantInfo = createDefaultTenantInfo();
-        admin.tenants().createTenant("prop", tenantInfo);
+        admin.tenants().createTenant("tenant", tenantInfo);
         admin.topics().createPartitionedTopic(topicName, numberOfPartitions);
 
         // 1. producer connect

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/SequenceIdWithErrorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/SequenceIdWithErrorTest.java
@@ -44,9 +44,9 @@ public class SequenceIdWithErrorTest extends BkEnsemblesTestBase {
      */
     @Test
     public void testCheckSequenceId() throws Exception {
-        admin.namespaces().createNamespace("prop/my-test", Collections.singleton("usc"));
+        admin.namespaces().createNamespace("tenant/my-test", Collections.singleton("usc"));
 
-        String topicName = "prop/my-test/my-topic";
+        String topicName = "tenant/my-test/my-topic";
         int num = 10;
 
         @Cleanup

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TopicsConsumerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TopicsConsumerImplTest.java
@@ -113,13 +113,13 @@ public class TopicsConsumerImplTest extends ProducerConsumerBase {
         String key = "TopicsFromDifferentNamespace";
         final String subscriptionName = "my-ex-subscription-" + key;
 
-        final String topicName1 = "persistent://prop/use/ns-abc1/topic-1-" + key;
-        final String topicName2 = "persistent://prop/use/ns-abc2/topic-2-" + key;
-        final String topicName3 = "persistent://prop/use/ns-abc3/topic-3-" + key;
+        final String topicName1 = "persistent://tenant/ns-abc1/topic-1-" + key;
+        final String topicName2 = "persistent://tenant/ns-abc2/topic-2-" + key;
+        final String topicName3 = "persistent://tenant/ns-abc3/topic-3-" + key;
         List<String> topicNames = Lists.newArrayList(topicName1, topicName2, topicName3);
 
         TenantInfoImpl tenantInfo = createDefaultTenantInfo();
-        admin.tenants().createTenant("prop", tenantInfo);
+        admin.tenants().createTenant("tenant", tenantInfo);
         admin.topics().createPartitionedTopic(topicName2, 2);
         admin.topics().createPartitionedTopic(topicName3, 3);
 
@@ -140,10 +140,10 @@ public class TopicsConsumerImplTest extends ProducerConsumerBase {
     @Test(timeOut = testTimeout)
     public void testRetryClusterTopic() throws Exception {
         String key = "testRetryClusterTopic";
-        final String topicName = "persistent://prop/use/ns-abc1/topic-1-" + key;
+        final String topicName = "persistent://tenant/ns-abc1/topic-1-" + key;
         TenantInfoImpl tenantInfo = createDefaultTenantInfo();
-        final String namespace = "prop/ns-abc1";
-        admin.tenants().createTenant("prop", tenantInfo);
+        final String namespace = "tenant/ns-abc1";
+        admin.tenants().createTenant("tenant", tenantInfo);
         admin.namespaces().createNamespace(namespace, Set.of("test"));
         Consumer consumer = pulsarClient.newConsumer()
                 .topic(topicName)
@@ -160,13 +160,13 @@ public class TopicsConsumerImplTest extends ProducerConsumerBase {
         String key = "TopicsConsumerGet";
         final String subscriptionName = "my-ex-subscription-" + key;
 
-        final String topicName1 = "persistent://prop/use/ns-abc/topic-1-" + key;
-        final String topicName2 = "persistent://prop/use/ns-abc/topic-2-" + key;
-        final String topicName3 = "persistent://prop/use/ns-abc/topic-3-" + key;
+        final String topicName1 = "persistent://tenant/ns-abc/topic-1-" + key;
+        final String topicName2 = "persistent://tenant/ns-abc/topic-2-" + key;
+        final String topicName3 = "persistent://tenant/ns-abc/topic-3-" + key;
         List<String> topicNames = Lists.newArrayList(topicName1, topicName2);
 
         TenantInfoImpl tenantInfo = createDefaultTenantInfo();
-        admin.tenants().createTenant("prop", tenantInfo);
+        admin.tenants().createTenant("tenant", tenantInfo);
         admin.topics().createPartitionedTopic(topicName2, 2);
         admin.topics().createPartitionedTopic(topicName3, 3);
 
@@ -258,13 +258,13 @@ public class TopicsConsumerImplTest extends ProducerConsumerBase {
         final String messagePredicate = "my-message-" + key + "-";
         final int totalMessages = 30;
 
-        final String topicName1 = "persistent://prop/use/ns-abc/topic-1-" + key;
-        final String topicName2 = "persistent://prop/use/ns-abc/topic-2-" + key;
-        final String topicName3 = "persistent://prop/use/ns-abc/topic-3-" + key;
+        final String topicName1 = "persistent://tenant/ns-abc/topic-1-" + key;
+        final String topicName2 = "persistent://tenant/ns-abc/topic-2-" + key;
+        final String topicName3 = "persistent://tenant/ns-abc/topic-3-" + key;
         List<String> topicNames = Lists.newArrayList(topicName1, topicName2, topicName3);
 
         TenantInfoImpl tenantInfo = createDefaultTenantInfo();
-        admin.tenants().createTenant("prop", tenantInfo);
+        admin.tenants().createTenant("tenant", tenantInfo);
         admin.topics().createPartitionedTopic(topicName2, 2);
         admin.topics().createPartitionedTopic(topicName3, 3);
 
@@ -324,13 +324,13 @@ public class TopicsConsumerImplTest extends ProducerConsumerBase {
         final String messagePredicate = "my-message-" + key + "-";
         final int totalMessages = 30;
 
-        final String topicName1 = "persistent://prop/use/ns-abc/topic-1-" + key;
-        final String topicName2 = "persistent://prop/use/ns-abc/topic-2-" + key;
-        final String topicName3 = "persistent://prop/use/ns-abc/topic-3-" + key;
+        final String topicName1 = "persistent://tenant/ns-abc/topic-1-" + key;
+        final String topicName2 = "persistent://tenant/ns-abc/topic-2-" + key;
+        final String topicName3 = "persistent://tenant/ns-abc/topic-3-" + key;
         List<String> topicNames = Lists.newArrayList(topicName1, topicName2, topicName3);
 
         TenantInfoImpl tenantInfo = createDefaultTenantInfo();
-        admin.tenants().createTenant("prop", tenantInfo);
+        admin.tenants().createTenant("tenant", tenantInfo);
         admin.topics().createPartitionedTopic(topicName2, 2);
         admin.topics().createPartitionedTopic(topicName3, 3);
 
@@ -409,13 +409,13 @@ public class TopicsConsumerImplTest extends ProducerConsumerBase {
         final String messagePredicate = "my-message-" + key + "-";
         final int totalMessages = 30;
 
-        final String topicName1 = "persistent://prop/use/ns-abc/topic-1-" + key;
-        final String topicName2 = "persistent://prop/use/ns-abc/topic-2-" + key;
-        final String topicName3 = "persistent://prop/use/ns-abc/topic-3-" + key;
+        final String topicName1 = "persistent://tenant/ns-abc/topic-1-" + key;
+        final String topicName2 = "persistent://tenant/ns-abc/topic-2-" + key;
+        final String topicName3 = "persistent://tenant/ns-abc/topic-3-" + key;
         List<String> topicNames = Lists.newArrayList(topicName1, topicName2, topicName3);
 
         TenantInfoImpl tenantInfo = createDefaultTenantInfo();
-        admin.tenants().createTenant("prop", tenantInfo);
+        admin.tenants().createTenant("tenant", tenantInfo);
         admin.topics().createPartitionedTopic(topicName2, 2);
         admin.topics().createPartitionedTopic(topicName3, 3);
 
@@ -548,9 +548,9 @@ public class TopicsConsumerImplTest extends ProducerConsumerBase {
 
     @Test
     public void testTopicNameValid() throws Exception{
-        final String topicName = "persistent://prop/use/ns-abc/testTopicNameValid";
+        final String topicName = "persistent://tenant/ns-abc/testTopicNameValid";
         TenantInfoImpl tenantInfo = createDefaultTenantInfo();
-        admin.tenants().createTenant("prop", tenantInfo);
+        admin.tenants().createTenant("tenant", tenantInfo);
         admin.topics().createPartitionedTopic(topicName, 3);
         Consumer<byte[]> consumer = pulsarClient.newConsumer()
                 .topic(topicName)
@@ -606,13 +606,13 @@ public class TopicsConsumerImplTest extends ProducerConsumerBase {
         final String messagePredicate = "my-message-" + key + "-";
         final int totalMessages = 30;
 
-        final String topicName1 = "persistent://prop/use/ns-abc/topic-1-" + key;
-        final String topicName2 = "persistent://prop/use/ns-abc/topic-2-" + key;
-        final String topicName3 = "persistent://prop/use/ns-abc/topic-3-" + key;
+        final String topicName1 = "persistent://tenant/ns-abc/topic-1-" + key;
+        final String topicName2 = "persistent://tenant/ns-abc/topic-2-" + key;
+        final String topicName3 = "persistent://tenant/ns-abc/topic-3-" + key;
         List<String> topicNames = Lists.newArrayList(topicName1, topicName2, topicName3);
 
         TenantInfoImpl tenantInfo = createDefaultTenantInfo();
-        admin.tenants().createTenant("prop", tenantInfo);
+        admin.tenants().createTenant("tenant", tenantInfo);
         admin.topics().createPartitionedTopic(topicName2, 2);
         admin.topics().createPartitionedTopic(topicName3, 3);
 
@@ -771,11 +771,11 @@ public class TopicsConsumerImplTest extends ProducerConsumerBase {
         String key = "TopicsNameSubscribeWithBuilder";
         final String subscriptionName = "my-ex-subscription-" + key;
 
-        final String topicName2 = "persistent://prop/use/ns-abc/topic-2-" + key;
-        final String topicName3 = "persistent://prop/use/ns-abc/topic-3-" + key;
+        final String topicName2 = "persistent://tenant/ns-abc/topic-2-" + key;
+        final String topicName3 = "persistent://tenant/ns-abc/topic-3-" + key;
 
         TenantInfoImpl tenantInfo = createDefaultTenantInfo();
-        admin.tenants().createTenant("prop", tenantInfo);
+        admin.tenants().createTenant("tenant", tenantInfo);
         admin.topics().createPartitionedTopic(topicName2, 2);
         admin.topics().createPartitionedTopic(topicName3, 3);
 
@@ -841,11 +841,11 @@ public class TopicsConsumerImplTest extends ProducerConsumerBase {
         // set latch larger than totalMessages, so timeout message get resend
         CountDownLatch latch = new CountDownLatch(totalMessages * 3);
 
-        final String topicName1 = "persistent://prop/use/ns-abc/topic-1-" + key;
+        final String topicName1 = "persistent://tenant/ns-abc/topic-1-" + key;
         List<String> topicNames = Lists.newArrayList(topicName1);
 
         TenantInfoImpl tenantInfo = createDefaultTenantInfo();
-        admin.tenants().createTenant("prop", tenantInfo);
+        admin.tenants().createTenant("tenant", tenantInfo);
         admin.topics().createPartitionedTopic(topicName1, 2);
 
         // 1. producer connect
@@ -907,7 +907,7 @@ public class TopicsConsumerImplTest extends ProducerConsumerBase {
         List<String> topicNames = Lists.newArrayList(topicName1, topicName2);
 
         TenantInfoImpl tenantInfo = createDefaultTenantInfo();
-        admin.tenants().createTenant("prop", tenantInfo);
+        admin.tenants().createTenant("tenant", tenantInfo);
         admin.topics().createPartitionedTopic(topicName1, 2);
         admin.topics().createPartitionedTopic(topicName2, 2);
 
@@ -966,7 +966,7 @@ public class TopicsConsumerImplTest extends ProducerConsumerBase {
                 "persistent://my-property/my-ns/testConsumerDistributionInFailoverSubscriptionWhenUpdatePartitions";
         final String subName = "failover-test";
         TenantInfoImpl tenantInfo = createDefaultTenantInfo();
-        admin.tenants().createTenant("prop", tenantInfo);
+        admin.tenants().createTenant("tenant", tenantInfo);
         admin.topics().createPartitionedTopic(topicName, 2);
         assertEquals(admin.topics().getPartitionedTopicMetadata(topicName).partitions, 2);
         Consumer<String> consumer1 = pulsarClient.newConsumer(Schema.STRING)
@@ -1076,13 +1076,13 @@ public class TopicsConsumerImplTest extends ProducerConsumerBase {
         int totalMessages = 10;
         this.conf.setTtlDurationDefaultInSeconds(defaultTTLSec);
 
-        final String namespace = "prop/use/expiry";
+        final String namespace = "tenant/expiry";
         final String topicName = "persistent://" + namespace + "/expiry";
         final String subName = "expiredSub";
 
         admin.clusters().createCluster("use", ClusterData.builder().serviceUrl(brokerUrl.toString()).build());
 
-        admin.tenants().createTenant("prop", new TenantInfoImpl(null, Sets.newHashSet("use")));
+        admin.tenants().createTenant("tenant", new TenantInfoImpl(null, Sets.newHashSet("use")));
         admin.namespaces().createNamespace(namespace);
 
         Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName(subName)
@@ -1118,13 +1118,13 @@ public class TopicsConsumerImplTest extends ProducerConsumerBase {
         final String messagePredicate = "my-message-" + key + "-";
         final int totalMessages = 30;
 
-        final String topicName1 = "persistent://prop/use/ns-abc/topic-1-" + key;
-        final String topicName2 = "persistent://prop/use/ns-abc/topic-2-" + key;
-        final String topicName3 = "persistent://prop/use/ns-abc/topic-3-" + key;
+        final String topicName1 = "persistent://tenant/ns-abc/topic-1-" + key;
+        final String topicName2 = "persistent://tenant/ns-abc/topic-2-" + key;
+        final String topicName3 = "persistent://tenant/ns-abc/topic-3-" + key;
         List<String> topicNames = Lists.newArrayList(topicName1, topicName2, topicName3);
 
         TenantInfoImpl tenantInfo = createDefaultTenantInfo();
-        admin.tenants().createTenant("prop", tenantInfo);
+        admin.tenants().createTenant("tenant", tenantInfo);
         admin.topics().createPartitionedTopic(topicName2, 2);
         admin.topics().createPartitionedTopic(topicName3, 3);
 
@@ -1245,13 +1245,13 @@ public class TopicsConsumerImplTest extends ProducerConsumerBase {
     @Test(timeOut = testTimeout)
     public void multiTopicsInDifferentNameSpace() throws PulsarAdminException, PulsarClientException {
         List<String> topics = new ArrayList<>();
-        topics.add("persistent://prop/use/ns-abc/topic-1");
-        topics.add("persistent://prop/use/ns-abc/topic-2");
-        topics.add("persistent://prop/use/ns-abc1/topic-3");
+        topics.add("persistent://tenant/ns-abc/topic-1");
+        topics.add("persistent://tenant/ns-abc/topic-2");
+        topics.add("persistent://tenant/ns-abc1/topic-3");
         admin.clusters().createCluster("use", ClusterData.builder().serviceUrl(brokerUrl.toString()).build());
-        admin.tenants().createTenant("prop", new TenantInfoImpl(null, Sets.newHashSet("use")));
-        admin.namespaces().createNamespace("prop/use/ns-abc");
-        admin.namespaces().createNamespace("prop/use/ns-abc1");
+        admin.tenants().createTenant("tenant", new TenantInfoImpl(null, Sets.newHashSet("use")));
+        admin.namespaces().createNamespace("tenant/ns-abc");
+        admin.namespaces().createNamespace("tenant/ns-abc1");
         Consumer consumer = pulsarClient.newConsumer()
                 .topics(topics)
                 .subscriptionName("multiTopicSubscription")
@@ -1259,15 +1259,15 @@ public class TopicsConsumerImplTest extends ProducerConsumerBase {
                 .subscribe();
         // create Producer
         Producer<String> producer = pulsarClient.newProducer(Schema.STRING)
-                .topic("persistent://prop/use/ns-abc/topic-1")
+                .topic("persistent://tenant/ns-abc/topic-1")
                 .producerName("producer")
                 .create();
         Producer<String> producer1 = pulsarClient.newProducer(Schema.STRING)
-                .topic("persistent://prop/use/ns-abc/topic-2")
+                .topic("persistent://tenant/ns-abc/topic-2")
                 .producerName("producer1")
                 .create();
         Producer<String> producer2 = pulsarClient.newProducer(Schema.STRING)
-                .topic("persistent://prop/use/ns-abc1/topic-3")
+                .topic("persistent://tenant/ns-abc1/topic-3")
                 .producerName("producer2")
                 .create();
         //send message

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/UnAcknowledgedMessagesTimeoutTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/UnAcknowledgedMessagesTimeoutTest.java
@@ -72,7 +72,7 @@ public class UnAcknowledgedMessagesTimeoutTest extends BrokerTestBase {
     @Test(dataProvider = "variationsRedeliveryTracker")
     public void testExclusiveSingleAckedNormalTopic(boolean isRedeliveryTracker) throws Exception {
         String key = "testExclusiveSingleAckedNormalTopic";
-        final String topicName = "persistent://prop/ns-abc/topic-" + key;
+        final String topicName = "persistent://tenant/ns-abc/topic-" + key;
         final String subscriptionName = "my-ex-subscription-" + key;
         final String messagePredicate = "my-message-" + key + "-";
         final int totalMessages = 10;
@@ -139,7 +139,7 @@ public class UnAcknowledgedMessagesTimeoutTest extends BrokerTestBase {
     @Test(dataProvider = "variationsRedeliveryTracker")
     public void testExclusiveCumulativeAckedNormalTopic(boolean isRedeliveryTracker) throws Exception {
         String key = "testExclusiveCumulativeAckedNormalTopic";
-        final String topicName = "persistent://prop/use/ns-abc/topic-" + key;
+        final String topicName = "persistent://tenant/ns-abc/topic-" + key;
         final String subscriptionName = "my-ex-subscription-" + key;
         final String messagePredicate = "my-message-" + key + "-";
         final int totalMessages = 10;
@@ -195,7 +195,7 @@ public class UnAcknowledgedMessagesTimeoutTest extends BrokerTestBase {
     @Test(dataProvider = "variationsRedeliveryTracker")
     public void testSharedSingleAckedPartitionedTopic(boolean isRedeliveryTracker) throws Exception {
         String key = "testSharedSingleAckedPartitionedTopic";
-        final String topicName = "persistent://prop/ns-abc/topic-" + key;
+        final String topicName = "persistent://tenant/ns-abc/topic-" + key;
         final String subscriptionName = "my-shared-subscription-" + key;
         final String messagePredicate = "my-message-" + key + "-";
         final int totalMessages = 20;
@@ -301,7 +301,7 @@ public class UnAcknowledgedMessagesTimeoutTest extends BrokerTestBase {
     @Test(dataProvider = "variationsRedeliveryTracker")
     public void testFailoverSingleAckedPartitionedTopic(boolean isRedeliveryTracker) throws Exception {
         String key = "testFailoverSingleAckedPartitionedTopic";
-        final String topicName = "persistent://prop/ns-abc/topic-" + key + UUID.randomUUID().toString();
+        final String topicName = "persistent://tenant/ns-abc/topic-" + key + UUID.randomUUID().toString();
         final String subscriptionName = "my-failover-subscription-" + key;
         final String messagePredicate = "my-message-" + key + "-";
         final int totalMessages = 10;
@@ -440,7 +440,7 @@ public class UnAcknowledgedMessagesTimeoutTest extends BrokerTestBase {
     @Test
     public void testCheckUnAcknowledgedMessageTimer() throws PulsarClientException, InterruptedException {
         String key = "testCheckUnAcknowledgedMessageTimer";
-        final String topicName = "persistent://prop/ns-abc/topic-" + key;
+        final String topicName = "persistent://tenant/ns-abc/topic-" + key;
         final String subscriptionName = "my-ex-subscription-" + key;
         final String messagePredicate = "my-message-" + key + "-";
         final int totalMessages = 3;
@@ -495,7 +495,7 @@ public class UnAcknowledgedMessagesTimeoutTest extends BrokerTestBase {
                                                               long maxDelayMs, int multiplier)
             throws PulsarClientException, InterruptedException {
         String key = "testCheckUnAcknowledgedMessageRedeliveryTimer";
-        final String topicName = "persistent://prop/ns-abc/topic-" + key;
+        final String topicName = "persistent://tenant/ns-abc/topic-" + key;
         final String subscriptionName = "my-ex-subscription-" + key;
         final String messagePredicate = "my-message-" + key + "-";
         final int totalMessages = 3;
@@ -544,7 +544,7 @@ public class UnAcknowledgedMessagesTimeoutTest extends BrokerTestBase {
 
     @Test
     public void testSingleMessageBatch() throws Exception {
-        String topicName = "prop/ns-abc/topic-estSingleMessageBatch";
+        String topicName = "tenant/ns-abc/topic-estSingleMessageBatch";
 
         Producer<String> producer = pulsarClient.newProducer(Schema.STRING)
                 .topic(topicName)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ZeroQueueSizeTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ZeroQueueSizeTest.java
@@ -81,7 +81,7 @@ public class ZeroQueueSizeTest extends BrokerTestBase {
     @Test(expectedExceptions = PulsarClientException.InvalidConfigurationException.class)
     public void zeroQueueSizeReceiveAsyncInCompatibility() throws PulsarClientException {
         String key = "zeroQueueSizeReceiveAsyncInCompatibility";
-        final String topicName = "persistent://prop/use/ns-abc/topic-" + key;
+        final String topicName = "persistent://tenant/ns-abc/topic-" + key;
         final String subscriptionName = "my-ex-subscription-" + key;
 
         Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName(subscriptionName)
@@ -92,7 +92,7 @@ public class ZeroQueueSizeTest extends BrokerTestBase {
     @Test(expectedExceptions = PulsarClientException.class)
     public void zeroQueueSizePartitionedTopicInCompatibility() throws PulsarClientException, PulsarAdminException {
         String key = "zeroQueueSizePartitionedTopicInCompatibility";
-        final String topicName = "persistent://prop/use/ns-abc/topic-" + key;
+        final String topicName = "persistent://tenant/ns-abc/topic-" + key;
         final String subscriptionName = "my-ex-subscription-" + key;
         int numberOfPartitions = 3;
         admin.topics().createPartitionedTopic(topicName, numberOfPartitions);
@@ -104,7 +104,7 @@ public class ZeroQueueSizeTest extends BrokerTestBase {
         String key = "nonZeroQueueSizeNormalConsumer";
 
         // 1. Config
-        final String topicName = "persistent://prop/use/ns-abc/topic-" + key;
+        final String topicName = "persistent://tenant/ns-abc/topic-" + key;
         final String subscriptionName = "my-ex-subscription-" + key;
         final String messagePredicate = "my-message-" + key + "-";
 
@@ -141,7 +141,7 @@ public class ZeroQueueSizeTest extends BrokerTestBase {
         String key = "zeroQueueSizeConsumerListener";
 
         // 1. Config
-        final String topicName = "persistent://prop/use/ns-abc/topic-" + key;
+        final String topicName = "persistent://tenant/ns-abc/topic-" + key;
         final String subscriptionName = "my-ex-subscription-" + key;
         final String messagePredicate = "my-message-" + key + "-";
 
@@ -185,7 +185,7 @@ public class ZeroQueueSizeTest extends BrokerTestBase {
         String key = "zeroQueueSizeSharedSubscription";
 
         // 1. Config
-        final String topicName = "persistent://prop/use/ns-abc/topic-" + key;
+        final String topicName = "persistent://tenant/ns-abc/topic-" + key;
         final String subscriptionName = "my-ex-subscription-" + key;
         final String messagePredicate = "my-message-" + key + "-";
 
@@ -226,7 +226,7 @@ public class ZeroQueueSizeTest extends BrokerTestBase {
         String key = "zeroQueueSizeFailoverSubscription";
 
         // 1. Config
-        final String topicName = "persistent://prop/use/ns-abc/topic-" + key;
+        final String topicName = "persistent://tenant/ns-abc/topic-" + key;
         final String subscriptionName = "my-ex-subscription-" + key;
         final String messagePredicate = "my-message-" + key + "-";
 
@@ -318,7 +318,7 @@ public class ZeroQueueSizeTest extends BrokerTestBase {
 
     @Test
     public void testZeroQueueSizeMessageRedelivery() throws PulsarClientException {
-        final String topic = "persistent://prop/ns-abc/testZeroQueueSizeMessageRedelivery";
+        final String topic = "persistent://tenant/ns-abc/testZeroQueueSizeMessageRedelivery";
         Consumer<Integer> consumer = pulsarClient.newConsumer(Schema.INT32)
             .topic(topic)
             .receiverQueueSize(0)
@@ -350,7 +350,7 @@ public class ZeroQueueSizeTest extends BrokerTestBase {
 
     @Test
     public void testZeroQueueSizeMessageRedeliveryForListener() throws Exception {
-        final String topic = "persistent://prop/ns-abc/testZeroQueueSizeMessageRedeliveryForListener";
+        final String topic = "persistent://tenant/ns-abc/testZeroQueueSizeMessageRedeliveryForListener";
         final int messages = 10;
         final CountDownLatch latch = new CountDownLatch(messages * 2);
         Set<Integer> receivedMessages = new HashSet<>();
@@ -388,7 +388,7 @@ public class ZeroQueueSizeTest extends BrokerTestBase {
     @Test
     public void testZeroQueueSizeMessageRedeliveryForAsyncReceive()
             throws PulsarClientException, ExecutionException, InterruptedException {
-        final String topic = "persistent://prop/ns-abc/testZeroQueueSizeMessageRedeliveryForAsyncReceive";
+        final String topic = "persistent://tenant/ns-abc/testZeroQueueSizeMessageRedeliveryForAsyncReceive";
         Consumer<Integer> consumer = pulsarClient.newConsumer(Schema.INT32)
             .topic(topic)
             .receiverQueueSize(0)
@@ -424,7 +424,7 @@ public class ZeroQueueSizeTest extends BrokerTestBase {
 
     @Test(timeOut = 30000)
     public void testPauseAndResume() throws Exception {
-        final String topicName = "persistent://prop/ns-abc/zero-queue-pause-and-resume";
+        final String topicName = "persistent://tenant/ns-abc/zero-queue-pause-and-resume";
         final String subName = "sub";
 
         AtomicReference<CountDownLatch> latch = new AtomicReference<>(new CountDownLatch(1));
@@ -460,7 +460,7 @@ public class ZeroQueueSizeTest extends BrokerTestBase {
 
     @Test(timeOut = 30000)
     public void testPauseAndResumeWithUnloading() throws Exception {
-        final String topicName = "persistent://prop/ns-abc/zero-queue-pause-and-resume-with-unloading";
+        final String topicName = "persistent://tenant/ns-abc/zero-queue-pause-and-resume-with-unloading";
         final String subName = "sub";
 
         AtomicReference<CountDownLatch> latch = new AtomicReference<>(new CountDownLatch(1));
@@ -499,7 +499,7 @@ public class ZeroQueueSizeTest extends BrokerTestBase {
 
     @Test(timeOut = 30000)
     public void testPauseAndResumeNoReconnection() throws Exception {
-        final String topicName = "persistent://prop/ns-abc/zero-queue-pause-and-resume-no-reconnection";
+        final String topicName = "persistent://tenant/ns-abc/zero-queue-pause-and-resume-no-reconnection";
         final String subName = "sub";
 
         final Object object = new Object();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/stats/client/PulsarBrokerStatsClientTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/stats/client/PulsarBrokerStatsClientTest.java
@@ -85,7 +85,7 @@ public class PulsarBrokerStatsClientTest extends ProducerConsumerBase {
             // Ok
         }
         try {
-            client.getBrokerResourceAvailability("prop/cluster/ns");
+            client.getBrokerResourceAvailability("tenant/ns");
         } catch (PulsarAdminException e) {
             // Ok
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/v1/V1ProxyAuthenticationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/v1/V1ProxyAuthenticationTest.java
@@ -115,7 +115,7 @@ public class V1ProxyAuthenticationTest extends V1ProducerConsumerBase {
     }
 
     private void socketTest() throws Exception {
-        final String topic = "prop/use/my-ns/my-topic1";
+        final String topic = "tenant/my-ns/my-topic1";
         final String consumerUri = "ws://localhost:" + proxyServer.getListenPortHTTP().get()
                 + "/ws/consumer/persistent/" + topic + "/my-sub";
         final String producerUri = "ws://localhost:" + proxyServer.getListenPortHTTP().get()
@@ -167,7 +167,7 @@ public class V1ProxyAuthenticationTest extends V1ProducerConsumerBase {
 
     @Test(timeOut = 10000)
     public void statsTest() throws Exception {
-        final String topic = "prop/use/my-ns/my-topic2";
+        final String topic = "tenant/my-ns/my-topic2";
         final String consumerUri = "ws://localhost:" + proxyServer.getListenPortHTTP().get()
                 + "/ws/consumer/persistent/" + topic + "/my-sub";
         final String producerUri = "ws://localhost:" + proxyServer.getListenPortHTTP().get()

--- a/pulsar-broker/src/test/resources/prometheus_metrics_sample.txt
+++ b/pulsar-broker/src/test/resources/prometheus_metrics_sample.txt
@@ -337,295 +337,295 @@ pulsar_storage_write_rate{cluster="use"} 0
 pulsar_storage_read_rate{cluster="use"} 0
 # TYPE pulsar_msg_backlog gauge
 pulsar_msg_backlog{cluster="use"} 0
-pulsar_subscriptions_count{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 1.0
-pulsar_producers_count{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 1.0
-pulsar_consumers_count{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 1.0
-pulsar_rate_in{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
-pulsar_rate_out{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
-pulsar_throughput_in{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
-pulsar_throughput_out{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
-pulsar_storage_size{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
-pulsar_msg_backlog{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
+pulsar_subscriptions_count{cluster="use",namespace="external-repl-tenant/io",topic="persistent://external-repl-tenant/io/my-topic1"} 1.0
+pulsar_producers_count{cluster="use",namespace="external-repl-tenant/io",topic="persistent://external-repl-tenant/io/my-topic1"} 1.0
+pulsar_consumers_count{cluster="use",namespace="external-repl-tenant/io",topic="persistent://external-repl-tenant/io/my-topic1"} 1.0
+pulsar_rate_in{cluster="use",namespace="external-repl-tenant/io",topic="persistent://external-repl-tenant/io/my-topic1"} 0.0
+pulsar_rate_out{cluster="use",namespace="external-repl-tenant/io",topic="persistent://external-repl-tenant/io/my-topic1"} 0.0
+pulsar_throughput_in{cluster="use",namespace="external-repl-tenant/io",topic="persistent://external-repl-tenant/io/my-topic1"} 0.0
+pulsar_throughput_out{cluster="use",namespace="external-repl-tenant/io",topic="persistent://external-repl-tenant/io/my-topic1"} 0.0
+pulsar_storage_size{cluster="use",namespace="external-repl-tenant/io",topic="persistent://external-repl-tenant/io/my-topic1"} 0.0
+pulsar_msg_backlog{cluster="use",namespace="external-repl-tenant/io",topic="persistent://external-repl-tenant/io/my-topic1"} 0.0
 # TYPE pulsar_storage_backlog_size gauge
-pulsar_storage_backlog_size{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
+pulsar_storage_backlog_size{cluster="use",namespace="external-repl-tenant/io",topic="persistent://external-repl-tenant/io/my-topic1"} 0.0
 # TYPE pulsar_storage_offloaded_size gauge
-pulsar_storage_offloaded_size{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
+pulsar_storage_offloaded_size{cluster="use",namespace="external-repl-tenant/io",topic="persistent://external-repl-tenant/io/my-topic1"} 0.0
 # TYPE pulsar_storage_backlog_quota_limit gauge
-pulsar_storage_backlog_quota_limit{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} -1073741824.0
+pulsar_storage_backlog_quota_limit{cluster="use",namespace="external-repl-tenant/io",topic="persistent://external-repl-tenant/io/my-topic1"} -1073741824.0
 # TYPE pulsar_storage_write_latency_le_0_5 gauge
-pulsar_storage_write_latency_le_0_5{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
+pulsar_storage_write_latency_le_0_5{cluster="use",namespace="external-repl-tenant/io",topic="persistent://external-repl-tenant/io/my-topic1"} 0.0
 # TYPE pulsar_storage_write_latency_le_1 gauge
-pulsar_storage_write_latency_le_1{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
+pulsar_storage_write_latency_le_1{cluster="use",namespace="external-repl-tenant/io",topic="persistent://external-repl-tenant/io/my-topic1"} 0.0
 # TYPE pulsar_storage_write_latency_le_5 gauge
-pulsar_storage_write_latency_le_5{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
+pulsar_storage_write_latency_le_5{cluster="use",namespace="external-repl-tenant/io",topic="persistent://external-repl-tenant/io/my-topic1"} 0.0
 # TYPE pulsar_storage_write_latency_le_10 gauge
-pulsar_storage_write_latency_le_10{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
+pulsar_storage_write_latency_le_10{cluster="use",namespace="external-repl-tenant/io",topic="persistent://external-repl-tenant/io/my-topic1"} 0.0
 # TYPE pulsar_storage_write_latency_le_20 gauge
-pulsar_storage_write_latency_le_20{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
+pulsar_storage_write_latency_le_20{cluster="use",namespace="external-repl-tenant/io",topic="persistent://external-repl-tenant/io/my-topic1"} 0.0
 # TYPE pulsar_storage_write_latency_le_50 gauge
-pulsar_storage_write_latency_le_50{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
+pulsar_storage_write_latency_le_50{cluster="use",namespace="external-repl-tenant/io",topic="persistent://external-repl-tenant/io/my-topic1"} 0.0
 # TYPE pulsar_storage_write_latency_le_100 gauge
-pulsar_storage_write_latency_le_100{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
+pulsar_storage_write_latency_le_100{cluster="use",namespace="external-repl-tenant/io",topic="persistent://external-repl-tenant/io/my-topic1"} 0.0
 # TYPE pulsar_storage_write_latency_le_200 gauge
-pulsar_storage_write_latency_le_200{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
+pulsar_storage_write_latency_le_200{cluster="use",namespace="external-repl-tenant/io",topic="persistent://external-repl-tenant/io/my-topic1"} 0.0
 # TYPE pulsar_storage_write_latency_le_1000 gauge
-pulsar_storage_write_latency_le_1000{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
+pulsar_storage_write_latency_le_1000{cluster="use",namespace="external-repl-tenant/io",topic="persistent://external-repl-tenant/io/my-topic1"} 0.0
 # TYPE pulsar_storage_write_latency_overflow gauge
-pulsar_storage_write_latency_overflow{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
+pulsar_storage_write_latency_overflow{cluster="use",namespace="external-repl-tenant/io",topic="persistent://external-repl-tenant/io/my-topic1"} 0.0
 # TYPE pulsar_storage_write_latency_count gauge
-pulsar_storage_write_latency_count{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
+pulsar_storage_write_latency_count{cluster="use",namespace="external-repl-tenant/io",topic="persistent://external-repl-tenant/io/my-topic1"} 0.0
 # TYPE pulsar_storage_write_latency_sum gauge
-pulsar_storage_write_latency_sum{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
+pulsar_storage_write_latency_sum{cluster="use",namespace="external-repl-tenant/io",topic="persistent://external-repl-tenant/io/my-topic1"} 0.0
 # TYPE pulsar_storage_ledger_write_latency_le_0_5 gauge
-pulsar_storage_ledger_write_latency_le_0_5{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
+pulsar_storage_ledger_write_latency_le_0_5{cluster="use",namespace="external-repl-tenant/io",topic="persistent://external-repl-tenant/io/my-topic1"} 0.0
 # TYPE pulsar_storage_ledger_write_latency_le_1 gauge
-pulsar_storage_ledger_write_latency_le_1{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
+pulsar_storage_ledger_write_latency_le_1{cluster="use",namespace="external-repl-tenant/io",topic="persistent://external-repl-tenant/io/my-topic1"} 0.0
 # TYPE pulsar_storage_ledger_write_latency_le_5 gauge
-pulsar_storage_ledger_write_latency_le_5{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
+pulsar_storage_ledger_write_latency_le_5{cluster="use",namespace="external-repl-tenant/io",topic="persistent://external-repl-tenant/io/my-topic1"} 0.0
 # TYPE pulsar_storage_ledger_write_latency_le_10 gauge
-pulsar_storage_ledger_write_latency_le_10{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
+pulsar_storage_ledger_write_latency_le_10{cluster="use",namespace="external-repl-tenant/io",topic="persistent://external-repl-tenant/io/my-topic1"} 0.0
 # TYPE pulsar_storage_ledger_write_latency_le_20 gauge
-pulsar_storage_ledger_write_latency_le_20{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
+pulsar_storage_ledger_write_latency_le_20{cluster="use",namespace="external-repl-tenant/io",topic="persistent://external-repl-tenant/io/my-topic1"} 0.0
 # TYPE pulsar_storage_ledger_write_latency_le_50 gauge
-pulsar_storage_ledger_write_latency_le_50{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
+pulsar_storage_ledger_write_latency_le_50{cluster="use",namespace="external-repl-tenant/io",topic="persistent://external-repl-tenant/io/my-topic1"} 0.0
 # TYPE pulsar_storage_ledger_write_latency_le_100 gauge
-pulsar_storage_ledger_write_latency_le_100{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
+pulsar_storage_ledger_write_latency_le_100{cluster="use",namespace="external-repl-tenant/io",topic="persistent://external-repl-tenant/io/my-topic1"} 0.0
 # TYPE pulsar_storage_ledger_write_latency_le_200 gauge
-pulsar_storage_ledger_write_latency_le_200{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
+pulsar_storage_ledger_write_latency_le_200{cluster="use",namespace="external-repl-tenant/io",topic="persistent://external-repl-tenant/io/my-topic1"} 0.0
 # TYPE pulsar_storage_ledger_write_latency_le_1000 gauge
-pulsar_storage_ledger_write_latency_le_1000{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
+pulsar_storage_ledger_write_latency_le_1000{cluster="use",namespace="external-repl-tenant/io",topic="persistent://external-repl-tenant/io/my-topic1"} 0.0
 # TYPE pulsar_storage_ledger_write_latency_overflow gauge
-pulsar_storage_ledger_write_latency_overflow{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
+pulsar_storage_ledger_write_latency_overflow{cluster="use",namespace="external-repl-tenant/io",topic="persistent://external-repl-tenant/io/my-topic1"} 0.0
 # TYPE pulsar_storage_ledger_write_latency_count gauge
-pulsar_storage_ledger_write_latency_count{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
+pulsar_storage_ledger_write_latency_count{cluster="use",namespace="external-repl-tenant/io",topic="persistent://external-repl-tenant/io/my-topic1"} 0.0
 # TYPE pulsar_storage_ledger_write_latency_sum gauge
-pulsar_storage_ledger_write_latency_sum{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
+pulsar_storage_ledger_write_latency_sum{cluster="use",namespace="external-repl-tenant/io",topic="persistent://external-repl-tenant/io/my-topic1"} 0.0
 # TYPE pulsar_entry_size_le_128 gauge
-pulsar_entry_size_le_128{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
+pulsar_entry_size_le_128{cluster="use",namespace="external-repl-tenant/io",topic="persistent://external-repl-tenant/io/my-topic1"} 0.0
 # TYPE pulsar_entry_size_le_512 gauge
-pulsar_entry_size_le_512{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
+pulsar_entry_size_le_512{cluster="use",namespace="external-repl-tenant/io",topic="persistent://external-repl-tenant/io/my-topic1"} 0.0
 # TYPE pulsar_entry_size_le_1_kb gauge
-pulsar_entry_size_le_1_kb{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
+pulsar_entry_size_le_1_kb{cluster="use",namespace="external-repl-tenant/io",topic="persistent://external-repl-tenant/io/my-topic1"} 0.0
 # TYPE pulsar_entry_size_le_2_kb gauge
-pulsar_entry_size_le_2_kb{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
+pulsar_entry_size_le_2_kb{cluster="use",namespace="external-repl-tenant/io",topic="persistent://external-repl-tenant/io/my-topic1"} 0.0
 # TYPE pulsar_entry_size_le_4_kb gauge
-pulsar_entry_size_le_4_kb{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
+pulsar_entry_size_le_4_kb{cluster="use",namespace="external-repl-tenant/io",topic="persistent://external-repl-tenant/io/my-topic1"} 0.0
 # TYPE pulsar_entry_size_le_16_kb gauge
-pulsar_entry_size_le_16_kb{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
+pulsar_entry_size_le_16_kb{cluster="use",namespace="external-repl-tenant/io",topic="persistent://external-repl-tenant/io/my-topic1"} 0.0
 # TYPE pulsar_entry_size_le_100_kb gauge
-pulsar_entry_size_le_100_kb{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
+pulsar_entry_size_le_100_kb{cluster="use",namespace="external-repl-tenant/io",topic="persistent://external-repl-tenant/io/my-topic1"} 0.0
 # TYPE pulsar_entry_size_le_1_mb gauge
-pulsar_entry_size_le_1_mb{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
+pulsar_entry_size_le_1_mb{cluster="use",namespace="external-repl-tenant/io",topic="persistent://external-repl-tenant/io/my-topic1"} 0.0
 # TYPE pulsar_entry_size_le_overflow gauge
-pulsar_entry_size_le_overflow{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
+pulsar_entry_size_le_overflow{cluster="use",namespace="external-repl-tenant/io",topic="persistent://external-repl-tenant/io/my-topic1"} 0.0
 # TYPE pulsar_entry_size_count gauge
-pulsar_entry_size_count{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
+pulsar_entry_size_count{cluster="use",namespace="external-repl-tenant/io",topic="persistent://external-repl-tenant/io/my-topic1"} 0.0
 # TYPE pulsar_entry_size_sum gauge
-pulsar_entry_size_sum{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
+pulsar_entry_size_sum{cluster="use",namespace="external-repl-tenant/io",topic="persistent://external-repl-tenant/io/my-topic1"} 0.0
 # TYPE pulsar_subscription_back_log gauge
-pulsar_subscription_back_log{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1",subscription="test-sub"} 0
+pulsar_subscription_back_log{cluster="use",namespace="external-repl-tenant/io",topic="persistent://external-repl-tenant/io/my-topic1",subscription="test-sub"} 0
 # TYPE pulsar_subscription_back_log_no_delayed gauge
-pulsar_subscription_back_log_no_delayed{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1",subscription="test-sub"} 0
+pulsar_subscription_back_log_no_delayed{cluster="use",namespace="external-repl-tenant/io",topic="persistent://external-repl-tenant/io/my-topic1",subscription="test-sub"} 0
 # TYPE pulsar_subscription_delayed gauge
-pulsar_subscription_delayed{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1",subscription="test-sub"} 0
+pulsar_subscription_delayed{cluster="use",namespace="external-repl-tenant/io",topic="persistent://external-repl-tenant/io/my-topic1",subscription="test-sub"} 0
 # TYPE pulsar_subscription_msg_rate_redeliver gauge
-pulsar_subscription_msg_rate_redeliver{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1",subscription="test-sub"} 0.0
+pulsar_subscription_msg_rate_redeliver{cluster="use",namespace="external-repl-tenant/io",topic="persistent://external-repl-tenant/io/my-topic1",subscription="test-sub"} 0.0
 # TYPE pulsar_subscription_unacked_messages gauge
-pulsar_subscription_unacked_messages{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1",subscription="test-sub"} 0
+pulsar_subscription_unacked_messages{cluster="use",namespace="external-repl-tenant/io",topic="persistent://external-repl-tenant/io/my-topic1",subscription="test-sub"} 0
 # TYPE pulsar_subscription_blocked_on_unacked_messages gauge
-pulsar_subscription_blocked_on_unacked_messages{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1",subscription="test-sub"} 0
+pulsar_subscription_blocked_on_unacked_messages{cluster="use",namespace="external-repl-tenant/io",topic="persistent://external-repl-tenant/io/my-topic1",subscription="test-sub"} 0
 # TYPE pulsar_subscription_msg_rate_out gauge
-pulsar_subscription_msg_rate_out{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1",subscription="test-sub"} 0.0
+pulsar_subscription_msg_rate_out{cluster="use",namespace="external-repl-tenant/io",topic="persistent://external-repl-tenant/io/my-topic1",subscription="test-sub"} 0.0
 # TYPE pulsar_subscription_msg_throughput_out gauge
-pulsar_subscription_msg_throughput_out{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1",subscription="test-sub"} 0.0
+pulsar_subscription_msg_throughput_out{cluster="use",namespace="external-repl-tenant/io",topic="persistent://external-repl-tenant/io/my-topic1",subscription="test-sub"} 0.0
 # TYPE pulsar_out_bytes_total gauge
-pulsar_out_bytes_total{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1",subscription="test-sub"} 0
+pulsar_out_bytes_total{cluster="use",namespace="external-repl-tenant/io",topic="persistent://external-repl-tenant/io/my-topic1",subscription="test-sub"} 0
 # TYPE pulsar_out_messages_total gauge
-pulsar_out_messages_total{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1",subscription="test-sub"} 0
+pulsar_out_messages_total{cluster="use",namespace="external-repl-tenant/io",topic="persistent://external-repl-tenant/io/my-topic1",subscription="test-sub"} 0
 # TYPE pulsar_subscription_last_expire_timestamp gauge
-pulsar_subscription_last_expire_timestamp{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1",subscription="test-sub"} 0
+pulsar_subscription_last_expire_timestamp{cluster="use",namespace="external-repl-tenant/io",topic="persistent://external-repl-tenant/io/my-topic1",subscription="test-sub"} 0
 # TYPE pulsar_subscription_last_acked_timestamp gauge
-pulsar_subscription_last_acked_timestamp{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1",subscription="test-sub"} 0
+pulsar_subscription_last_acked_timestamp{cluster="use",namespace="external-repl-tenant/io",topic="persistent://external-repl-tenant/io/my-topic1",subscription="test-sub"} 0
 # TYPE pulsar_subscription_last_consumed_flow_timestamp gauge
-pulsar_subscription_last_consumed_flow_timestamp{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1",subscription="test-sub"} 1617950344921
+pulsar_subscription_last_consumed_flow_timestamp{cluster="use",namespace="external-repl-tenant/io",topic="persistent://external-repl-tenant/io/my-topic1",subscription="test-sub"} 1617950344921
 # TYPE pulsar_subscription_last_consumed_timestamp gauge
-pulsar_subscription_last_consumed_timestamp{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1",subscription="test-sub"} 0
+pulsar_subscription_last_consumed_timestamp{cluster="use",namespace="external-repl-tenant/io",topic="persistent://external-repl-tenant/io/my-topic1",subscription="test-sub"} 0
 # TYPE pulsar_subscription_last_mark_delete_advanced_timestamp gauge
-pulsar_subscription_last_mark_delete_advanced_timestamp{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1",subscription="test-sub"} 0
+pulsar_subscription_last_mark_delete_advanced_timestamp{cluster="use",namespace="external-repl-tenant/io",topic="persistent://external-repl-tenant/io/my-topic1",subscription="test-sub"} 0
 # TYPE pulsar_subscription_msg_rate_expired gauge
-pulsar_subscription_msg_rate_expired{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1",subscription="test-sub"} 0.0
+pulsar_subscription_msg_rate_expired{cluster="use",namespace="external-repl-tenant/io",topic="persistent://external-repl-tenant/io/my-topic1",subscription="test-sub"} 0.0
 # TYPE pulsar_subscription_total_msg_expired gauge
-pulsar_subscription_total_msg_expired{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1",subscription="test-sub"} 0
+pulsar_subscription_total_msg_expired{cluster="use",namespace="external-repl-tenant/io",topic="persistent://external-repl-tenant/io/my-topic1",subscription="test-sub"} 0
 # TYPE pulsar_in_bytes_total gauge
-pulsar_in_bytes_total{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
+pulsar_in_bytes_total{cluster="use",namespace="external-repl-tenant/io",topic="persistent://external-repl-tenant/io/my-topic1"} 0.0
 # TYPE pulsar_in_messages_total gauge
-pulsar_in_messages_total{cluster="use",namespace="external-repl-prop/io",topic="persistent://external-repl-prop/io/my-topic1"} 0.0
-pulsar_topics_count{cluster="use",namespace="external-repl-prop/io"} 1
-pulsar_subscriptions_count{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
-pulsar_producers_count{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 1.0
-pulsar_consumers_count{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
-pulsar_rate_in{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
-pulsar_rate_out{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
-pulsar_throughput_in{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
-pulsar_throughput_out{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
-pulsar_storage_size{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 1728.0
-pulsar_msg_backlog{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
-pulsar_storage_backlog_size{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
-pulsar_storage_offloaded_size{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
-pulsar_storage_backlog_quota_limit{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} -1073741824.0
-pulsar_storage_write_latency_le_0_5{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
-pulsar_storage_write_latency_le_1{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
-pulsar_storage_write_latency_le_5{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
-pulsar_storage_write_latency_le_10{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
-pulsar_storage_write_latency_le_20{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
-pulsar_storage_write_latency_le_50{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
-pulsar_storage_write_latency_le_100{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
-pulsar_storage_write_latency_le_200{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
-pulsar_storage_write_latency_le_1000{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
-pulsar_storage_write_latency_overflow{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
-pulsar_storage_write_latency_count{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
-pulsar_storage_write_latency_sum{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
-pulsar_storage_ledger_write_latency_le_0_5{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
-pulsar_storage_ledger_write_latency_le_1{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
-pulsar_storage_ledger_write_latency_le_5{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
-pulsar_storage_ledger_write_latency_le_10{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
-pulsar_storage_ledger_write_latency_le_20{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
-pulsar_storage_ledger_write_latency_le_50{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
-pulsar_storage_ledger_write_latency_le_100{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
-pulsar_storage_ledger_write_latency_le_200{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
-pulsar_storage_ledger_write_latency_le_1000{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
-pulsar_storage_ledger_write_latency_overflow{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
-pulsar_storage_ledger_write_latency_count{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
-pulsar_storage_ledger_write_latency_sum{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
-pulsar_entry_size_le_128{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
-pulsar_entry_size_le_512{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
-pulsar_entry_size_le_1_kb{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
-pulsar_entry_size_le_2_kb{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
-pulsar_entry_size_le_4_kb{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
-pulsar_entry_size_le_16_kb{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
-pulsar_entry_size_le_100_kb{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
-pulsar_entry_size_le_1_mb{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
-pulsar_entry_size_le_overflow{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
-pulsar_entry_size_count{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
-pulsar_entry_size_sum{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 0.0
-pulsar_in_bytes_total{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 864.0
-pulsar_in_messages_total{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/metadata"} 2.0
-pulsar_subscriptions_count{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
-pulsar_producers_count{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 1.0
-pulsar_consumers_count{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
-pulsar_rate_in{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
-pulsar_rate_out{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
-pulsar_throughput_in{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
-pulsar_throughput_out{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
-pulsar_storage_size{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 1748.0
-pulsar_msg_backlog{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
-pulsar_storage_backlog_size{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
-pulsar_storage_offloaded_size{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
-pulsar_storage_backlog_quota_limit{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} -1073741824.0
-pulsar_storage_write_latency_le_0_5{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
-pulsar_storage_write_latency_le_1{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
-pulsar_storage_write_latency_le_5{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
-pulsar_storage_write_latency_le_10{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
-pulsar_storage_write_latency_le_20{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
-pulsar_storage_write_latency_le_50{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
-pulsar_storage_write_latency_le_100{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
-pulsar_storage_write_latency_le_200{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
-pulsar_storage_write_latency_le_1000{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
-pulsar_storage_write_latency_overflow{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
-pulsar_storage_write_latency_count{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
-pulsar_storage_write_latency_sum{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
-pulsar_storage_ledger_write_latency_le_0_5{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
-pulsar_storage_ledger_write_latency_le_1{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
-pulsar_storage_ledger_write_latency_le_5{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
-pulsar_storage_ledger_write_latency_le_10{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
-pulsar_storage_ledger_write_latency_le_20{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
-pulsar_storage_ledger_write_latency_le_50{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
-pulsar_storage_ledger_write_latency_le_100{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
-pulsar_storage_ledger_write_latency_le_200{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
-pulsar_storage_ledger_write_latency_le_1000{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
-pulsar_storage_ledger_write_latency_overflow{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
-pulsar_storage_ledger_write_latency_count{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
-pulsar_storage_ledger_write_latency_sum{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
-pulsar_entry_size_le_128{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
-pulsar_entry_size_le_512{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
-pulsar_entry_size_le_1_kb{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
-pulsar_entry_size_le_2_kb{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
-pulsar_entry_size_le_4_kb{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
-pulsar_entry_size_le_16_kb{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
-pulsar_entry_size_le_100_kb{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
-pulsar_entry_size_le_1_mb{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
-pulsar_entry_size_le_overflow{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
-pulsar_entry_size_count{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
-pulsar_entry_size_sum{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 0.0
-pulsar_in_bytes_total{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 874.0
-pulsar_in_messages_total{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/assignment"} 2.0
-pulsar_subscriptions_count{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 1.0
-pulsar_producers_count{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
-pulsar_consumers_count{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 1.0
-pulsar_rate_in{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
-pulsar_rate_out{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
-pulsar_throughput_in{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
-pulsar_throughput_out{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
-pulsar_storage_size{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
-pulsar_msg_backlog{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
-pulsar_storage_backlog_size{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
-pulsar_storage_offloaded_size{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
-pulsar_storage_backlog_quota_limit{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} -1073741824.0
-pulsar_storage_write_latency_le_0_5{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
-pulsar_storage_write_latency_le_1{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
-pulsar_storage_write_latency_le_5{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
-pulsar_storage_write_latency_le_10{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
-pulsar_storage_write_latency_le_20{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
-pulsar_storage_write_latency_le_50{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
-pulsar_storage_write_latency_le_100{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
-pulsar_storage_write_latency_le_200{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
-pulsar_storage_write_latency_le_1000{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
-pulsar_storage_write_latency_overflow{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
-pulsar_storage_write_latency_count{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
-pulsar_storage_write_latency_sum{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
-pulsar_storage_ledger_write_latency_le_0_5{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
-pulsar_storage_ledger_write_latency_le_1{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
-pulsar_storage_ledger_write_latency_le_5{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
-pulsar_storage_ledger_write_latency_le_10{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
-pulsar_storage_ledger_write_latency_le_20{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
-pulsar_storage_ledger_write_latency_le_50{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
-pulsar_storage_ledger_write_latency_le_100{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
-pulsar_storage_ledger_write_latency_le_200{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
-pulsar_storage_ledger_write_latency_le_1000{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
-pulsar_storage_ledger_write_latency_overflow{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
-pulsar_storage_ledger_write_latency_count{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
-pulsar_storage_ledger_write_latency_sum{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
-pulsar_entry_size_le_128{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
-pulsar_entry_size_le_512{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
-pulsar_entry_size_le_1_kb{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
-pulsar_entry_size_le_2_kb{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
-pulsar_entry_size_le_4_kb{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
-pulsar_entry_size_le_16_kb{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
-pulsar_entry_size_le_100_kb{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
-pulsar_entry_size_le_1_mb{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
-pulsar_entry_size_le_overflow{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
-pulsar_entry_size_count{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
-pulsar_entry_size_sum{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
-pulsar_subscription_back_log{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate",subscription="participants"} 0
-pulsar_subscription_back_log_no_delayed{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate",subscription="participants"} 0
-pulsar_subscription_delayed{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate",subscription="participants"} 0
-pulsar_subscription_msg_rate_redeliver{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate",subscription="participants"} 0.0
-pulsar_subscription_unacked_messages{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate",subscription="participants"} 0
-pulsar_subscription_blocked_on_unacked_messages{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate",subscription="participants"} 0
-pulsar_subscription_msg_rate_out{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate",subscription="participants"} 0.0
-pulsar_subscription_msg_throughput_out{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate",subscription="participants"} 0.0
-pulsar_out_bytes_total{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate",subscription="participants"} 0
-pulsar_out_messages_total{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate",subscription="participants"} 0
-pulsar_subscription_last_expire_timestamp{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate",subscription="participants"} 0
-pulsar_subscription_last_acked_timestamp{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate",subscription="participants"} 0
-pulsar_subscription_last_consumed_flow_timestamp{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate",subscription="participants"} 1617950342238
-pulsar_subscription_last_consumed_timestamp{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate",subscription="participants"} 0
-pulsar_subscription_last_mark_delete_advanced_timestamp{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate",subscription="participants"} 0
-pulsar_subscription_msg_rate_expired{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate",subscription="participants"} 0.0
-pulsar_subscription_total_msg_expired{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate",subscription="participants"} 0
-pulsar_in_bytes_total{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
-pulsar_in_messages_total{cluster="use",namespace="external-repl-prop/pulsar-function-admin",topic="persistent://external-repl-prop/pulsar-function-admin/coordinate"} 0.0
-pulsar_topics_count{cluster="use",namespace="external-repl-prop/pulsar-function-admin"} 3
+pulsar_in_messages_total{cluster="use",namespace="external-repl-tenant/io",topic="persistent://external-repl-tenant/io/my-topic1"} 0.0
+pulsar_topics_count{cluster="use",namespace="external-repl-tenant/io"} 1
+pulsar_subscriptions_count{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/metadata"} 0.0
+pulsar_producers_count{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/metadata"} 1.0
+pulsar_consumers_count{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/metadata"} 0.0
+pulsar_rate_in{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/metadata"} 0.0
+pulsar_rate_out{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/metadata"} 0.0
+pulsar_throughput_in{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/metadata"} 0.0
+pulsar_throughput_out{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/metadata"} 0.0
+pulsar_storage_size{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/metadata"} 1728.0
+pulsar_msg_backlog{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/metadata"} 0.0
+pulsar_storage_backlog_size{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/metadata"} 0.0
+pulsar_storage_offloaded_size{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/metadata"} 0.0
+pulsar_storage_backlog_quota_limit{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/metadata"} -1073741824.0
+pulsar_storage_write_latency_le_0_5{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/metadata"} 0.0
+pulsar_storage_write_latency_le_1{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/metadata"} 0.0
+pulsar_storage_write_latency_le_5{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/metadata"} 0.0
+pulsar_storage_write_latency_le_10{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/metadata"} 0.0
+pulsar_storage_write_latency_le_20{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/metadata"} 0.0
+pulsar_storage_write_latency_le_50{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/metadata"} 0.0
+pulsar_storage_write_latency_le_100{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/metadata"} 0.0
+pulsar_storage_write_latency_le_200{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/metadata"} 0.0
+pulsar_storage_write_latency_le_1000{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/metadata"} 0.0
+pulsar_storage_write_latency_overflow{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/metadata"} 0.0
+pulsar_storage_write_latency_count{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/metadata"} 0.0
+pulsar_storage_write_latency_sum{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/metadata"} 0.0
+pulsar_storage_ledger_write_latency_le_0_5{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/metadata"} 0.0
+pulsar_storage_ledger_write_latency_le_1{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/metadata"} 0.0
+pulsar_storage_ledger_write_latency_le_5{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/metadata"} 0.0
+pulsar_storage_ledger_write_latency_le_10{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/metadata"} 0.0
+pulsar_storage_ledger_write_latency_le_20{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/metadata"} 0.0
+pulsar_storage_ledger_write_latency_le_50{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/metadata"} 0.0
+pulsar_storage_ledger_write_latency_le_100{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/metadata"} 0.0
+pulsar_storage_ledger_write_latency_le_200{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/metadata"} 0.0
+pulsar_storage_ledger_write_latency_le_1000{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/metadata"} 0.0
+pulsar_storage_ledger_write_latency_overflow{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/metadata"} 0.0
+pulsar_storage_ledger_write_latency_count{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/metadata"} 0.0
+pulsar_storage_ledger_write_latency_sum{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/metadata"} 0.0
+pulsar_entry_size_le_128{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/metadata"} 0.0
+pulsar_entry_size_le_512{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/metadata"} 0.0
+pulsar_entry_size_le_1_kb{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/metadata"} 0.0
+pulsar_entry_size_le_2_kb{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/metadata"} 0.0
+pulsar_entry_size_le_4_kb{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/metadata"} 0.0
+pulsar_entry_size_le_16_kb{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/metadata"} 0.0
+pulsar_entry_size_le_100_kb{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/metadata"} 0.0
+pulsar_entry_size_le_1_mb{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/metadata"} 0.0
+pulsar_entry_size_le_overflow{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/metadata"} 0.0
+pulsar_entry_size_count{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/metadata"} 0.0
+pulsar_entry_size_sum{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/metadata"} 0.0
+pulsar_in_bytes_total{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/metadata"} 864.0
+pulsar_in_messages_total{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/metadata"} 2.0
+pulsar_subscriptions_count{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/assignment"} 0.0
+pulsar_producers_count{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/assignment"} 1.0
+pulsar_consumers_count{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/assignment"} 0.0
+pulsar_rate_in{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/assignment"} 0.0
+pulsar_rate_out{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/assignment"} 0.0
+pulsar_throughput_in{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/assignment"} 0.0
+pulsar_throughput_out{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/assignment"} 0.0
+pulsar_storage_size{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/assignment"} 1748.0
+pulsar_msg_backlog{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/assignment"} 0.0
+pulsar_storage_backlog_size{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/assignment"} 0.0
+pulsar_storage_offloaded_size{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/assignment"} 0.0
+pulsar_storage_backlog_quota_limit{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/assignment"} -1073741824.0
+pulsar_storage_write_latency_le_0_5{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/assignment"} 0.0
+pulsar_storage_write_latency_le_1{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/assignment"} 0.0
+pulsar_storage_write_latency_le_5{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/assignment"} 0.0
+pulsar_storage_write_latency_le_10{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/assignment"} 0.0
+pulsar_storage_write_latency_le_20{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/assignment"} 0.0
+pulsar_storage_write_latency_le_50{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/assignment"} 0.0
+pulsar_storage_write_latency_le_100{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/assignment"} 0.0
+pulsar_storage_write_latency_le_200{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/assignment"} 0.0
+pulsar_storage_write_latency_le_1000{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/assignment"} 0.0
+pulsar_storage_write_latency_overflow{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/assignment"} 0.0
+pulsar_storage_write_latency_count{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/assignment"} 0.0
+pulsar_storage_write_latency_sum{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/assignment"} 0.0
+pulsar_storage_ledger_write_latency_le_0_5{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/assignment"} 0.0
+pulsar_storage_ledger_write_latency_le_1{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/assignment"} 0.0
+pulsar_storage_ledger_write_latency_le_5{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/assignment"} 0.0
+pulsar_storage_ledger_write_latency_le_10{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/assignment"} 0.0
+pulsar_storage_ledger_write_latency_le_20{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/assignment"} 0.0
+pulsar_storage_ledger_write_latency_le_50{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/assignment"} 0.0
+pulsar_storage_ledger_write_latency_le_100{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/assignment"} 0.0
+pulsar_storage_ledger_write_latency_le_200{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/assignment"} 0.0
+pulsar_storage_ledger_write_latency_le_1000{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/assignment"} 0.0
+pulsar_storage_ledger_write_latency_overflow{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/assignment"} 0.0
+pulsar_storage_ledger_write_latency_count{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/assignment"} 0.0
+pulsar_storage_ledger_write_latency_sum{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/assignment"} 0.0
+pulsar_entry_size_le_128{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/assignment"} 0.0
+pulsar_entry_size_le_512{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/assignment"} 0.0
+pulsar_entry_size_le_1_kb{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/assignment"} 0.0
+pulsar_entry_size_le_2_kb{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/assignment"} 0.0
+pulsar_entry_size_le_4_kb{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/assignment"} 0.0
+pulsar_entry_size_le_16_kb{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/assignment"} 0.0
+pulsar_entry_size_le_100_kb{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/assignment"} 0.0
+pulsar_entry_size_le_1_mb{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/assignment"} 0.0
+pulsar_entry_size_le_overflow{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/assignment"} 0.0
+pulsar_entry_size_count{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/assignment"} 0.0
+pulsar_entry_size_sum{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/assignment"} 0.0
+pulsar_in_bytes_total{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/assignment"} 874.0
+pulsar_in_messages_total{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/assignment"} 2.0
+pulsar_subscriptions_count{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/coordinate"} 1.0
+pulsar_producers_count{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/coordinate"} 0.0
+pulsar_consumers_count{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/coordinate"} 1.0
+pulsar_rate_in{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/coordinate"} 0.0
+pulsar_rate_out{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/coordinate"} 0.0
+pulsar_throughput_in{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/coordinate"} 0.0
+pulsar_throughput_out{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/coordinate"} 0.0
+pulsar_storage_size{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/coordinate"} 0.0
+pulsar_msg_backlog{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/coordinate"} 0.0
+pulsar_storage_backlog_size{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/coordinate"} 0.0
+pulsar_storage_offloaded_size{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/coordinate"} 0.0
+pulsar_storage_backlog_quota_limit{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/coordinate"} -1073741824.0
+pulsar_storage_write_latency_le_0_5{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/coordinate"} 0.0
+pulsar_storage_write_latency_le_1{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/coordinate"} 0.0
+pulsar_storage_write_latency_le_5{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/coordinate"} 0.0
+pulsar_storage_write_latency_le_10{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/coordinate"} 0.0
+pulsar_storage_write_latency_le_20{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/coordinate"} 0.0
+pulsar_storage_write_latency_le_50{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/coordinate"} 0.0
+pulsar_storage_write_latency_le_100{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/coordinate"} 0.0
+pulsar_storage_write_latency_le_200{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/coordinate"} 0.0
+pulsar_storage_write_latency_le_1000{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/coordinate"} 0.0
+pulsar_storage_write_latency_overflow{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/coordinate"} 0.0
+pulsar_storage_write_latency_count{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/coordinate"} 0.0
+pulsar_storage_write_latency_sum{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/coordinate"} 0.0
+pulsar_storage_ledger_write_latency_le_0_5{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/coordinate"} 0.0
+pulsar_storage_ledger_write_latency_le_1{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/coordinate"} 0.0
+pulsar_storage_ledger_write_latency_le_5{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/coordinate"} 0.0
+pulsar_storage_ledger_write_latency_le_10{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/coordinate"} 0.0
+pulsar_storage_ledger_write_latency_le_20{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/coordinate"} 0.0
+pulsar_storage_ledger_write_latency_le_50{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/coordinate"} 0.0
+pulsar_storage_ledger_write_latency_le_100{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/coordinate"} 0.0
+pulsar_storage_ledger_write_latency_le_200{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/coordinate"} 0.0
+pulsar_storage_ledger_write_latency_le_1000{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/coordinate"} 0.0
+pulsar_storage_ledger_write_latency_overflow{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/coordinate"} 0.0
+pulsar_storage_ledger_write_latency_count{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/coordinate"} 0.0
+pulsar_storage_ledger_write_latency_sum{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/coordinate"} 0.0
+pulsar_entry_size_le_128{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/coordinate"} 0.0
+pulsar_entry_size_le_512{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/coordinate"} 0.0
+pulsar_entry_size_le_1_kb{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/coordinate"} 0.0
+pulsar_entry_size_le_2_kb{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/coordinate"} 0.0
+pulsar_entry_size_le_4_kb{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/coordinate"} 0.0
+pulsar_entry_size_le_16_kb{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/coordinate"} 0.0
+pulsar_entry_size_le_100_kb{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/coordinate"} 0.0
+pulsar_entry_size_le_1_mb{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/coordinate"} 0.0
+pulsar_entry_size_le_overflow{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/coordinate"} 0.0
+pulsar_entry_size_count{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/coordinate"} 0.0
+pulsar_entry_size_sum{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/coordinate"} 0.0
+pulsar_subscription_back_log{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/coordinate",subscription="participants"} 0
+pulsar_subscription_back_log_no_delayed{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/coordinate",subscription="participants"} 0
+pulsar_subscription_delayed{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/coordinate",subscription="participants"} 0
+pulsar_subscription_msg_rate_redeliver{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/coordinate",subscription="participants"} 0.0
+pulsar_subscription_unacked_messages{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/coordinate",subscription="participants"} 0
+pulsar_subscription_blocked_on_unacked_messages{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/coordinate",subscription="participants"} 0
+pulsar_subscription_msg_rate_out{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/coordinate",subscription="participants"} 0.0
+pulsar_subscription_msg_throughput_out{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/coordinate",subscription="participants"} 0.0
+pulsar_out_bytes_total{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/coordinate",subscription="participants"} 0
+pulsar_out_messages_total{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/coordinate",subscription="participants"} 0
+pulsar_subscription_last_expire_timestamp{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/coordinate",subscription="participants"} 0
+pulsar_subscription_last_acked_timestamp{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/coordinate",subscription="participants"} 0
+pulsar_subscription_last_consumed_flow_timestamp{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/coordinate",subscription="participants"} 1617950342238
+pulsar_subscription_last_consumed_timestamp{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/coordinate",subscription="participants"} 0
+pulsar_subscription_last_mark_delete_advanced_timestamp{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/coordinate",subscription="participants"} 0
+pulsar_subscription_msg_rate_expired{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/coordinate",subscription="participants"} 0.0
+pulsar_subscription_total_msg_expired{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/coordinate",subscription="participants"} 0
+pulsar_in_bytes_total{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/coordinate"} 0.0
+pulsar_in_messages_total{cluster="use",namespace="external-repl-tenant/pulsar-function-admin",topic="persistent://external-repl-tenant/pulsar-function-admin/coordinate"} 0.0
+pulsar_topics_count{cluster="use",namespace="external-repl-tenant/pulsar-function-admin"} 3
 pulsar_function_worker_schedule_execution_time_total_ms{cluster="use",quantile="0.5",} 39.596969
 pulsar_function_worker_schedule_execution_time_total_ms{cluster="use",quantile="0.9",} 84.478748
 pulsar_function_worker_schedule_execution_time_total_ms{cluster="use",quantile="1.0",} 125.453621
@@ -662,27 +662,27 @@ pulsar_function_worker_rebalance_execution_time_total_ms_sum{cluster="use",} 0.0
 pulsar_function_worker_total_function_count{cluster="use",} 1
 pulsar_function_worker_total_expected_instance_count{cluster="use",} 1
 pulsar_function_worker_is_leader{cluster="use",} 1
-pulsar_function_last_invocation{tenant="external-repl-prop",namespace="external-repl-prop/io",name="PulsarSink-test",instance_id="0",cluster="use",fqfn="external-repl-prop/io/PulsarSink-test",} 0.0
-pulsar_function_processed_successfully_1min_total{tenant="external-repl-prop",namespace="external-repl-prop/io",name="PulsarSink-test",instance_id="0",cluster="use",fqfn="external-repl-prop/io/PulsarSink-test",} 0.0
-pulsar_function_received_1min_total{tenant="external-repl-prop",namespace="external-repl-prop/io",name="PulsarSink-test",instance_id="0",cluster="use",fqfn="external-repl-prop/io/PulsarSink-test",} 0.0
-pulsar_function_user_exceptions_total{tenant="external-repl-prop",namespace="external-repl-prop/io",name="PulsarSink-test",instance_id="0",cluster="use",fqfn="external-repl-prop/io/PulsarSink-test",} 0.0
-pulsar_function_process_latency_ms_1min{tenant="external-repl-prop",namespace="external-repl-prop/io",name="PulsarSink-test",instance_id="0",cluster="use",fqfn="external-repl-prop/io/PulsarSink-test",quantile="0.5",} NaN
-pulsar_function_process_latency_ms_1min{tenant="external-repl-prop",namespace="external-repl-prop/io",name="PulsarSink-test",instance_id="0",cluster="use",fqfn="external-repl-prop/io/PulsarSink-test",quantile="0.9",} NaN
-pulsar_function_process_latency_ms_1min{tenant="external-repl-prop",namespace="external-repl-prop/io",name="PulsarSink-test",instance_id="0",cluster="use",fqfn="external-repl-prop/io/PulsarSink-test",quantile="0.99",} NaN
-pulsar_function_process_latency_ms_1min{tenant="external-repl-prop",namespace="external-repl-prop/io",name="PulsarSink-test",instance_id="0",cluster="use",fqfn="external-repl-prop/io/PulsarSink-test",quantile="0.999",} NaN
-pulsar_function_process_latency_ms_1min_count{tenant="external-repl-prop",namespace="external-repl-prop/io",name="PulsarSink-test",instance_id="0",cluster="use",fqfn="external-repl-prop/io/PulsarSink-test",} 0.0
-pulsar_function_process_latency_ms_1min_sum{tenant="external-repl-prop",namespace="external-repl-prop/io",name="PulsarSink-test",instance_id="0",cluster="use",fqfn="external-repl-prop/io/PulsarSink-test",} 0.0
-pulsar_function_processed_successfully_total{tenant="external-repl-prop",namespace="external-repl-prop/io",name="PulsarSink-test",instance_id="0",cluster="use",fqfn="external-repl-prop/io/PulsarSink-test",} 0.0
-pulsar_function_received_total{tenant="external-repl-prop",namespace="external-repl-prop/io",name="PulsarSink-test",instance_id="0",cluster="use",fqfn="external-repl-prop/io/PulsarSink-test",} 0.0
-pulsar_function_system_exceptions_total{tenant="external-repl-prop",namespace="external-repl-prop/io",name="PulsarSink-test",instance_id="0",cluster="use",fqfn="external-repl-prop/io/PulsarSink-test",} 0.0
-pulsar_function_process_latency_ms{tenant="external-repl-prop",namespace="external-repl-prop/io",name="PulsarSink-test",instance_id="0",cluster="use",fqfn="external-repl-prop/io/PulsarSink-test",quantile="0.5",} NaN
-pulsar_function_process_latency_ms{tenant="external-repl-prop",namespace="external-repl-prop/io",name="PulsarSink-test",instance_id="0",cluster="use",fqfn="external-repl-prop/io/PulsarSink-test",quantile="0.9",} NaN
-pulsar_function_process_latency_ms{tenant="external-repl-prop",namespace="external-repl-prop/io",name="PulsarSink-test",instance_id="0",cluster="use",fqfn="external-repl-prop/io/PulsarSink-test",quantile="0.99",} NaN
-pulsar_function_process_latency_ms{tenant="external-repl-prop",namespace="external-repl-prop/io",name="PulsarSink-test",instance_id="0",cluster="use",fqfn="external-repl-prop/io/PulsarSink-test",quantile="0.999",} NaN
-pulsar_function_process_latency_ms_count{tenant="external-repl-prop",namespace="external-repl-prop/io",name="PulsarSink-test",instance_id="0",cluster="use",fqfn="external-repl-prop/io/PulsarSink-test",} 0.0
-pulsar_function_process_latency_ms_sum{tenant="external-repl-prop",namespace="external-repl-prop/io",name="PulsarSink-test",instance_id="0",cluster="use",fqfn="external-repl-prop/io/PulsarSink-test",} 0.0
-pulsar_function_system_exceptions_1min_total{tenant="external-repl-prop",namespace="external-repl-prop/io",name="PulsarSink-test",instance_id="0",cluster="use",fqfn="external-repl-prop/io/PulsarSink-test",} 0.0
-pulsar_function_user_exceptions_1min_total{tenant="external-repl-prop",namespace="external-repl-prop/io",name="PulsarSink-test",instance_id="0",cluster="use",fqfn="external-repl-prop/io/PulsarSink-test",} 0.0
+pulsar_function_last_invocation{tenant="external-repl-prop",namespace="external-repl-tenant/io",name="PulsarSink-test",instance_id="0",cluster="use",fqfn="external-repl-tenant/io/PulsarSink-test",} 0.0
+pulsar_function_processed_successfully_1min_total{tenant="external-repl-prop",namespace="external-repl-tenant/io",name="PulsarSink-test",instance_id="0",cluster="use",fqfn="external-repl-tenant/io/PulsarSink-test",} 0.0
+pulsar_function_received_1min_total{tenant="external-repl-prop",namespace="external-repl-tenant/io",name="PulsarSink-test",instance_id="0",cluster="use",fqfn="external-repl-tenant/io/PulsarSink-test",} 0.0
+pulsar_function_user_exceptions_total{tenant="external-repl-prop",namespace="external-repl-tenant/io",name="PulsarSink-test",instance_id="0",cluster="use",fqfn="external-repl-tenant/io/PulsarSink-test",} 0.0
+pulsar_function_process_latency_ms_1min{tenant="external-repl-prop",namespace="external-repl-tenant/io",name="PulsarSink-test",instance_id="0",cluster="use",fqfn="external-repl-tenant/io/PulsarSink-test",quantile="0.5",} NaN
+pulsar_function_process_latency_ms_1min{tenant="external-repl-prop",namespace="external-repl-tenant/io",name="PulsarSink-test",instance_id="0",cluster="use",fqfn="external-repl-tenant/io/PulsarSink-test",quantile="0.9",} NaN
+pulsar_function_process_latency_ms_1min{tenant="external-repl-prop",namespace="external-repl-tenant/io",name="PulsarSink-test",instance_id="0",cluster="use",fqfn="external-repl-tenant/io/PulsarSink-test",quantile="0.99",} NaN
+pulsar_function_process_latency_ms_1min{tenant="external-repl-prop",namespace="external-repl-tenant/io",name="PulsarSink-test",instance_id="0",cluster="use",fqfn="external-repl-tenant/io/PulsarSink-test",quantile="0.999",} NaN
+pulsar_function_process_latency_ms_1min_count{tenant="external-repl-prop",namespace="external-repl-tenant/io",name="PulsarSink-test",instance_id="0",cluster="use",fqfn="external-repl-tenant/io/PulsarSink-test",} 0.0
+pulsar_function_process_latency_ms_1min_sum{tenant="external-repl-prop",namespace="external-repl-tenant/io",name="PulsarSink-test",instance_id="0",cluster="use",fqfn="external-repl-tenant/io/PulsarSink-test",} 0.0
+pulsar_function_processed_successfully_total{tenant="external-repl-prop",namespace="external-repl-tenant/io",name="PulsarSink-test",instance_id="0",cluster="use",fqfn="external-repl-tenant/io/PulsarSink-test",} 0.0
+pulsar_function_received_total{tenant="external-repl-prop",namespace="external-repl-tenant/io",name="PulsarSink-test",instance_id="0",cluster="use",fqfn="external-repl-tenant/io/PulsarSink-test",} 0.0
+pulsar_function_system_exceptions_total{tenant="external-repl-prop",namespace="external-repl-tenant/io",name="PulsarSink-test",instance_id="0",cluster="use",fqfn="external-repl-tenant/io/PulsarSink-test",} 0.0
+pulsar_function_process_latency_ms{tenant="external-repl-prop",namespace="external-repl-tenant/io",name="PulsarSink-test",instance_id="0",cluster="use",fqfn="external-repl-tenant/io/PulsarSink-test",quantile="0.5",} NaN
+pulsar_function_process_latency_ms{tenant="external-repl-prop",namespace="external-repl-tenant/io",name="PulsarSink-test",instance_id="0",cluster="use",fqfn="external-repl-tenant/io/PulsarSink-test",quantile="0.9",} NaN
+pulsar_function_process_latency_ms{tenant="external-repl-prop",namespace="external-repl-tenant/io",name="PulsarSink-test",instance_id="0",cluster="use",fqfn="external-repl-tenant/io/PulsarSink-test",quantile="0.99",} NaN
+pulsar_function_process_latency_ms{tenant="external-repl-prop",namespace="external-repl-tenant/io",name="PulsarSink-test",instance_id="0",cluster="use",fqfn="external-repl-tenant/io/PulsarSink-test",quantile="0.999",} NaN
+pulsar_function_process_latency_ms_count{tenant="external-repl-prop",namespace="external-repl-tenant/io",name="PulsarSink-test",instance_id="0",cluster="use",fqfn="external-repl-tenant/io/PulsarSink-test",} 0.0
+pulsar_function_process_latency_ms_sum{tenant="external-repl-prop",namespace="external-repl-tenant/io",name="PulsarSink-test",instance_id="0",cluster="use",fqfn="external-repl-tenant/io/PulsarSink-test",} 0.0
+pulsar_function_system_exceptions_1min_total{tenant="external-repl-prop",namespace="external-repl-tenant/io",name="PulsarSink-test",instance_id="0",cluster="use",fqfn="external-repl-tenant/io/PulsarSink-test",} 0.0
+pulsar_function_user_exceptions_1min_total{tenant="external-repl-prop",namespace="external-repl-tenant/io",name="PulsarSink-test",instance_id="0",cluster="use",fqfn="external-repl-tenant/io/PulsarSink-test",} 0.0
 # TYPE pulsar_ml_cache_evictions gauge
 pulsar_ml_cache_evictions{cluster="use"} 0
 # TYPE pulsar_ml_cache_hits_rate gauge
@@ -712,124 +712,124 @@ pulsar_ml_cache_used_size{cluster="use"} 0
 # TYPE pulsar_ml_count gauge
 pulsar_ml_count{cluster="use"} 4
 # TYPE pulsar_ml_AddEntryBytesRate gauge
-pulsar_ml_AddEntryBytesRate{cluster="use", namespace="external-repl-prop/io/persistent"} 0.0
+pulsar_ml_AddEntryBytesRate{cluster="use", namespace="external-repl-tenant/io/persistent"} 0.0
 # TYPE pulsar_ml_AddEntryErrors gauge
-pulsar_ml_AddEntryErrors{cluster="use", namespace="external-repl-prop/io/persistent"} 0.0
+pulsar_ml_AddEntryErrors{cluster="use", namespace="external-repl-tenant/io/persistent"} 0.0
 # TYPE pulsar_ml_AddEntryLatencyBuckets gauge
-pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="0.0_0.5"} 0.0
-pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="0.5_1.0"} 0.0
-pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="1.0_5.0"} 0.0
-pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="10.0_20.0"} 0.0
-pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="100.0_200.0"} 0.0
-pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="20.0_50.0"} 0.0
-pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="200.0_1000.0"} 0.0
-pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="5.0_10.0"} 0.0
-pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="50.0_100.0"} 0.0
+pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-tenant/io/persistent", quantile="0.0_0.5"} 0.0
+pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-tenant/io/persistent", quantile="0.5_1.0"} 0.0
+pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-tenant/io/persistent", quantile="1.0_5.0"} 0.0
+pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-tenant/io/persistent", quantile="10.0_20.0"} 0.0
+pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-tenant/io/persistent", quantile="100.0_200.0"} 0.0
+pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-tenant/io/persistent", quantile="20.0_50.0"} 0.0
+pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-tenant/io/persistent", quantile="200.0_1000.0"} 0.0
+pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-tenant/io/persistent", quantile="5.0_10.0"} 0.0
+pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-tenant/io/persistent", quantile="50.0_100.0"} 0.0
 # TYPE pulsar_ml_AddEntryLatencyBuckets_OVERFLOW gauge
-pulsar_ml_AddEntryLatencyBuckets_OVERFLOW{cluster="use", namespace="external-repl-prop/io/persistent"} 0.0
+pulsar_ml_AddEntryLatencyBuckets_OVERFLOW{cluster="use", namespace="external-repl-tenant/io/persistent"} 0.0
 # TYPE pulsar_ml_AddEntryMessagesRate gauge
-pulsar_ml_AddEntryMessagesRate{cluster="use", namespace="external-repl-prop/io/persistent"} 0.0
+pulsar_ml_AddEntryMessagesRate{cluster="use", namespace="external-repl-tenant/io/persistent"} 0.0
 # TYPE pulsar_ml_AddEntrySucceed gauge
-pulsar_ml_AddEntrySucceed{cluster="use", namespace="external-repl-prop/io/persistent"} 0.0
+pulsar_ml_AddEntrySucceed{cluster="use", namespace="external-repl-tenant/io/persistent"} 0.0
 # TYPE pulsar_ml_EntrySizeBuckets gauge
-pulsar_ml_EntrySizeBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="0.0_128.0"} 0.0
-pulsar_ml_EntrySizeBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="1024.0_2048.0"} 0.0
-pulsar_ml_EntrySizeBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="102400.0_1232896.0"} 0.0
-pulsar_ml_EntrySizeBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="128.0_512.0"} 0.0
-pulsar_ml_EntrySizeBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="16384.0_102400.0"} 0.0
-pulsar_ml_EntrySizeBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="2048.0_4096.0"} 0.0
-pulsar_ml_EntrySizeBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="4096.0_16384.0"} 0.0
-pulsar_ml_EntrySizeBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="512.0_1024.0"} 0.0
+pulsar_ml_EntrySizeBuckets{cluster="use", namespace="external-repl-tenant/io/persistent", quantile="0.0_128.0"} 0.0
+pulsar_ml_EntrySizeBuckets{cluster="use", namespace="external-repl-tenant/io/persistent", quantile="1024.0_2048.0"} 0.0
+pulsar_ml_EntrySizeBuckets{cluster="use", namespace="external-repl-tenant/io/persistent", quantile="102400.0_1232896.0"} 0.0
+pulsar_ml_EntrySizeBuckets{cluster="use", namespace="external-repl-tenant/io/persistent", quantile="128.0_512.0"} 0.0
+pulsar_ml_EntrySizeBuckets{cluster="use", namespace="external-repl-tenant/io/persistent", quantile="16384.0_102400.0"} 0.0
+pulsar_ml_EntrySizeBuckets{cluster="use", namespace="external-repl-tenant/io/persistent", quantile="2048.0_4096.0"} 0.0
+pulsar_ml_EntrySizeBuckets{cluster="use", namespace="external-repl-tenant/io/persistent", quantile="4096.0_16384.0"} 0.0
+pulsar_ml_EntrySizeBuckets{cluster="use", namespace="external-repl-tenant/io/persistent", quantile="512.0_1024.0"} 0.0
 # TYPE pulsar_ml_EntrySizeBuckets_OVERFLOW gauge
-pulsar_ml_EntrySizeBuckets_OVERFLOW{cluster="use", namespace="external-repl-prop/io/persistent"} 0.0
+pulsar_ml_EntrySizeBuckets_OVERFLOW{cluster="use", namespace="external-repl-tenant/io/persistent"} 0.0
 # TYPE pulsar_ml_LedgerAddEntryLatencyBuckets gauge
-pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="0.0_0.5"} 0.0
-pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="0.5_1.0"} 0.0
-pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="1.0_5.0"} 0.0
-pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="10.0_20.0"} 0.0
-pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="100.0_200.0"} 0.0
-pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="20.0_50.0"} 0.0
-pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="200.0_1000.0"} 0.0
-pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="5.0_10.0"} 0.0
-pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="50.0_100.0"} 0.0
+pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-tenant/io/persistent", quantile="0.0_0.5"} 0.0
+pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-tenant/io/persistent", quantile="0.5_1.0"} 0.0
+pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-tenant/io/persistent", quantile="1.0_5.0"} 0.0
+pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-tenant/io/persistent", quantile="10.0_20.0"} 0.0
+pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-tenant/io/persistent", quantile="100.0_200.0"} 0.0
+pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-tenant/io/persistent", quantile="20.0_50.0"} 0.0
+pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-tenant/io/persistent", quantile="200.0_1000.0"} 0.0
+pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-tenant/io/persistent", quantile="5.0_10.0"} 0.0
+pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-tenant/io/persistent", quantile="50.0_100.0"} 0.0
 # TYPE pulsar_ml_LedgerAddEntryLatencyBuckets_OVERFLOW gauge
-pulsar_ml_LedgerAddEntryLatencyBuckets_OVERFLOW{cluster="use", namespace="external-repl-prop/io/persistent"} 0.0
+pulsar_ml_LedgerAddEntryLatencyBuckets_OVERFLOW{cluster="use", namespace="external-repl-tenant/io/persistent"} 0.0
 # TYPE pulsar_ml_LedgerSwitchLatencyBuckets gauge
-pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="0.0_0.5"} 0.0
-pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="0.5_1.0"} 0.0
-pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="1.0_5.0"} 0.0
-pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="10.0_20.0"} 0.0
-pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="100.0_200.0"} 0.0
-pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="20.0_50.0"} 0.0
-pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="200.0_1000.0"} 0.0
-pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="5.0_10.0"} 0.0
-pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-prop/io/persistent", quantile="50.0_100.0"} 0.0
+pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-tenant/io/persistent", quantile="0.0_0.5"} 0.0
+pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-tenant/io/persistent", quantile="0.5_1.0"} 0.0
+pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-tenant/io/persistent", quantile="1.0_5.0"} 0.0
+pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-tenant/io/persistent", quantile="10.0_20.0"} 0.0
+pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-tenant/io/persistent", quantile="100.0_200.0"} 0.0
+pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-tenant/io/persistent", quantile="20.0_50.0"} 0.0
+pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-tenant/io/persistent", quantile="200.0_1000.0"} 0.0
+pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-tenant/io/persistent", quantile="5.0_10.0"} 0.0
+pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-tenant/io/persistent", quantile="50.0_100.0"} 0.0
 # TYPE pulsar_ml_LedgerSwitchLatencyBuckets_OVERFLOW gauge
-pulsar_ml_LedgerSwitchLatencyBuckets_OVERFLOW{cluster="use", namespace="external-repl-prop/io/persistent"} 0.0
+pulsar_ml_LedgerSwitchLatencyBuckets_OVERFLOW{cluster="use", namespace="external-repl-tenant/io/persistent"} 0.0
 # TYPE pulsar_ml_MarkDeleteRate gauge
-pulsar_ml_MarkDeleteRate{cluster="use", namespace="external-repl-prop/io/persistent"} 0.0
+pulsar_ml_MarkDeleteRate{cluster="use", namespace="external-repl-tenant/io/persistent"} 0.0
 # TYPE pulsar_ml_NumberOfMessagesInBacklog gauge
-pulsar_ml_NumberOfMessagesInBacklog{cluster="use", namespace="external-repl-prop/io/persistent"} 0.0
+pulsar_ml_NumberOfMessagesInBacklog{cluster="use", namespace="external-repl-tenant/io/persistent"} 0.0
 # TYPE pulsar_ml_ReadEntriesBytesRate gauge
-pulsar_ml_ReadEntriesBytesRate{cluster="use", namespace="external-repl-prop/io/persistent"} 0.0
+pulsar_ml_ReadEntriesBytesRate{cluster="use", namespace="external-repl-tenant/io/persistent"} 0.0
 # TYPE pulsar_ml_ReadEntriesErrors gauge
-pulsar_ml_ReadEntriesErrors{cluster="use", namespace="external-repl-prop/io/persistent"} 0.0
+pulsar_ml_ReadEntriesErrors{cluster="use", namespace="external-repl-tenant/io/persistent"} 0.0
 # TYPE pulsar_ml_ReadEntriesRate gauge
-pulsar_ml_ReadEntriesRate{cluster="use", namespace="external-repl-prop/io/persistent"} 0.0
+pulsar_ml_ReadEntriesRate{cluster="use", namespace="external-repl-tenant/io/persistent"} 0.0
 # TYPE pulsar_ml_ReadEntriesSucceeded gauge
-pulsar_ml_ReadEntriesSucceeded{cluster="use", namespace="external-repl-prop/io/persistent"} 0.0
+pulsar_ml_ReadEntriesSucceeded{cluster="use", namespace="external-repl-tenant/io/persistent"} 0.0
 # TYPE pulsar_ml_StoredMessagesSize gauge
-pulsar_ml_StoredMessagesSize{cluster="use", namespace="external-repl-prop/io/persistent"} 0.0
-pulsar_ml_AddEntryBytesRate{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent"} 0.0
-pulsar_ml_AddEntryErrors{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent"} 0.0
-pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="0.0_0.5"} 0.0
-pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="0.5_1.0"} 0.0
-pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="1.0_5.0"} 0.0
-pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="10.0_20.0"} 0.0
-pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="100.0_200.0"} 0.0
-pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="20.0_50.0"} 0.0
-pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="200.0_1000.0"} 0.0
-pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="5.0_10.0"} 0.0
-pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="50.0_100.0"} 0.0
-pulsar_ml_AddEntryLatencyBuckets_OVERFLOW{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent"} 0.0
-pulsar_ml_AddEntryMessagesRate{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent"} 0.0
-pulsar_ml_AddEntrySucceed{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent"} 0.0
-pulsar_ml_EntrySizeBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="0.0_128.0"} 0.0
-pulsar_ml_EntrySizeBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="1024.0_2048.0"} 0.0
-pulsar_ml_EntrySizeBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="102400.0_1232896.0"} 0.0
-pulsar_ml_EntrySizeBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="128.0_512.0"} 0.0
-pulsar_ml_EntrySizeBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="16384.0_102400.0"} 0.0
-pulsar_ml_EntrySizeBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="2048.0_4096.0"} 0.0
-pulsar_ml_EntrySizeBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="4096.0_16384.0"} 0.0
-pulsar_ml_EntrySizeBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="512.0_1024.0"} 0.0
-pulsar_ml_EntrySizeBuckets_OVERFLOW{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent"} 0.0
-pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="0.0_0.5"} 0.0
-pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="0.5_1.0"} 0.0
-pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="1.0_5.0"} 0.0
-pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="10.0_20.0"} 0.0
-pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="100.0_200.0"} 0.0
-pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="20.0_50.0"} 0.0
-pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="200.0_1000.0"} 0.0
-pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="5.0_10.0"} 0.0
-pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="50.0_100.0"} 0.0
-pulsar_ml_LedgerAddEntryLatencyBuckets_OVERFLOW{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent"} 0.0
-pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="0.0_0.5"} 0.0
-pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="0.5_1.0"} 0.0
-pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="1.0_5.0"} 0.0
-pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="10.0_20.0"} 0.0
-pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="100.0_200.0"} 0.0
-pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="20.0_50.0"} 0.0
-pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="200.0_1000.0"} 0.0
-pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="5.0_10.0"} 0.0
-pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent", quantile="50.0_100.0"} 0.0
-pulsar_ml_LedgerSwitchLatencyBuckets_OVERFLOW{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent"} 0.0
-pulsar_ml_MarkDeleteRate{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent"} 0.0
-pulsar_ml_NumberOfMessagesInBacklog{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent"} 0.0
-pulsar_ml_ReadEntriesBytesRate{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent"} 0.0
-pulsar_ml_ReadEntriesErrors{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent"} 0.0
-pulsar_ml_ReadEntriesRate{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent"} 0.0
-pulsar_ml_ReadEntriesSucceeded{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent"} 0.0
-pulsar_ml_StoredMessagesSize{cluster="use", namespace="external-repl-prop/pulsar-function-admin/persistent"} 3476.0
+pulsar_ml_StoredMessagesSize{cluster="use", namespace="external-repl-tenant/io/persistent"} 0.0
+pulsar_ml_AddEntryBytesRate{cluster="use", namespace="external-repl-tenant/pulsar-function-admin/persistent"} 0.0
+pulsar_ml_AddEntryErrors{cluster="use", namespace="external-repl-tenant/pulsar-function-admin/persistent"} 0.0
+pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-tenant/pulsar-function-admin/persistent", quantile="0.0_0.5"} 0.0
+pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-tenant/pulsar-function-admin/persistent", quantile="0.5_1.0"} 0.0
+pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-tenant/pulsar-function-admin/persistent", quantile="1.0_5.0"} 0.0
+pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-tenant/pulsar-function-admin/persistent", quantile="10.0_20.0"} 0.0
+pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-tenant/pulsar-function-admin/persistent", quantile="100.0_200.0"} 0.0
+pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-tenant/pulsar-function-admin/persistent", quantile="20.0_50.0"} 0.0
+pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-tenant/pulsar-function-admin/persistent", quantile="200.0_1000.0"} 0.0
+pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-tenant/pulsar-function-admin/persistent", quantile="5.0_10.0"} 0.0
+pulsar_ml_AddEntryLatencyBuckets{cluster="use", namespace="external-repl-tenant/pulsar-function-admin/persistent", quantile="50.0_100.0"} 0.0
+pulsar_ml_AddEntryLatencyBuckets_OVERFLOW{cluster="use", namespace="external-repl-tenant/pulsar-function-admin/persistent"} 0.0
+pulsar_ml_AddEntryMessagesRate{cluster="use", namespace="external-repl-tenant/pulsar-function-admin/persistent"} 0.0
+pulsar_ml_AddEntrySucceed{cluster="use", namespace="external-repl-tenant/pulsar-function-admin/persistent"} 0.0
+pulsar_ml_EntrySizeBuckets{cluster="use", namespace="external-repl-tenant/pulsar-function-admin/persistent", quantile="0.0_128.0"} 0.0
+pulsar_ml_EntrySizeBuckets{cluster="use", namespace="external-repl-tenant/pulsar-function-admin/persistent", quantile="1024.0_2048.0"} 0.0
+pulsar_ml_EntrySizeBuckets{cluster="use", namespace="external-repl-tenant/pulsar-function-admin/persistent", quantile="102400.0_1232896.0"} 0.0
+pulsar_ml_EntrySizeBuckets{cluster="use", namespace="external-repl-tenant/pulsar-function-admin/persistent", quantile="128.0_512.0"} 0.0
+pulsar_ml_EntrySizeBuckets{cluster="use", namespace="external-repl-tenant/pulsar-function-admin/persistent", quantile="16384.0_102400.0"} 0.0
+pulsar_ml_EntrySizeBuckets{cluster="use", namespace="external-repl-tenant/pulsar-function-admin/persistent", quantile="2048.0_4096.0"} 0.0
+pulsar_ml_EntrySizeBuckets{cluster="use", namespace="external-repl-tenant/pulsar-function-admin/persistent", quantile="4096.0_16384.0"} 0.0
+pulsar_ml_EntrySizeBuckets{cluster="use", namespace="external-repl-tenant/pulsar-function-admin/persistent", quantile="512.0_1024.0"} 0.0
+pulsar_ml_EntrySizeBuckets_OVERFLOW{cluster="use", namespace="external-repl-tenant/pulsar-function-admin/persistent"} 0.0
+pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-tenant/pulsar-function-admin/persistent", quantile="0.0_0.5"} 0.0
+pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-tenant/pulsar-function-admin/persistent", quantile="0.5_1.0"} 0.0
+pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-tenant/pulsar-function-admin/persistent", quantile="1.0_5.0"} 0.0
+pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-tenant/pulsar-function-admin/persistent", quantile="10.0_20.0"} 0.0
+pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-tenant/pulsar-function-admin/persistent", quantile="100.0_200.0"} 0.0
+pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-tenant/pulsar-function-admin/persistent", quantile="20.0_50.0"} 0.0
+pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-tenant/pulsar-function-admin/persistent", quantile="200.0_1000.0"} 0.0
+pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-tenant/pulsar-function-admin/persistent", quantile="5.0_10.0"} 0.0
+pulsar_ml_LedgerAddEntryLatencyBuckets{cluster="use", namespace="external-repl-tenant/pulsar-function-admin/persistent", quantile="50.0_100.0"} 0.0
+pulsar_ml_LedgerAddEntryLatencyBuckets_OVERFLOW{cluster="use", namespace="external-repl-tenant/pulsar-function-admin/persistent"} 0.0
+pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-tenant/pulsar-function-admin/persistent", quantile="0.0_0.5"} 0.0
+pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-tenant/pulsar-function-admin/persistent", quantile="0.5_1.0"} 0.0
+pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-tenant/pulsar-function-admin/persistent", quantile="1.0_5.0"} 0.0
+pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-tenant/pulsar-function-admin/persistent", quantile="10.0_20.0"} 0.0
+pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-tenant/pulsar-function-admin/persistent", quantile="100.0_200.0"} 0.0
+pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-tenant/pulsar-function-admin/persistent", quantile="20.0_50.0"} 0.0
+pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-tenant/pulsar-function-admin/persistent", quantile="200.0_1000.0"} 0.0
+pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-tenant/pulsar-function-admin/persistent", quantile="5.0_10.0"} 0.0
+pulsar_ml_LedgerSwitchLatencyBuckets{cluster="use", namespace="external-repl-tenant/pulsar-function-admin/persistent", quantile="50.0_100.0"} 0.0
+pulsar_ml_LedgerSwitchLatencyBuckets_OVERFLOW{cluster="use", namespace="external-repl-tenant/pulsar-function-admin/persistent"} 0.0
+pulsar_ml_MarkDeleteRate{cluster="use", namespace="external-repl-tenant/pulsar-function-admin/persistent"} 0.0
+pulsar_ml_NumberOfMessagesInBacklog{cluster="use", namespace="external-repl-tenant/pulsar-function-admin/persistent"} 0.0
+pulsar_ml_ReadEntriesBytesRate{cluster="use", namespace="external-repl-tenant/pulsar-function-admin/persistent"} 0.0
+pulsar_ml_ReadEntriesErrors{cluster="use", namespace="external-repl-tenant/pulsar-function-admin/persistent"} 0.0
+pulsar_ml_ReadEntriesRate{cluster="use", namespace="external-repl-tenant/pulsar-function-admin/persistent"} 0.0
+pulsar_ml_ReadEntriesSucceeded{cluster="use", namespace="external-repl-tenant/pulsar-function-admin/persistent"} 0.0
+pulsar_ml_StoredMessagesSize{cluster="use", namespace="external-repl-tenant/pulsar-function-admin/persistent"} 3476.0
 # TYPE pulsar_active_connections gauge
 pulsar_active_connections{cluster="use", broker="localhost", metric="broker_connection"} 3
 # TYPE pulsar_connection_closed_total_count gauge

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Namespaces.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Namespaces.java
@@ -104,7 +104,7 @@ public interface Namespaces {
      * Response Example:
      *
      * <pre>
-     * <code>["my-tenant/use/namespace1", "my-tenant/use/namespace2"]</code>
+     * <code>["my-tenant/namespace1", "my-tenant/namespace2"]</code>
      * </pre>
      *
      * @param tenant
@@ -130,8 +130,8 @@ public interface Namespaces {
      * Response Example:
      *
      * <pre>
-     * <code>["persistent://my-tenant/use/namespace1/my-topic-1",
-     *  "persistent://my-tenant/use/namespace1/my-topic-2"]</code>
+     * <code>["persistent://my-tenant/namespace1/my-topic-1",
+     *  "persistent://my-tenant/namespace1/my-topic-2"]</code>
      * </pre>
      *
      * @param namespace
@@ -154,8 +154,8 @@ public interface Namespaces {
      * Response Example:
      *
      * <pre>
-     * <code>["persistent://my-tenant/use/namespace1/my-topic-1",
-     *  "persistent://my-tenant/use/namespace1/my-topic-2"]</code>
+     * <code>["persistent://my-tenant/namespace1/my-topic-1",
+     *  "persistent://my-tenant/namespace1/my-topic-2"]</code>
      * </pre>
      *
      * @param namespace
@@ -171,8 +171,8 @@ public interface Namespaces {
      * Response Example:
      *
      * <pre>
-     * <code>["persistent://my-tenant/use/namespace1/my-topic-1",
-     *  "persistent://my-tenant/use/namespace1/my-topic-2"]</code>
+     * <code>["persistent://my-tenant/namespace1/my-topic-1",
+     *  "persistent://my-tenant/namespace1/my-topic-2"]</code>
      * </pre>
      *
      * @param namespace
@@ -197,8 +197,8 @@ public interface Namespaces {
      * Response Example:
      *
      * <pre>
-     * <code>["persistent://my-tenant/use/namespace1/my-topic-1",
-     *  "persistent://my-tenant/use/namespace1/my-topic-2"]</code>
+     * <code>["persistent://my-tenant/namespace1/my-topic-1",
+     *  "persistent://my-tenant/namespace1/my-topic-2"]</code>
      * </pre>
      *
      * @param namespace
@@ -251,7 +251,7 @@ public interface Namespaces {
      *       "my-role" : [ "produce" ]
      *     },
      *     "destination_auth" : {
-     *       "persistent://prop/local/ns1/my-topic" : {
+     *       "persistent://tenant/local/ns1/my-topic" : {
      *         "role-1" : [ "produce" ],
      *         "role-2" : [ "consume" ]
      *       }
@@ -290,7 +290,7 @@ public interface Namespaces {
      *       "my-role" : [ "produce" ]
      *     },
      *     "destination_auth" : {
-     *       "persistent://prop/local/ns1/my-topic" : {
+     *       "persistent://tenant/local/ns1/my-topic" : {
      *         "role-1" : [ "produce" ],
      *         "role-2" : [ "consume" ]
      *       }

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -385,8 +385,8 @@ public class PulsarAdminToolTest {
         // filesystem offload
         CmdNamespaces namespaces = new CmdNamespaces(() -> admin);
         namespaces.run(split(
-          "set-offload-policies myprop/clust/ns2 -d filesystem -oat 100M -oats 1h -oae 1h -orp bookkeeper-first"));
-        verify(mockNamespaces).setOffloadPolicies("myprop/clust/ns2",
+          "set-offload-policies mytenant/ns2 -d filesystem -oat 100M -oats 1h -oae 1h -orp bookkeeper-first"));
+        verify(mockNamespaces).setOffloadPolicies("mytenant/ns2",
           OffloadPoliciesImpl.create("filesystem", null, null,
             null, null, null, null, null, 64 * 1024 * 1024, 1024 * 1024,
             100 * 1024 * 1024L, 3600L, 3600 * 1000L, OffloadedReadPriority.BOOKKEEPER_FIRST));
@@ -394,9 +394,9 @@ public class PulsarAdminToolTest {
         // S3 offload
         CmdNamespaces namespaces2 = new CmdNamespaces(() -> admin);
         namespaces2.run(split(
-          "set-offload-policies myprop/clust/ns1 -r test-region -d aws-s3 -b test-bucket -e http://test.endpoint "
+          "set-offload-policies mytenant/ns1 -r test-region -d aws-s3 -b test-bucket -e http://test.endpoint "
                   + "-mbs 32M -rbs 5M -oat 10M -oats 100 -oae 10s -orp tiered-storage-first"));
-        verify(mockNamespaces).setOffloadPolicies("myprop/clust/ns1",
+        verify(mockNamespaces).setOffloadPolicies("mytenant/ns1",
           OffloadPoliciesImpl.create("aws-s3", "test-region", "test-bucket",
             "http://test.endpoint", null, null, null, null, 32 * 1024 * 1024, 5 * 1024 * 1024,
             10 * 1024 * 1024L, 100L, 10000L, OffloadedReadPriority.TIERED_STORAGE_FIRST));
@@ -415,120 +415,120 @@ public class PulsarAdminToolTest {
         namespaces.run(split("list myprop"));
         verify(mockNamespaces).getNamespaces("myprop");
 
-        namespaces.run(split("list-cluster myprop/clust"));
+        namespaces.run(split("list-cluster mytenant"));
         verify(mockNamespaces).getNamespaces("myprop", "clust");
 
-        namespaces.run(split("topics myprop/clust/ns1"));
-        verify(mockNamespaces).getTopics("myprop/clust/ns1", ListNamespaceTopicsOptions.builder().build());
+        namespaces.run(split("topics mytenant/ns1"));
+        verify(mockNamespaces).getTopics("mytenant/ns1", ListNamespaceTopicsOptions.builder().build());
 
-        namespaces.run(split("policies myprop/clust/ns1"));
-        verify(mockNamespaces).getPolicies("myprop/clust/ns1");
+        namespaces.run(split("policies mytenant/ns1"));
+        verify(mockNamespaces).getPolicies("mytenant/ns1");
 
-        namespaces.run(split("create myprop/clust/ns1"));
-        verify(mockNamespaces).createNamespace("myprop/clust/ns1");
+        namespaces.run(split("create mytenant/ns1"));
+        verify(mockNamespaces).createNamespace("mytenant/ns1");
 
-        namespaces.run(split("delete myprop/clust/ns1"));
-        verify(mockNamespaces).deleteNamespace("myprop/clust/ns1", false);
+        namespaces.run(split("delete mytenant/ns1"));
+        verify(mockNamespaces).deleteNamespace("mytenant/ns1", false);
 
-        namespaces.run(split("permissions myprop/clust/ns1"));
-        verify(mockNamespaces).getPermissions("myprop/clust/ns1");
+        namespaces.run(split("permissions mytenant/ns1"));
+        verify(mockNamespaces).getPermissions("mytenant/ns1");
 
-        namespaces.run(split("grant-permission myprop/clust/ns1 --role role1 --actions produce,consume"));
-        verify(mockNamespaces).grantPermissionOnNamespace("myprop/clust/ns1", "role1",
+        namespaces.run(split("grant-permission mytenant/ns1 --role role1 --actions produce,consume"));
+        verify(mockNamespaces).grantPermissionOnNamespace("mytenant/ns1", "role1",
                 EnumSet.of(AuthAction.produce, AuthAction.consume));
 
-        namespaces.run(split("revoke-permission myprop/clust/ns1 --role role1"));
-        verify(mockNamespaces).revokePermissionsOnNamespace("myprop/clust/ns1", "role1");
+        namespaces.run(split("revoke-permission mytenant/ns1 --role role1"));
+        verify(mockNamespaces).revokePermissionsOnNamespace("mytenant/ns1", "role1");
 
-        namespaces.run(split("set-clusters myprop/clust/ns1 -c use,usw,usc"));
-        verify(mockNamespaces).setNamespaceReplicationClusters("myprop/clust/ns1",
+        namespaces.run(split("set-clusters mytenant/ns1 -c use,usw,usc"));
+        verify(mockNamespaces).setNamespaceReplicationClusters("mytenant/ns1",
                 Sets.newHashSet("use", "usw", "usc"));
 
-        namespaces.run(split("get-clusters myprop/clust/ns1"));
-        verify(mockNamespaces).getNamespaceReplicationClusters("myprop/clust/ns1");
+        namespaces.run(split("get-clusters mytenant/ns1"));
+        verify(mockNamespaces).getNamespaceReplicationClusters("mytenant/ns1");
 
-            namespaces.run(split("set-allowed-clusters myprop/clust/ns1 -c use,usw,usc"));
-            verify(mockNamespaces).setNamespaceAllowedClusters("myprop/clust/ns1",
+            namespaces.run(split("set-allowed-clusters mytenant/ns1 -c use,usw,usc"));
+            verify(mockNamespaces).setNamespaceAllowedClusters("mytenant/ns1",
                     Sets.newHashSet("use", "usw", "usc"));
 
-            namespaces.run(split("get-allowed-clusters myprop/clust/ns1"));
-            verify(mockNamespaces).getNamespaceAllowedClusters("myprop/clust/ns1");
+            namespaces.run(split("get-allowed-clusters mytenant/ns1"));
+            verify(mockNamespaces).getNamespaceAllowedClusters("mytenant/ns1");
 
 
-            namespaces.run(split("set-subscription-types-enabled myprop/clust/ns1 -t Shared,Failover"));
-        verify(mockNamespaces).setSubscriptionTypesEnabled("myprop/clust/ns1",
+            namespaces.run(split("set-subscription-types-enabled mytenant/ns1 -t Shared,Failover"));
+        verify(mockNamespaces).setSubscriptionTypesEnabled("mytenant/ns1",
                 Sets.newHashSet(SubscriptionType.Shared, SubscriptionType.Failover));
 
-        namespaces.run(split("get-subscription-types-enabled myprop/clust/ns1"));
-        verify(mockNamespaces).getSubscriptionTypesEnabled("myprop/clust/ns1");
+        namespaces.run(split("get-subscription-types-enabled mytenant/ns1"));
+        verify(mockNamespaces).getSubscriptionTypesEnabled("mytenant/ns1");
 
-        namespaces.run(split("remove-subscription-types-enabled myprop/clust/ns1"));
-        verify(mockNamespaces).removeSubscriptionTypesEnabled("myprop/clust/ns1");
+        namespaces.run(split("remove-subscription-types-enabled mytenant/ns1"));
+        verify(mockNamespaces).removeSubscriptionTypesEnabled("mytenant/ns1");
 
-        namespaces.run(split("get-schema-validation-enforce myprop/clust/ns1 -ap"));
-        verify(mockNamespaces).getSchemaValidationEnforced("myprop/clust/ns1", true);
+        namespaces.run(split("get-schema-validation-enforce mytenant/ns1 -ap"));
+        verify(mockNamespaces).getSchemaValidationEnforced("mytenant/ns1", true);
 
         namespaces.run(split(
-                "set-bookie-affinity-group myprop/clust/ns1 --primary-group test1 --secondary-group test2"));
-        verify(mockNamespaces).setBookieAffinityGroup("myprop/clust/ns1",
+                "set-bookie-affinity-group mytenant/ns1 --primary-group test1 --secondary-group test2"));
+        verify(mockNamespaces).setBookieAffinityGroup("mytenant/ns1",
                 BookieAffinityGroupData.builder()
                         .bookkeeperAffinityGroupPrimary("test1")
                         .bookkeeperAffinityGroupSecondary("test2")
                         .build());
 
-        namespaces.run(split("get-bookie-affinity-group myprop/clust/ns1"));
-        verify(mockNamespaces).getBookieAffinityGroup("myprop/clust/ns1");
+        namespaces.run(split("get-bookie-affinity-group mytenant/ns1"));
+        verify(mockNamespaces).getBookieAffinityGroup("mytenant/ns1");
 
-        namespaces.run(split("delete-bookie-affinity-group myprop/clust/ns1"));
-        verify(mockNamespaces).deleteBookieAffinityGroup("myprop/clust/ns1");
+        namespaces.run(split("delete-bookie-affinity-group mytenant/ns1"));
+        verify(mockNamespaces).deleteBookieAffinityGroup("mytenant/ns1");
 
-        namespaces.run(split("set-replicator-dispatch-rate myprop/clust/ns1 -md 10 -bd 11 -dt 12"));
-        verify(mockNamespaces).setReplicatorDispatchRate("myprop/clust/ns1", DispatchRate.builder()
+        namespaces.run(split("set-replicator-dispatch-rate mytenant/ns1 -md 10 -bd 11 -dt 12"));
+        verify(mockNamespaces).setReplicatorDispatchRate("mytenant/ns1", DispatchRate.builder()
                 .dispatchThrottlingRateInMsg(10)
                 .dispatchThrottlingRateInByte(11)
                 .ratePeriodInSecond(12)
                 .build());
 
-        namespaces.run(split("get-replicator-dispatch-rate myprop/clust/ns1"));
-        verify(mockNamespaces).getReplicatorDispatchRate("myprop/clust/ns1");
+        namespaces.run(split("get-replicator-dispatch-rate mytenant/ns1"));
+        verify(mockNamespaces).getReplicatorDispatchRate("mytenant/ns1");
 
-        namespaces.run(split("remove-replicator-dispatch-rate myprop/clust/ns1"));
-        verify(mockNamespaces).removeReplicatorDispatchRate("myprop/clust/ns1");
+        namespaces.run(split("remove-replicator-dispatch-rate mytenant/ns1"));
+        verify(mockNamespaces).removeReplicatorDispatchRate("mytenant/ns1");
 
 
-        assertFalse(namespaces.run(split("unload myprop/clust/ns1 -d broker")));
-        verify(mockNamespaces, times(0)).unload("myprop/clust/ns1");
+        assertFalse(namespaces.run(split("unload mytenant/ns1 -d broker")));
+        verify(mockNamespaces, times(0)).unload("mytenant/ns1");
 
         namespaces = new CmdNamespaces(() -> admin);
-        namespaces.run(split("unload myprop/clust/ns1"));
-        verify(mockNamespaces).unload("myprop/clust/ns1");
+        namespaces.run(split("unload mytenant/ns1"));
+        verify(mockNamespaces).unload("mytenant/ns1");
 
         // message_age must have time limit, destination_storage must have size limit
         Assert.assertFalse(namespaces.run(
-                split("set-backlog-quota myprop/clust/ns1 -p producer_exception -l 10G -t message_age")));
+                split("set-backlog-quota mytenant/ns1 -p producer_exception -l 10G -t message_age")));
         Assert.assertFalse(namespaces.run(
-                split("set-backlog-quota myprop/clust/ns1 -p producer_exception -lt 10h -t destination_storage")));
+                split("set-backlog-quota mytenant/ns1 -p producer_exception -lt 10h -t destination_storage")));
 
         mockNamespaces = mock(Namespaces.class);
         when(admin.namespaces()).thenReturn(mockNamespaces);
         namespaces = new CmdNamespaces(() -> admin);
 
-        namespaces.run(split("unload myprop/clust/ns1 -b 0x80000000_0xffffffff"));
-        verify(mockNamespaces).unloadNamespaceBundle("myprop/clust/ns1", "0x80000000_0xffffffff", null);
+        namespaces.run(split("unload mytenant/ns1 -b 0x80000000_0xffffffff"));
+        verify(mockNamespaces).unloadNamespaceBundle("mytenant/ns1", "0x80000000_0xffffffff", null);
 
         namespaces = new CmdNamespaces(() -> admin);
-        namespaces.run(split("unload myprop/clust/ns1 -b 0x80000000_0xffffffff -d broker"));
-        verify(mockNamespaces).unloadNamespaceBundle("myprop/clust/ns1", "0x80000000_0xffffffff", "broker");
+        namespaces.run(split("unload mytenant/ns1 -b 0x80000000_0xffffffff -d broker"));
+        verify(mockNamespaces).unloadNamespaceBundle("mytenant/ns1", "0x80000000_0xffffffff", "broker");
 
-        namespaces.run(split("split-bundle myprop/clust/ns1 -b 0x00000000_0xffffffff"));
-        verify(mockNamespaces).splitNamespaceBundle("myprop/clust/ns1", "0x00000000_0xffffffff",
+        namespaces.run(split("split-bundle mytenant/ns1 -b 0x00000000_0xffffffff"));
+        verify(mockNamespaces).splitNamespaceBundle("mytenant/ns1", "0x00000000_0xffffffff",
                 false, null);
 
-        namespaces.run(split("get-backlog-quotas myprop/clust/ns1"));
-        verify(mockNamespaces).getBacklogQuotaMap("myprop/clust/ns1");
+        namespaces.run(split("get-backlog-quotas mytenant/ns1"));
+        verify(mockNamespaces).getBacklogQuotaMap("mytenant/ns1");
 
-        namespaces.run(split("set-backlog-quota myprop/clust/ns1 -p producer_request_hold -l 10"));
-        verify(mockNamespaces).setBacklogQuota("myprop/clust/ns1",
+        namespaces.run(split("set-backlog-quota mytenant/ns1 -p producer_request_hold -l 10"));
+        verify(mockNamespaces).setBacklogQuota("mytenant/ns1",
                 BacklogQuota.builder()
                         .limitSize(10)
                         .retentionPolicy(RetentionPolicy.producer_request_hold)
@@ -539,8 +539,8 @@ public class PulsarAdminToolTest {
         when(admin.namespaces()).thenReturn(mockNamespaces);
         namespaces = new CmdNamespaces(() -> admin);
 
-        namespaces.run(split("set-backlog-quota myprop/clust/ns1 -p producer_exception -l 10K"));
-        verify(mockNamespaces).setBacklogQuota("myprop/clust/ns1",
+        namespaces.run(split("set-backlog-quota mytenant/ns1 -p producer_exception -l 10K"));
+        verify(mockNamespaces).setBacklogQuota("mytenant/ns1",
                 BacklogQuota.builder()
                         .limitSize(10 * 1024)
                         .retentionPolicy(RetentionPolicy.producer_exception)
@@ -551,8 +551,8 @@ public class PulsarAdminToolTest {
         when(admin.namespaces()).thenReturn(mockNamespaces);
         namespaces = new CmdNamespaces(() -> admin);
 
-        namespaces.run(split("set-backlog-quota myprop/clust/ns1 -p producer_exception -l 10M"));
-        verify(mockNamespaces).setBacklogQuota("myprop/clust/ns1",
+        namespaces.run(split("set-backlog-quota mytenant/ns1 -p producer_exception -l 10M"));
+        verify(mockNamespaces).setBacklogQuota("mytenant/ns1",
                 BacklogQuota.builder()
                         .limitSize(10 * 1024 * 1024)
                         .retentionPolicy(RetentionPolicy.producer_exception)
@@ -563,8 +563,8 @@ public class PulsarAdminToolTest {
         when(admin.namespaces()).thenReturn(mockNamespaces);
         namespaces = new CmdNamespaces(() -> admin);
 
-        namespaces.run(split("set-backlog-quota myprop/clust/ns1 -p producer_exception -l 10G"));
-        verify(mockNamespaces).setBacklogQuota("myprop/clust/ns1",
+        namespaces.run(split("set-backlog-quota mytenant/ns1 -p producer_exception -l 10G"));
+        verify(mockNamespaces).setBacklogQuota("mytenant/ns1",
                 BacklogQuota.builder()
                         .limitSize(10L * 1024 * 1024 * 1024)
                         .retentionPolicy(RetentionPolicy.producer_exception)
@@ -576,8 +576,8 @@ public class PulsarAdminToolTest {
         namespaces = new CmdNamespaces(() -> admin);
 
         namespaces.run(split(
-                "set-backlog-quota myprop/clust/ns1 -p consumer_backlog_eviction -lt 10m -t message_age"));
-        verify(mockNamespaces).setBacklogQuota("myprop/clust/ns1",
+                "set-backlog-quota mytenant/ns1 -p consumer_backlog_eviction -lt 10m -t message_age"));
+        verify(mockNamespaces).setBacklogQuota("mytenant/ns1",
                 BacklogQuota.builder()
                         .limitTime(10 * 60)
                         .retentionPolicy(RetentionPolicy.consumer_backlog_eviction)
@@ -588,202 +588,202 @@ public class PulsarAdminToolTest {
         when(admin.namespaces()).thenReturn(mockNamespaces);
         namespaces = new CmdNamespaces(() -> admin);
 
-        namespaces.run(split("set-backlog-quota myprop/clust/ns1 -p producer_exception -lt 10000 -t message_age"));
-        verify(mockNamespaces).setBacklogQuota("myprop/clust/ns1",
+        namespaces.run(split("set-backlog-quota mytenant/ns1 -p producer_exception -lt 10000 -t message_age"));
+        verify(mockNamespaces).setBacklogQuota("mytenant/ns1",
                 BacklogQuota.builder()
                         .limitTime(10000)
                         .retentionPolicy(RetentionPolicy.producer_exception)
                         .build(),
                         BacklogQuota.BacklogQuotaType.message_age);
 
-        namespaces.run(split("set-persistence myprop/clust/ns1 -e 2 -w 1 -a 1 -r 100.0"));
-        verify(mockNamespaces).setPersistence("myprop/clust/ns1",
+        namespaces.run(split("set-persistence mytenant/ns1 -e 2 -w 1 -a 1 -r 100.0"));
+        verify(mockNamespaces).setPersistence("mytenant/ns1",
                 new PersistencePolicies(2, 1, 1, 100.0d));
 
-        namespaces.run(split("get-persistence myprop/clust/ns1"));
-        verify(mockNamespaces).getPersistence("myprop/clust/ns1");
+        namespaces.run(split("get-persistence mytenant/ns1"));
+        verify(mockNamespaces).getPersistence("mytenant/ns1");
 
-        namespaces.run(split("remove-persistence myprop/clust/ns1"));
-        verify(mockNamespaces).removePersistence("myprop/clust/ns1");
+        namespaces.run(split("remove-persistence mytenant/ns1"));
+        verify(mockNamespaces).removePersistence("mytenant/ns1");
 
-        namespaces.run(split("get-max-subscriptions-per-topic myprop/clust/ns1"));
-        verify(mockNamespaces).getMaxSubscriptionsPerTopic("myprop/clust/ns1");
-        namespaces.run(split("set-max-subscriptions-per-topic myprop/clust/ns1 -m 300"));
-        verify(mockNamespaces).setMaxSubscriptionsPerTopic("myprop/clust/ns1", 300);
-        namespaces.run(split("remove-max-subscriptions-per-topic myprop/clust/ns1"));
-        verify(mockNamespaces).removeMaxSubscriptionsPerTopic("myprop/clust/ns1");
+        namespaces.run(split("get-max-subscriptions-per-topic mytenant/ns1"));
+        verify(mockNamespaces).getMaxSubscriptionsPerTopic("mytenant/ns1");
+        namespaces.run(split("set-max-subscriptions-per-topic mytenant/ns1 -m 300"));
+        verify(mockNamespaces).setMaxSubscriptionsPerTopic("mytenant/ns1", 300);
+        namespaces.run(split("remove-max-subscriptions-per-topic mytenant/ns1"));
+        verify(mockNamespaces).removeMaxSubscriptionsPerTopic("mytenant/ns1");
 
-        namespaces.run(split("set-message-ttl myprop/clust/ns1 -ttl 300"));
-        verify(mockNamespaces).setNamespaceMessageTTL("myprop/clust/ns1", 300);
+        namespaces.run(split("set-message-ttl mytenant/ns1 -ttl 300"));
+        verify(mockNamespaces).setNamespaceMessageTTL("mytenant/ns1", 300);
 
-        namespaces.run(split("set-subscription-expiration-time myprop/clust/ns1 -t 60"));
-        verify(mockNamespaces).setSubscriptionExpirationTime("myprop/clust/ns1", 60);
+        namespaces.run(split("set-subscription-expiration-time mytenant/ns1 -t 60"));
+        verify(mockNamespaces).setSubscriptionExpirationTime("mytenant/ns1", 60);
 
-        namespaces.run(split("get-deduplication myprop/clust/ns1"));
-        verify(mockNamespaces).getDeduplicationStatus("myprop/clust/ns1");
-        namespaces.run(split("set-deduplication myprop/clust/ns1 --enable"));
-        verify(mockNamespaces).setDeduplicationStatus("myprop/clust/ns1", true);
-        namespaces.run(split("remove-deduplication myprop/clust/ns1"));
-        verify(mockNamespaces).removeDeduplicationStatus("myprop/clust/ns1");
+        namespaces.run(split("get-deduplication mytenant/ns1"));
+        verify(mockNamespaces).getDeduplicationStatus("mytenant/ns1");
+        namespaces.run(split("set-deduplication mytenant/ns1 --enable"));
+        verify(mockNamespaces).setDeduplicationStatus("mytenant/ns1", true);
+        namespaces.run(split("remove-deduplication mytenant/ns1"));
+        verify(mockNamespaces).removeDeduplicationStatus("mytenant/ns1");
 
-        namespaces.run(split("set-auto-topic-creation myprop/clust/ns1 -e -t non-partitioned"));
-        verify(mockNamespaces).setAutoTopicCreation("myprop/clust/ns1",
+        namespaces.run(split("set-auto-topic-creation mytenant/ns1 -e -t non-partitioned"));
+        verify(mockNamespaces).setAutoTopicCreation("mytenant/ns1",
                 AutoTopicCreationOverride.builder()
                         .allowAutoTopicCreation(true)
                         .topicType(TopicType.NON_PARTITIONED.toString())
                         .build());
 
-        namespaces.run(split("get-auto-topic-creation myprop/clust/ns1"));
-        verify(mockNamespaces).getAutoTopicCreation("myprop/clust/ns1");
+        namespaces.run(split("get-auto-topic-creation mytenant/ns1"));
+        verify(mockNamespaces).getAutoTopicCreation("mytenant/ns1");
 
-        namespaces.run(split("remove-auto-topic-creation myprop/clust/ns1"));
-        verify(mockNamespaces).removeAutoTopicCreation("myprop/clust/ns1");
+        namespaces.run(split("remove-auto-topic-creation mytenant/ns1"));
+        verify(mockNamespaces).removeAutoTopicCreation("mytenant/ns1");
 
-        namespaces.run(split("set-auto-subscription-creation myprop/clust/ns1 -e"));
-        verify(mockNamespaces).setAutoSubscriptionCreation("myprop/clust/ns1",
+        namespaces.run(split("set-auto-subscription-creation mytenant/ns1 -e"));
+        verify(mockNamespaces).setAutoSubscriptionCreation("mytenant/ns1",
                 AutoSubscriptionCreationOverride.builder().allowAutoSubscriptionCreation(true).build());
 
-        namespaces.run(split("get-auto-subscription-creation myprop/clust/ns1"));
-        verify(mockNamespaces).getAutoSubscriptionCreation("myprop/clust/ns1");
+        namespaces.run(split("get-auto-subscription-creation mytenant/ns1"));
+        verify(mockNamespaces).getAutoSubscriptionCreation("mytenant/ns1");
 
-        namespaces.run(split("remove-auto-subscription-creation myprop/clust/ns1"));
-        verify(mockNamespaces).removeAutoSubscriptionCreation("myprop/clust/ns1");
+        namespaces.run(split("remove-auto-subscription-creation mytenant/ns1"));
+        verify(mockNamespaces).removeAutoSubscriptionCreation("mytenant/ns1");
 
-        namespaces.run(split("get-message-ttl myprop/clust/ns1"));
-        verify(mockNamespaces).getNamespaceMessageTTL("myprop/clust/ns1");
+        namespaces.run(split("get-message-ttl mytenant/ns1"));
+        verify(mockNamespaces).getNamespaceMessageTTL("mytenant/ns1");
 
-        namespaces.run(split("get-subscription-expiration-time myprop/clust/ns1"));
-        verify(mockNamespaces).getSubscriptionExpirationTime("myprop/clust/ns1");
+        namespaces.run(split("get-subscription-expiration-time mytenant/ns1"));
+        verify(mockNamespaces).getSubscriptionExpirationTime("mytenant/ns1");
 
-        namespaces.run(split("remove-subscription-expiration-time myprop/clust/ns1"));
-        verify(mockNamespaces).removeSubscriptionExpirationTime("myprop/clust/ns1");
+        namespaces.run(split("remove-subscription-expiration-time mytenant/ns1"));
+        verify(mockNamespaces).removeSubscriptionExpirationTime("mytenant/ns1");
 
-        namespaces.run(split("set-anti-affinity-group myprop/clust/ns1 -g group"));
-        verify(mockNamespaces).setNamespaceAntiAffinityGroup("myprop/clust/ns1", "group");
+        namespaces.run(split("set-anti-affinity-group mytenant/ns1 -g group"));
+        verify(mockNamespaces).setNamespaceAntiAffinityGroup("mytenant/ns1", "group");
 
-        namespaces.run(split("get-anti-affinity-group myprop/clust/ns1"));
-        verify(mockNamespaces).getNamespaceAntiAffinityGroup("myprop/clust/ns1");
+        namespaces.run(split("get-anti-affinity-group mytenant/ns1"));
+        verify(mockNamespaces).getNamespaceAntiAffinityGroup("mytenant/ns1");
 
         namespaces.run(split("get-anti-affinity-namespaces -p dummy -c cluster -g group"));
         verify(mockNamespaces).getAntiAffinityNamespaces("dummy", "cluster", "group");
 
-        namespaces.run(split("delete-anti-affinity-group myprop/clust/ns1 "));
-        verify(mockNamespaces).deleteNamespaceAntiAffinityGroup("myprop/clust/ns1");
+        namespaces.run(split("delete-anti-affinity-group mytenant/ns1 "));
+        verify(mockNamespaces).deleteNamespaceAntiAffinityGroup("mytenant/ns1");
 
 
-        namespaces.run(split("set-retention myprop/clust/ns1 -t 1h -s 1M"));
-        verify(mockNamespaces).setRetention("myprop/clust/ns1",
+        namespaces.run(split("set-retention mytenant/ns1 -t 1h -s 1M"));
+        verify(mockNamespaces).setRetention("mytenant/ns1",
                 new RetentionPolicies(60, 1));
 
         // Test with default time unit (seconds)
         namespaces = new CmdNamespaces(() -> admin);
         reset(mockNamespaces);
-        namespaces.run(split("set-retention myprop/clust/ns1 -t 120 -s 20M"));
-        verify(mockNamespaces).setRetention("myprop/clust/ns1",
+        namespaces.run(split("set-retention mytenant/ns1 -t 120 -s 20M"));
+        verify(mockNamespaces).setRetention("mytenant/ns1",
                 new RetentionPolicies(2, 20));
 
         // Test with explicit time unit (seconds)
         namespaces = new CmdNamespaces(() -> admin);
         reset(mockNamespaces);
-        namespaces.run(split("set-retention myprop/clust/ns1 -t 120s -s 20M"));
-        verify(mockNamespaces).setRetention("myprop/clust/ns1",
+        namespaces.run(split("set-retention mytenant/ns1 -t 120s -s 20M"));
+        verify(mockNamespaces).setRetention("mytenant/ns1",
                 new RetentionPolicies(2, 20));
 
         // Test size with default size less than 1 mb
         namespaces = new CmdNamespaces(() -> admin);
         reset(mockNamespaces);
-        namespaces.run(split("set-retention myprop/clust/ns1 -t 120s -s 4096"));
-        verify(mockNamespaces).setRetention("myprop/clust/ns1",
+        namespaces.run(split("set-retention mytenant/ns1 -t 120s -s 4096"));
+        verify(mockNamespaces).setRetention("mytenant/ns1",
                 new RetentionPolicies(2, 0));
 
         // Test size with default size greater than 1mb
         namespaces = new CmdNamespaces(() -> admin);
         reset(mockNamespaces);
-        namespaces.run(split("set-retention myprop/clust/ns1 -t 180 -s " + (2 * 1024 * 1024)));
-        verify(mockNamespaces).setRetention("myprop/clust/ns1",
+        namespaces.run(split("set-retention mytenant/ns1 -t 180 -s " + (2 * 1024 * 1024)));
+        verify(mockNamespaces).setRetention("mytenant/ns1",
                 new RetentionPolicies(3, 2));
 
-        namespaces.run(split("get-retention myprop/clust/ns1"));
-        verify(mockNamespaces).getRetention("myprop/clust/ns1");
+        namespaces.run(split("get-retention mytenant/ns1"));
+        verify(mockNamespaces).getRetention("mytenant/ns1");
 
-        namespaces.run(split("remove-retention myprop/clust/ns1"));
-        verify(mockNamespaces).removeRetention("myprop/clust/ns1");
+        namespaces.run(split("remove-retention mytenant/ns1"));
+        verify(mockNamespaces).removeRetention("mytenant/ns1");
 
-        namespaces.run(split("set-delayed-delivery myprop/clust/ns1 -e -t 1s -md 5s"));
-        verify(mockNamespaces).setDelayedDeliveryMessages("myprop/clust/ns1",
+        namespaces.run(split("set-delayed-delivery mytenant/ns1 -e -t 1s -md 5s"));
+        verify(mockNamespaces).setDelayedDeliveryMessages("mytenant/ns1",
                 DelayedDeliveryPolicies.builder().tickTime(1000).active(true)
                         .maxDeliveryDelayInMillis(5000).build());
 
-        namespaces.run(split("get-delayed-delivery myprop/clust/ns1"));
-        verify(mockNamespaces).getDelayedDelivery("myprop/clust/ns1");
+        namespaces.run(split("get-delayed-delivery mytenant/ns1"));
+        verify(mockNamespaces).getDelayedDelivery("mytenant/ns1");
 
-        namespaces.run(split("remove-delayed-delivery myprop/clust/ns1"));
-        verify(mockNamespaces).removeDelayedDeliveryMessages("myprop/clust/ns1");
+        namespaces.run(split("remove-delayed-delivery mytenant/ns1"));
+        verify(mockNamespaces).removeDelayedDeliveryMessages("mytenant/ns1");
 
         namespaces.run(split(
-                "set-inactive-topic-policies myprop/clust/ns1 -e -t 1s -m delete_when_no_subscriptions"));
-        verify(mockNamespaces).setInactiveTopicPolicies("myprop/clust/ns1",
+                "set-inactive-topic-policies mytenant/ns1 -e -t 1s -m delete_when_no_subscriptions"));
+        verify(mockNamespaces).setInactiveTopicPolicies("mytenant/ns1",
                 new InactiveTopicPolicies(
                         InactiveTopicDeleteMode.delete_when_no_subscriptions, 1, true));
 
-        namespaces.run(split("get-inactive-topic-policies myprop/clust/ns1"));
-        verify(mockNamespaces).getInactiveTopicPolicies("myprop/clust/ns1");
+        namespaces.run(split("get-inactive-topic-policies mytenant/ns1"));
+        verify(mockNamespaces).getInactiveTopicPolicies("mytenant/ns1");
 
-        namespaces.run(split("remove-inactive-topic-policies myprop/clust/ns1"));
-        verify(mockNamespaces).removeInactiveTopicPolicies("myprop/clust/ns1");
+        namespaces.run(split("remove-inactive-topic-policies mytenant/ns1"));
+        verify(mockNamespaces).removeInactiveTopicPolicies("mytenant/ns1");
 
-        namespaces.run(split("clear-backlog myprop/clust/ns1 -force"));
-        verify(mockNamespaces).clearNamespaceBacklog("myprop/clust/ns1");
-
-        mockNamespaces = mock(Namespaces.class);
-        when(admin.namespaces()).thenReturn(mockNamespaces);
-        namespaces = new CmdNamespaces(() -> admin);
-
-        namespaces.run(split("set-message-ttl myprop/clust/ns1 -ttl 6m"));
-        verify(mockNamespaces).setNamespaceMessageTTL("myprop/clust/ns1", 6 * 60);
-
-        namespaces.run(split("clear-backlog -b 0x80000000_0xffffffff myprop/clust/ns1 -force"));
-        verify(mockNamespaces).clearNamespaceBundleBacklog("myprop/clust/ns1", "0x80000000_0xffffffff");
+        namespaces.run(split("clear-backlog mytenant/ns1 -force"));
+        verify(mockNamespaces).clearNamespaceBacklog("mytenant/ns1");
 
         mockNamespaces = mock(Namespaces.class);
         when(admin.namespaces()).thenReturn(mockNamespaces);
         namespaces = new CmdNamespaces(() -> admin);
 
-        namespaces.run(split("clear-backlog -s my-sub myprop/clust/ns1 -force"));
-        verify(mockNamespaces).clearNamespaceBacklogForSubscription("myprop/clust/ns1", "my-sub");
+        namespaces.run(split("set-message-ttl mytenant/ns1 -ttl 6m"));
+        verify(mockNamespaces).setNamespaceMessageTTL("mytenant/ns1", 6 * 60);
+
+        namespaces.run(split("clear-backlog -b 0x80000000_0xffffffff mytenant/ns1 -force"));
+        verify(mockNamespaces).clearNamespaceBundleBacklog("mytenant/ns1", "0x80000000_0xffffffff");
 
         mockNamespaces = mock(Namespaces.class);
         when(admin.namespaces()).thenReturn(mockNamespaces);
         namespaces = new CmdNamespaces(() -> admin);
 
-        namespaces.run(split("clear-backlog -b 0x80000000_0xffffffff -s my-sub myprop/clust/ns1 -force"));
-        verify(mockNamespaces).clearNamespaceBundleBacklogForSubscription("myprop/clust/ns1",
+        namespaces.run(split("clear-backlog -s my-sub mytenant/ns1 -force"));
+        verify(mockNamespaces).clearNamespaceBacklogForSubscription("mytenant/ns1", "my-sub");
+
+        mockNamespaces = mock(Namespaces.class);
+        when(admin.namespaces()).thenReturn(mockNamespaces);
+        namespaces = new CmdNamespaces(() -> admin);
+
+        namespaces.run(split("clear-backlog -b 0x80000000_0xffffffff -s my-sub mytenant/ns1 -force"));
+        verify(mockNamespaces).clearNamespaceBundleBacklogForSubscription("mytenant/ns1",
                 "0x80000000_0xffffffff", "my-sub");
 
-        namespaces.run(split("unsubscribe -s my-sub myprop/clust/ns1"));
-        verify(mockNamespaces).unsubscribeNamespace("myprop/clust/ns1", "my-sub");
+        namespaces.run(split("unsubscribe -s my-sub mytenant/ns1"));
+        verify(mockNamespaces).unsubscribeNamespace("mytenant/ns1", "my-sub");
 
         mockNamespaces = mock(Namespaces.class);
         when(admin.namespaces()).thenReturn(mockNamespaces);
         namespaces = new CmdNamespaces(() -> admin);
 
-        namespaces.run(split("unsubscribe -b 0x80000000_0xffffffff -s my-sub myprop/clust/ns1"));
-        verify(mockNamespaces).unsubscribeNamespaceBundle("myprop/clust/ns1", "0x80000000_0xffffffff", "my-sub");
+        namespaces.run(split("unsubscribe -b 0x80000000_0xffffffff -s my-sub mytenant/ns1"));
+        verify(mockNamespaces).unsubscribeNamespaceBundle("mytenant/ns1", "0x80000000_0xffffffff", "my-sub");
 
         mockNamespaces = mock(Namespaces.class);
         when(admin.namespaces()).thenReturn(mockNamespaces);
         namespaces = new CmdNamespaces(() -> admin);
 
-        namespaces.run(split("get-max-producers-per-topic myprop/clust/ns1"));
-        verify(mockNamespaces).getMaxProducersPerTopic("myprop/clust/ns1");
+        namespaces.run(split("get-max-producers-per-topic mytenant/ns1"));
+        verify(mockNamespaces).getMaxProducersPerTopic("mytenant/ns1");
 
-        namespaces.run(split("set-max-producers-per-topic myprop/clust/ns1 -p 1"));
-        verify(mockNamespaces).setMaxProducersPerTopic("myprop/clust/ns1", 1);
+        namespaces.run(split("set-max-producers-per-topic mytenant/ns1 -p 1"));
+        verify(mockNamespaces).setMaxProducersPerTopic("mytenant/ns1", 1);
 
-        namespaces.run(split("remove-max-producers-per-topic myprop/clust/ns1"));
-        verify(mockNamespaces).removeMaxProducersPerTopic("myprop/clust/ns1");
+        namespaces.run(split("remove-max-producers-per-topic mytenant/ns1"));
+        verify(mockNamespaces).removeMaxProducersPerTopic("mytenant/ns1");
 
-        namespaces.run(split("get-max-consumers-per-topic myprop/clust/ns1"));
+        namespaces.run(split("get-max-consumers-per-topic mytenant/ns1"));
         verify(mockNamespaces).getMaxConsumersPerTopic("myprop/clust/ns1");
 
         namespaces.run(split("set-max-consumers-per-topic myprop/clust/ns1 -c 2"));
@@ -2307,17 +2307,17 @@ public class PulsarAdminToolTest {
 
         CmdTopics topics = new CmdTopics(() -> admin);
 
-        topics.run(split("stats non-persistent://myprop/ns1/ds1"));
-        verify(mockTopics).getStats("non-persistent://myprop/ns1/ds1", false, true, false);
+        topics.run(split("stats non-persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).getStats("non-persistent://mytenant/ns1/ds1", false, true, false);
 
-        topics.run(split("stats-internal non-persistent://myprop/ns1/ds1"));
-        verify(mockTopics).getInternalStats("non-persistent://myprop/ns1/ds1", false);
+        topics.run(split("stats-internal non-persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).getInternalStats("non-persistent://mytenant/ns1/ds1", false);
 
-        topics.run(split("create-partitioned-topic non-persistent://myprop/ns1/ds1 --partitions 32"));
-        verify(mockTopics).createPartitionedTopic("non-persistent://myprop/ns1/ds1", 32, null);
+        topics.run(split("create-partitioned-topic non-persistent://mytenant/ns1/ds1 --partitions 32"));
+        verify(mockTopics).createPartitionedTopic("non-persistent://mytenant/ns1/ds1", 32, null);
 
-        topics.run(split("list myprop/ns1"));
-        verify(mockTopics).getList("myprop/ns1", null, ListTopicsOptions.EMPTY);
+        topics.run(split("list mytenant/ns1"));
+        verify(mockTopics).getList("mytenant/ns1", null, ListTopicsOptions.EMPTY);
 
         NonPersistentTopics mockNonPersistentTopics = mock(NonPersistentTopics.class);
         when(admin.nonPersistentTopics()).thenReturn(mockNonPersistentTopics);

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.admin.cli;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -415,7 +416,7 @@ public class PulsarAdminToolTest {
         namespaces.run(split("list myprop"));
         verify(mockNamespaces).getNamespaces("myprop");
 
-        namespaces.run(split("list-cluster mytenant"));
+        namespaces.run(split("list-cluster myprop/clust"));
         verify(mockNamespaces).getNamespaces("myprop", "clust");
 
         namespaces.run(split("topics mytenant/ns1"));
@@ -425,7 +426,7 @@ public class PulsarAdminToolTest {
         verify(mockNamespaces).getPolicies("mytenant/ns1");
 
         namespaces.run(split("create mytenant/ns1"));
-        verify(mockNamespaces).createNamespace("mytenant/ns1");
+        verify(mockNamespaces).createNamespace(eq("mytenant/ns1"), any(Policies.class));
 
         namespaces.run(split("delete mytenant/ns1"));
         verify(mockNamespaces).deleteNamespace("mytenant/ns1", false);
@@ -784,144 +785,144 @@ public class PulsarAdminToolTest {
         verify(mockNamespaces).removeMaxProducersPerTopic("mytenant/ns1");
 
         namespaces.run(split("get-max-consumers-per-topic mytenant/ns1"));
-        verify(mockNamespaces).getMaxConsumersPerTopic("myprop/clust/ns1");
+        verify(mockNamespaces).getMaxConsumersPerTopic("mytenant/ns1");
 
-        namespaces.run(split("set-max-consumers-per-topic myprop/clust/ns1 -c 2"));
-        verify(mockNamespaces).setMaxConsumersPerTopic("myprop/clust/ns1", 2);
+        namespaces.run(split("set-max-consumers-per-topic mytenant/ns1 -c 2"));
+        verify(mockNamespaces).setMaxConsumersPerTopic("mytenant/ns1", 2);
 
-        namespaces.run(split("remove-max-consumers-per-topic myprop/clust/ns1"));
-        verify(mockNamespaces).removeMaxConsumersPerTopic("myprop/clust/ns1");
+        namespaces.run(split("remove-max-consumers-per-topic mytenant/ns1"));
+        verify(mockNamespaces).removeMaxConsumersPerTopic("mytenant/ns1");
 
-        namespaces.run(split("get-max-consumers-per-subscription myprop/clust/ns1"));
-        verify(mockNamespaces).getMaxConsumersPerSubscription("myprop/clust/ns1");
+        namespaces.run(split("get-max-consumers-per-subscription mytenant/ns1"));
+        verify(mockNamespaces).getMaxConsumersPerSubscription("mytenant/ns1");
 
-        namespaces.run(split("remove-max-consumers-per-subscription myprop/clust/ns1"));
-        verify(mockNamespaces).removeMaxConsumersPerSubscription("myprop/clust/ns1");
+        namespaces.run(split("remove-max-consumers-per-subscription mytenant/ns1"));
+        verify(mockNamespaces).removeMaxConsumersPerSubscription("mytenant/ns1");
 
-        namespaces.run(split("set-max-consumers-per-subscription myprop/clust/ns1 -c 3"));
-        verify(mockNamespaces).setMaxConsumersPerSubscription("myprop/clust/ns1", 3);
+        namespaces.run(split("set-max-consumers-per-subscription mytenant/ns1 -c 3"));
+        verify(mockNamespaces).setMaxConsumersPerSubscription("mytenant/ns1", 3);
 
-        namespaces.run(split("get-max-unacked-messages-per-subscription myprop/clust/ns1"));
-        verify(mockNamespaces).getMaxUnackedMessagesPerSubscription("myprop/clust/ns1");
+        namespaces.run(split("get-max-unacked-messages-per-subscription mytenant/ns1"));
+        verify(mockNamespaces).getMaxUnackedMessagesPerSubscription("mytenant/ns1");
 
-        namespaces.run(split("set-max-unacked-messages-per-subscription myprop/clust/ns1 -c 3"));
-        verify(mockNamespaces).setMaxUnackedMessagesPerSubscription("myprop/clust/ns1", 3);
+        namespaces.run(split("set-max-unacked-messages-per-subscription mytenant/ns1 -c 3"));
+        verify(mockNamespaces).setMaxUnackedMessagesPerSubscription("mytenant/ns1", 3);
 
-        namespaces.run(split("remove-max-unacked-messages-per-subscription myprop/clust/ns1"));
-        verify(mockNamespaces).removeMaxUnackedMessagesPerSubscription("myprop/clust/ns1");
+        namespaces.run(split("remove-max-unacked-messages-per-subscription mytenant/ns1"));
+        verify(mockNamespaces).removeMaxUnackedMessagesPerSubscription("mytenant/ns1");
 
-        namespaces.run(split("get-max-unacked-messages-per-consumer myprop/clust/ns1"));
-        verify(mockNamespaces).getMaxUnackedMessagesPerConsumer("myprop/clust/ns1");
+        namespaces.run(split("get-max-unacked-messages-per-consumer mytenant/ns1"));
+        verify(mockNamespaces).getMaxUnackedMessagesPerConsumer("mytenant/ns1");
 
-        namespaces.run(split("set-max-unacked-messages-per-consumer myprop/clust/ns1 -c 3"));
-        verify(mockNamespaces).setMaxUnackedMessagesPerConsumer("myprop/clust/ns1", 3);
+        namespaces.run(split("set-max-unacked-messages-per-consumer mytenant/ns1 -c 3"));
+        verify(mockNamespaces).setMaxUnackedMessagesPerConsumer("mytenant/ns1", 3);
 
-        namespaces.run(split("remove-max-unacked-messages-per-consumer myprop/clust/ns1"));
-        verify(mockNamespaces).removeMaxUnackedMessagesPerConsumer("myprop/clust/ns1");
+        namespaces.run(split("remove-max-unacked-messages-per-consumer mytenant/ns1"));
+        verify(mockNamespaces).removeMaxUnackedMessagesPerConsumer("mytenant/ns1");
 
         mockNamespaces = mock(Namespaces.class);
         when(admin.namespaces()).thenReturn(mockNamespaces);
         namespaces = new CmdNamespaces(() -> admin);
 
-        namespaces.run(split("set-dispatch-rate myprop/clust/ns1 -md -1 -bd -1 -dt 2"));
-        verify(mockNamespaces).setDispatchRate("myprop/clust/ns1", DispatchRate.builder()
+        namespaces.run(split("set-dispatch-rate mytenant/ns1 -md -1 -bd -1 -dt 2"));
+        verify(mockNamespaces).setDispatchRate("mytenant/ns1", DispatchRate.builder()
                 .dispatchThrottlingRateInMsg(-1)
                 .dispatchThrottlingRateInByte(-1)
                 .ratePeriodInSecond(2)
                 .build());
 
-        namespaces.run(split("get-dispatch-rate myprop/clust/ns1"));
-        verify(mockNamespaces).getDispatchRate("myprop/clust/ns1");
+        namespaces.run(split("get-dispatch-rate mytenant/ns1"));
+        verify(mockNamespaces).getDispatchRate("mytenant/ns1");
 
-        namespaces.run(split("remove-dispatch-rate myprop/clust/ns1"));
-        verify(mockNamespaces).removeDispatchRate("myprop/clust/ns1");
+        namespaces.run(split("remove-dispatch-rate mytenant/ns1"));
+        verify(mockNamespaces).removeDispatchRate("mytenant/ns1");
 
-        namespaces.run(split("set-publish-rate myprop/clust/ns1 -m 10 -b 20"));
-        verify(mockNamespaces).setPublishRate("myprop/clust/ns1", new PublishRate(10, 20));
+        namespaces.run(split("set-publish-rate mytenant/ns1 -m 10 -b 20"));
+        verify(mockNamespaces).setPublishRate("mytenant/ns1", new PublishRate(10, 20));
 
-        namespaces.run(split("get-publish-rate myprop/clust/ns1"));
-        verify(mockNamespaces).getPublishRate("myprop/clust/ns1");
+        namespaces.run(split("get-publish-rate mytenant/ns1"));
+        verify(mockNamespaces).getPublishRate("mytenant/ns1");
 
-        namespaces.run(split("remove-publish-rate myprop/clust/ns1"));
-        verify(mockNamespaces).removePublishRate("myprop/clust/ns1");
+        namespaces.run(split("remove-publish-rate mytenant/ns1"));
+        verify(mockNamespaces).removePublishRate("mytenant/ns1");
 
-        namespaces.run(split("set-subscribe-rate myprop/clust/ns1 -sr 2 -st 60"));
-        verify(mockNamespaces).setSubscribeRate("myprop/clust/ns1", new SubscribeRate(2, 60));
+        namespaces.run(split("set-subscribe-rate mytenant/ns1 -sr 2 -st 60"));
+        verify(mockNamespaces).setSubscribeRate("mytenant/ns1", new SubscribeRate(2, 60));
 
-        namespaces.run(split("get-subscribe-rate myprop/clust/ns1"));
-        verify(mockNamespaces).getSubscribeRate("myprop/clust/ns1");
+        namespaces.run(split("get-subscribe-rate mytenant/ns1"));
+        verify(mockNamespaces).getSubscribeRate("mytenant/ns1");
 
-        namespaces.run(split("remove-subscribe-rate myprop/clust/ns1"));
-        verify(mockNamespaces).removeSubscribeRate("myprop/clust/ns1");
+        namespaces.run(split("remove-subscribe-rate mytenant/ns1"));
+        verify(mockNamespaces).removeSubscribeRate("mytenant/ns1");
 
-        namespaces.run(split("set-subscription-dispatch-rate myprop/clust/ns1 -md -1 -bd -1 -dt 2"));
-        verify(mockNamespaces).setSubscriptionDispatchRate("myprop/clust/ns1", DispatchRate.builder()
+        namespaces.run(split("set-subscription-dispatch-rate mytenant/ns1 -md -1 -bd -1 -dt 2"));
+        verify(mockNamespaces).setSubscriptionDispatchRate("mytenant/ns1", DispatchRate.builder()
                 .dispatchThrottlingRateInMsg(-1)
                 .dispatchThrottlingRateInByte(-1)
                 .ratePeriodInSecond(2)
                 .build());
 
-        namespaces.run(split("get-subscription-dispatch-rate myprop/clust/ns1"));
-        verify(mockNamespaces).getSubscriptionDispatchRate("myprop/clust/ns1");
+        namespaces.run(split("get-subscription-dispatch-rate mytenant/ns1"));
+        verify(mockNamespaces).getSubscriptionDispatchRate("mytenant/ns1");
 
-        namespaces.run(split("remove-subscription-dispatch-rate myprop/clust/ns1"));
-        verify(mockNamespaces).removeSubscriptionDispatchRate("myprop/clust/ns1");
+        namespaces.run(split("remove-subscription-dispatch-rate mytenant/ns1"));
+        verify(mockNamespaces).removeSubscriptionDispatchRate("mytenant/ns1");
 
-        namespaces.run(split("get-compaction-threshold myprop/clust/ns1"));
-        verify(mockNamespaces).getCompactionThreshold("myprop/clust/ns1");
+        namespaces.run(split("get-compaction-threshold mytenant/ns1"));
+        verify(mockNamespaces).getCompactionThreshold("mytenant/ns1");
 
-        namespaces.run(split("remove-compaction-threshold myprop/clust/ns1"));
-        verify(mockNamespaces).removeCompactionThreshold("myprop/clust/ns1");
+        namespaces.run(split("remove-compaction-threshold mytenant/ns1"));
+        verify(mockNamespaces).removeCompactionThreshold("mytenant/ns1");
 
-        namespaces.run(split("set-compaction-threshold myprop/clust/ns1 -t 1G"));
-        verify(mockNamespaces).setCompactionThreshold("myprop/clust/ns1", 1024 * 1024 * 1024);
+        namespaces.run(split("set-compaction-threshold mytenant/ns1 -t 1G"));
+        verify(mockNamespaces).setCompactionThreshold("mytenant/ns1", 1024 * 1024 * 1024);
 
-        namespaces.run(split("get-offload-threshold myprop/clust/ns1"));
-        verify(mockNamespaces).getOffloadThreshold("myprop/clust/ns1");
+        namespaces.run(split("get-offload-threshold mytenant/ns1"));
+        verify(mockNamespaces).getOffloadThreshold("mytenant/ns1");
 
-        namespaces.run(split("set-offload-threshold myprop/clust/ns1 -s 1G"));
-        verify(mockNamespaces).setOffloadThreshold("myprop/clust/ns1", 1024 * 1024 * 1024);
+        namespaces.run(split("set-offload-threshold mytenant/ns1 -s 1G"));
+        verify(mockNamespaces).setOffloadThreshold("mytenant/ns1", 1024 * 1024 * 1024);
 
-        namespaces.run(split("get-offload-deletion-lag myprop/clust/ns1"));
-        verify(mockNamespaces).getOffloadDeleteLagMs("myprop/clust/ns1");
+        namespaces.run(split("get-offload-deletion-lag mytenant/ns1"));
+        verify(mockNamespaces).getOffloadDeleteLagMs("mytenant/ns1");
 
-        namespaces.run(split("set-offload-deletion-lag myprop/clust/ns1 -l 1d"));
-        verify(mockNamespaces).setOffloadDeleteLag("myprop/clust/ns1", 24 * 60 * 60, TimeUnit.SECONDS);
+        namespaces.run(split("set-offload-deletion-lag mytenant/ns1 -l 1d"));
+        verify(mockNamespaces).setOffloadDeleteLag("mytenant/ns1", 24 * 60 * 60, TimeUnit.SECONDS);
 
-        namespaces.run(split("clear-offload-deletion-lag myprop/clust/ns1"));
-        verify(mockNamespaces).clearOffloadDeleteLag("myprop/clust/ns1");
+        namespaces.run(split("clear-offload-deletion-lag mytenant/ns1"));
+        verify(mockNamespaces).clearOffloadDeleteLag("mytenant/ns1");
 
-        namespaces.run(split("set-offload-policies myprop/clust/ns1 -r test-region -d aws-s3 -b test-bucket "
+        namespaces.run(split("set-offload-policies mytenant/ns1 -r test-region -d aws-s3 -b test-bucket "
                 + "-e http://test.endpoint -mbs 32M -rbs 5M -oat 10M -oats 100 -oae 10s -orp tiered-storage-first"));
-        verify(mockNamespaces).setOffloadPolicies("myprop/clust/ns1",
+        verify(mockNamespaces).setOffloadPolicies("mytenant/ns1",
                 OffloadPoliciesImpl.create("aws-s3", "test-region", "test-bucket",
                         "http://test.endpoint", null, null, null, null, 32 * 1024 * 1024, 5 * 1024 * 1024,
                         10 * 1024 * 1024L, 100L, 10000L, OffloadedReadPriority.TIERED_STORAGE_FIRST));
 
-        namespaces.run(split("remove-offload-policies myprop/clust/ns1"));
-        verify(mockNamespaces).removeOffloadPolicies("myprop/clust/ns1");
+        namespaces.run(split("remove-offload-policies mytenant/ns1"));
+        verify(mockNamespaces).removeOffloadPolicies("mytenant/ns1");
 
-        namespaces.run(split("get-offload-policies myprop/clust/ns1"));
-        verify(mockNamespaces).getOffloadPolicies("myprop/clust/ns1");
+        namespaces.run(split("get-offload-policies mytenant/ns1"));
+        verify(mockNamespaces).getOffloadPolicies("mytenant/ns1");
 
-        namespaces.run(split("remove-message-ttl myprop/clust/ns1"));
-        verify(mockNamespaces).removeNamespaceMessageTTL("myprop/clust/ns1");
+        namespaces.run(split("remove-message-ttl mytenant/ns1"));
+        verify(mockNamespaces).removeNamespaceMessageTTL("mytenant/ns1");
 
-        namespaces.run(split("set-deduplication-snapshot-interval myprop/clust/ns1 -i 1000"));
-        verify(mockNamespaces).setDeduplicationSnapshotInterval("myprop/clust/ns1", 1000);
-        namespaces.run(split("get-deduplication-snapshot-interval myprop/clust/ns1"));
-        verify(mockNamespaces).getDeduplicationSnapshotInterval("myprop/clust/ns1");
-        namespaces.run(split("remove-deduplication-snapshot-interval myprop/clust/ns1"));
-        verify(mockNamespaces).removeDeduplicationSnapshotInterval("myprop/clust/ns1");
+        namespaces.run(split("set-deduplication-snapshot-interval mytenant/ns1 -i 1000"));
+        verify(mockNamespaces).setDeduplicationSnapshotInterval("mytenant/ns1", 1000);
+        namespaces.run(split("get-deduplication-snapshot-interval mytenant/ns1"));
+        verify(mockNamespaces).getDeduplicationSnapshotInterval("mytenant/ns1");
+        namespaces.run(split("remove-deduplication-snapshot-interval mytenant/ns1"));
+        verify(mockNamespaces).removeDeduplicationSnapshotInterval("mytenant/ns1");
 
-        namespaces.run(split("set-dispatcher-pause-on-ack-state-persistent myprop/clust/ns1"));
-        verify(mockNamespaces).setDispatcherPauseOnAckStatePersistent("myprop/clust/ns1");
+        namespaces.run(split("set-dispatcher-pause-on-ack-state-persistent mytenant/ns1"));
+        verify(mockNamespaces).setDispatcherPauseOnAckStatePersistent("mytenant/ns1");
 
-        namespaces.run(split("get-dispatcher-pause-on-ack-state-persistent myprop/clust/ns1"));
-        verify(mockNamespaces).getDispatcherPauseOnAckStatePersistent("myprop/clust/ns1");
+        namespaces.run(split("get-dispatcher-pause-on-ack-state-persistent mytenant/ns1"));
+        verify(mockNamespaces).getDispatcherPauseOnAckStatePersistent("mytenant/ns1");
 
-        namespaces.run(split("remove-dispatcher-pause-on-ack-state-persistent myprop/clust/ns1"));
-        verify(mockNamespaces).removeDispatcherPauseOnAckStatePersistent("myprop/clust/ns1");
+        namespaces.run(split("remove-dispatcher-pause-on-ack-state-persistent mytenant/ns1"));
+        verify(mockNamespaces).removeDispatcherPauseOnAckStatePersistent("mytenant/ns1");
 
     }
 
@@ -956,11 +957,11 @@ public class PulsarAdminToolTest {
         when(admin.namespaces()).thenReturn(mockNamespaces);
         CmdNamespaces namespaces = new CmdNamespaces(() -> admin);
 
-        namespaces.run(split("create my-prop/my-namespace"));
+        namespaces.run(split("create my-tenant/my-namespace"));
 
         Policies policies = new Policies();
         policies.bundles = null;
-        verify(mockNamespaces).createNamespace("my-prop/my-namespace", policies);
+        verify(mockNamespaces).createNamespace("my-tenant/my-namespace", policies);
     }
 
     @Test
@@ -970,12 +971,12 @@ public class PulsarAdminToolTest {
         when(admin.namespaces()).thenReturn(mockNamespaces);
         CmdNamespaces namespaces = new CmdNamespaces(() -> admin);
 
-        namespaces.run(split("create my-prop/my-namespace --bundles 5 --clusters a,b,c"));
+        namespaces.run(split("create my-tenant/my-namespace --bundles 5 --clusters a,b,c"));
 
         Policies policies = new Policies();
         policies.bundles = BundlesData.builder().numBundles(5).build();
         policies.replication_clusters = Sets.newHashSet("a", "b", "c");
-        verify(mockNamespaces).createNamespace("my-prop/my-namespace", policies);
+        verify(mockNamespaces).createNamespace("my-tenant/my-namespace", policies);
     }
 
     @Test
@@ -1004,17 +1005,17 @@ public class PulsarAdminToolTest {
         when(admin.resourceQuotas()).thenReturn(mockResourceQuotas);
         cmdResourceQuotas = new CmdResourceQuotas(() -> admin);
 
-        cmdResourceQuotas.run(split("get --namespace myprop/clust/ns1 --bundle 0x80000000_0xffffffff"));
-        verify(mockResourceQuotas).getNamespaceBundleResourceQuota("myprop/clust/ns1", "0x80000000_0xffffffff");
+        cmdResourceQuotas.run(split("get --namespace mytenant/ns1 --bundle 0x80000000_0xffffffff"));
+        verify(mockResourceQuotas).getNamespaceBundleResourceQuota("mytenant/ns1", "0x80000000_0xffffffff");
 
-        cmdResourceQuotas.run(split("set --namespace myprop/clust/ns1 --bundle 0x80000000_0xffffffff -mi "
+        cmdResourceQuotas.run(split("set --namespace mytenant/ns1 --bundle 0x80000000_0xffffffff -mi "
                 + "10 -mo 20 -bi 10000 -bo 20000 -mem 100"));
-        verify(mockResourceQuotas).setNamespaceBundleResourceQuota("myprop/clust/ns1",
+        verify(mockResourceQuotas).setNamespaceBundleResourceQuota("mytenant/ns1",
                 "0x80000000_0xffffffff", quota);
 
-        cmdResourceQuotas.run(split("reset-namespace-bundle-quota --namespace myprop/clust/ns1 --bundle "
+        cmdResourceQuotas.run(split("reset-namespace-bundle-quota --namespace mytenant/ns1 --bundle "
                 + "0x80000000_0xffffffff"));
-        verify(mockResourceQuotas).resetNamespaceBundleResourceQuota("myprop/clust/ns1",
+        verify(mockResourceQuotas).resetNamespaceBundleResourceQuota("mytenant/ns1",
                 "0x80000000_0xffffffff");
     }
 
@@ -1048,266 +1049,266 @@ public class PulsarAdminToolTest {
 
         CmdTopicPolicies cmdTopics = new CmdTopicPolicies(() -> admin);
 
-        cmdTopics.run(split("set-subscription-types-enabled persistent://myprop/clust/ns1/ds1 -t Shared,Failover"));
-        verify(mockTopicsPolicies).setSubscriptionTypesEnabled("persistent://myprop/clust/ns1/ds1",
+        cmdTopics.run(split("set-subscription-types-enabled persistent://mytenant/ns1/ds1 -t Shared,Failover"));
+        verify(mockTopicsPolicies).setSubscriptionTypesEnabled("persistent://mytenant/ns1/ds1",
                 Sets.newHashSet(SubscriptionType.Shared, SubscriptionType.Failover));
-        cmdTopics.run(split("get-subscription-types-enabled persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopicsPolicies).getSubscriptionTypesEnabled("persistent://myprop/clust/ns1/ds1");
-        cmdTopics.run(split("remove-subscription-types-enabled persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopicsPolicies).removeSubscriptionTypesEnabled("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("get-subscription-types-enabled persistent://mytenant/ns1/ds1"));
+        verify(mockTopicsPolicies).getSubscriptionTypesEnabled("persistent://mytenant/ns1/ds1");
+        cmdTopics.run(split("remove-subscription-types-enabled persistent://mytenant/ns1/ds1"));
+        verify(mockTopicsPolicies).removeSubscriptionTypesEnabled("persistent://mytenant/ns1/ds1");
 
-        cmdTopics.run(split("get-offload-policies persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopicsPolicies).getOffloadPolicies("persistent://myprop/clust/ns1/ds1", false);
+        cmdTopics.run(split("get-offload-policies persistent://mytenant/ns1/ds1"));
+        verify(mockTopicsPolicies).getOffloadPolicies("persistent://mytenant/ns1/ds1", false);
 
-        cmdTopics.run(split("remove-offload-policies persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopicsPolicies).removeOffloadPolicies("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("remove-offload-policies persistent://mytenant/ns1/ds1"));
+        verify(mockTopicsPolicies).removeOffloadPolicies("persistent://mytenant/ns1/ds1");
 
-        cmdTopics.run(split("set-offload-policies persistent://myprop/clust/ns1/ds1 -d s3 -r"
+        cmdTopics.run(split("set-offload-policies persistent://mytenant/ns1/ds1 -d s3 -r"
                 + " region -b bucket -e endpoint -m 8 -rb 9 -t 10 -ts 10 -orp tiered-storage-first"));
         verify(mockTopicsPolicies)
-                .setOffloadPolicies("persistent://myprop/clust/ns1/ds1", OffloadPoliciesImpl.create(
+                .setOffloadPolicies("persistent://mytenant/ns1/ds1", OffloadPoliciesImpl.create(
                         "s3", "region", "bucket" , "endpoint", null, null, null,
                         null, 8, 9, 10L,
                         10L, null, OffloadedReadPriority.TIERED_STORAGE_FIRST));
 
-        cmdTopics.run(split("get-retention persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopicsPolicies).getRetention("persistent://myprop/clust/ns1/ds1", false);
-        cmdTopics.run(split("set-retention persistent://myprop/clust/ns1/ds1 -t 10m -s 20M"));
-        verify(mockTopicsPolicies).setRetention("persistent://myprop/clust/ns1/ds1",
+        cmdTopics.run(split("get-retention persistent://mytenant/ns1/ds1"));
+        verify(mockTopicsPolicies).getRetention("persistent://mytenant/ns1/ds1", false);
+        cmdTopics.run(split("set-retention persistent://mytenant/ns1/ds1 -t 10m -s 20M"));
+        verify(mockTopicsPolicies).setRetention("persistent://mytenant/ns1/ds1",
                 new RetentionPolicies(10, 20));
 
         // Test with default time unit (seconds)
         cmdTopics = new CmdTopicPolicies(() -> admin);
         reset(mockTopicsPolicies);
-        cmdTopics.run(split("set-retention persistent://myprop/clust/ns1/ds1 -t 180 -s 20M"));
-        verify(mockTopicsPolicies).setRetention("persistent://myprop/clust/ns1/ds1",
+        cmdTopics.run(split("set-retention persistent://mytenant/ns1/ds1 -t 180 -s 20M"));
+        verify(mockTopicsPolicies).setRetention("persistent://mytenant/ns1/ds1",
                 new RetentionPolicies(3, 20));
 
         // Test with explicit time unit (seconds)
         cmdTopics = new CmdTopicPolicies(() -> admin);
         reset(mockTopicsPolicies);
-        cmdTopics.run(split("set-retention persistent://myprop/clust/ns1/ds1 -t 180s -s 20M"));
-        verify(mockTopicsPolicies).setRetention("persistent://myprop/clust/ns1/ds1",
+        cmdTopics.run(split("set-retention persistent://mytenant/ns1/ds1 -t 180s -s 20M"));
+        verify(mockTopicsPolicies).setRetention("persistent://mytenant/ns1/ds1",
                 new RetentionPolicies(3, 20));
 
         // Test size with default size less than 1 mb
         cmdTopics = new CmdTopicPolicies(() -> admin);
         reset(mockTopicsPolicies);
-        cmdTopics.run(split("set-retention persistent://myprop/clust/ns1/ds1 -t 180 -s 4096"));
-        verify(mockTopicsPolicies).setRetention("persistent://myprop/clust/ns1/ds1",
+        cmdTopics.run(split("set-retention persistent://mytenant/ns1/ds1 -t 180 -s 4096"));
+        verify(mockTopicsPolicies).setRetention("persistent://mytenant/ns1/ds1",
                 new RetentionPolicies(3, 0));
 
         // Test size with default size greater than 1mb
         cmdTopics = new CmdTopicPolicies(() -> admin);
         reset(mockTopicsPolicies);
-        cmdTopics.run(split("set-retention persistent://myprop/clust/ns1/ds1 -t 180 -s " + (2 * 1024 * 1024)));
-        verify(mockTopicsPolicies).setRetention("persistent://myprop/clust/ns1/ds1",
+        cmdTopics.run(split("set-retention persistent://mytenant/ns1/ds1 -t 180 -s " + (2 * 1024 * 1024)));
+        verify(mockTopicsPolicies).setRetention("persistent://mytenant/ns1/ds1",
                 new RetentionPolicies(3, 2));
 
-        cmdTopics.run(split("remove-retention persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopicsPolicies).removeRetention("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("remove-retention persistent://mytenant/ns1/ds1"));
+        verify(mockTopicsPolicies).removeRetention("persistent://mytenant/ns1/ds1");
 
-        cmdTopics.run(split("get-inactive-topic-policies persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopicsPolicies).getInactiveTopicPolicies("persistent://myprop/clust/ns1/ds1", false);
-        cmdTopics.run(split("remove-inactive-topic-policies persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopicsPolicies).removeInactiveTopicPolicies("persistent://myprop/clust/ns1/ds1");
-        cmdTopics.run(split("set-inactive-topic-policies persistent://myprop/clust/ns1/ds1"
+        cmdTopics.run(split("get-inactive-topic-policies persistent://mytenant/ns1/ds1"));
+        verify(mockTopicsPolicies).getInactiveTopicPolicies("persistent://mytenant/ns1/ds1", false);
+        cmdTopics.run(split("remove-inactive-topic-policies persistent://mytenant/ns1/ds1"));
+        verify(mockTopicsPolicies).removeInactiveTopicPolicies("persistent://mytenant/ns1/ds1");
+        cmdTopics.run(split("set-inactive-topic-policies persistent://mytenant/ns1/ds1"
                 + " -e -t 1s -m delete_when_no_subscriptions"));
-        verify(mockTopicsPolicies).setInactiveTopicPolicies("persistent://myprop/clust/ns1/ds1",
+        verify(mockTopicsPolicies).setInactiveTopicPolicies("persistent://mytenant/ns1/ds1",
                 new InactiveTopicPolicies(
                         InactiveTopicDeleteMode.delete_when_no_subscriptions, 1, true));
-        cmdTopics.run(split("get-compaction-threshold persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopicsPolicies).getCompactionThreshold("persistent://myprop/clust/ns1/ds1", false);
-        cmdTopics.run(split("set-compaction-threshold persistent://myprop/clust/ns1/ds1 -t 10k"));
-        verify(mockTopicsPolicies).setCompactionThreshold("persistent://myprop/clust/ns1/ds1", 10 * 1024);
-        cmdTopics.run(split("remove-compaction-threshold persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopicsPolicies).removeCompactionThreshold("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("get-compaction-threshold persistent://mytenant/ns1/ds1"));
+        verify(mockTopicsPolicies).getCompactionThreshold("persistent://mytenant/ns1/ds1", false);
+        cmdTopics.run(split("set-compaction-threshold persistent://mytenant/ns1/ds1 -t 10k"));
+        verify(mockTopicsPolicies).setCompactionThreshold("persistent://mytenant/ns1/ds1", 10 * 1024);
+        cmdTopics.run(split("remove-compaction-threshold persistent://mytenant/ns1/ds1"));
+        verify(mockTopicsPolicies).removeCompactionThreshold("persistent://mytenant/ns1/ds1");
 
-        cmdTopics.run(split("get-max-producers persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopicsPolicies).getMaxProducers("persistent://myprop/clust/ns1/ds1", false);
-        cmdTopics.run(split("remove-max-producers persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopicsPolicies).removeMaxProducers("persistent://myprop/clust/ns1/ds1");
-        cmdTopics.run(split("set-max-producers persistent://myprop/clust/ns1/ds1 -p 99"));
-        verify(mockTopicsPolicies).setMaxProducers("persistent://myprop/clust/ns1/ds1", 99);
+        cmdTopics.run(split("get-max-producers persistent://mytenant/ns1/ds1"));
+        verify(mockTopicsPolicies).getMaxProducers("persistent://mytenant/ns1/ds1", false);
+        cmdTopics.run(split("remove-max-producers persistent://mytenant/ns1/ds1"));
+        verify(mockTopicsPolicies).removeMaxProducers("persistent://mytenant/ns1/ds1");
+        cmdTopics.run(split("set-max-producers persistent://mytenant/ns1/ds1 -p 99"));
+        verify(mockTopicsPolicies).setMaxProducers("persistent://mytenant/ns1/ds1", 99);
 
-        cmdTopics.run(split("get-dispatch-rate persistent://myprop/clust/ns1/ds1 -ap"));
-        verify(mockTopicsPolicies).getDispatchRate("persistent://myprop/clust/ns1/ds1", true);
-        cmdTopics.run(split("remove-dispatch-rate persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopicsPolicies).removeDispatchRate("persistent://myprop/clust/ns1/ds1");
-        cmdTopics.run(split("set-dispatch-rate persistent://myprop/clust/ns1/ds1 -md -1 -bd -1 -dt 2"));
-        verify(mockTopicsPolicies).setDispatchRate("persistent://myprop/clust/ns1/ds1", DispatchRate.builder()
+        cmdTopics.run(split("get-dispatch-rate persistent://mytenant/ns1/ds1 -ap"));
+        verify(mockTopicsPolicies).getDispatchRate("persistent://mytenant/ns1/ds1", true);
+        cmdTopics.run(split("remove-dispatch-rate persistent://mytenant/ns1/ds1"));
+        verify(mockTopicsPolicies).removeDispatchRate("persistent://mytenant/ns1/ds1");
+        cmdTopics.run(split("set-dispatch-rate persistent://mytenant/ns1/ds1 -md -1 -bd -1 -dt 2"));
+        verify(mockTopicsPolicies).setDispatchRate("persistent://mytenant/ns1/ds1", DispatchRate.builder()
                 .dispatchThrottlingRateInMsg(-1)
                 .dispatchThrottlingRateInByte(-1)
                 .ratePeriodInSecond(2)
                 .build());
 
-        cmdTopics.run(split("set-replicator-dispatch-rate persistent://myprop/clust/ns1/ds1 -md -1 -bd -1 -dt 2"));
-        verify(mockTopicsPolicies).setReplicatorDispatchRate("persistent://myprop/clust/ns1/ds1",
+        cmdTopics.run(split("set-replicator-dispatch-rate persistent://mytenant/ns1/ds1 -md -1 -bd -1 -dt 2"));
+        verify(mockTopicsPolicies).setReplicatorDispatchRate("persistent://mytenant/ns1/ds1",
                 DispatchRate.builder()
                         .dispatchThrottlingRateInMsg(-1)
                         .dispatchThrottlingRateInByte(-1)
                         .ratePeriodInSecond(2)
                         .build());
-        cmdTopics.run(split("get-replicator-dispatch-rate persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopicsPolicies).getReplicatorDispatchRate("persistent://myprop/clust/ns1/ds1", false);
-        cmdTopics.run(split("remove-replicator-dispatch-rate persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopicsPolicies).removeReplicatorDispatchRate("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("get-replicator-dispatch-rate persistent://mytenant/ns1/ds1"));
+        verify(mockTopicsPolicies).getReplicatorDispatchRate("persistent://mytenant/ns1/ds1", false);
+        cmdTopics.run(split("remove-replicator-dispatch-rate persistent://mytenant/ns1/ds1"));
+        verify(mockTopicsPolicies).removeReplicatorDispatchRate("persistent://mytenant/ns1/ds1");
 
-        cmdTopics.run(split("set-subscription-dispatch-rate persistent://myprop/clust/ns1/ds1 -md -1 -bd -1 -dt 2"));
-        verify(mockTopicsPolicies).setSubscriptionDispatchRate("persistent://myprop/clust/ns1/ds1",
+        cmdTopics.run(split("set-subscription-dispatch-rate persistent://mytenant/ns1/ds1 -md -1 -bd -1 -dt 2"));
+        verify(mockTopicsPolicies).setSubscriptionDispatchRate("persistent://mytenant/ns1/ds1",
                 DispatchRate.builder()
                         .dispatchThrottlingRateInMsg(-1)
                         .dispatchThrottlingRateInByte(-1)
                         .ratePeriodInSecond(2)
                         .build());
-        cmdTopics.run(split("get-subscription-dispatch-rate persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopicsPolicies).getSubscriptionDispatchRate("persistent://myprop/clust/ns1/ds1", false);
-        cmdTopics.run(split("remove-subscription-dispatch-rate persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopicsPolicies).removeSubscriptionDispatchRate("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("get-subscription-dispatch-rate persistent://mytenant/ns1/ds1"));
+        verify(mockTopicsPolicies).getSubscriptionDispatchRate("persistent://mytenant/ns1/ds1", false);
+        cmdTopics.run(split("remove-subscription-dispatch-rate persistent://mytenant/ns1/ds1"));
+        verify(mockTopicsPolicies).removeSubscriptionDispatchRate("persistent://mytenant/ns1/ds1");
 
         cmdTopics = new CmdTopicPolicies(() -> admin);
         cmdTopics.run(split(
-                "set-subscription-dispatch-rate persistent://myprop/clust/ns1/ds1 -s sub -md -1 -bd -1 -dt 3"));
-        verify(mockTopicsPolicies).setSubscriptionDispatchRate("persistent://myprop/clust/ns1/ds1", "sub",
+                "set-subscription-dispatch-rate persistent://mytenant/ns1/ds1 -s sub -md -1 -bd -1 -dt 3"));
+        verify(mockTopicsPolicies).setSubscriptionDispatchRate("persistent://mytenant/ns1/ds1", "sub",
                 DispatchRate.builder()
                         .dispatchThrottlingRateInMsg(-1)
                         .dispatchThrottlingRateInByte(-1)
                         .ratePeriodInSecond(3)
                         .build());
-        cmdTopics.run(split("get-subscription-dispatch-rate persistent://myprop/clust/ns1/ds1 -s sub"));
-        verify(mockTopicsPolicies).getSubscriptionDispatchRate("persistent://myprop/clust/ns1/ds1",
+        cmdTopics.run(split("get-subscription-dispatch-rate persistent://mytenant/ns1/ds1 -s sub"));
+        verify(mockTopicsPolicies).getSubscriptionDispatchRate("persistent://mytenant/ns1/ds1",
                 "sub", false);
-        cmdTopics.run(split("remove-subscription-dispatch-rate persistent://myprop/clust/ns1/ds1 -s sub"));
-        verify(mockTopicsPolicies).removeSubscriptionDispatchRate("persistent://myprop/clust/ns1/ds1",
+        cmdTopics.run(split("remove-subscription-dispatch-rate persistent://mytenant/ns1/ds1 -s sub"));
+        verify(mockTopicsPolicies).removeSubscriptionDispatchRate("persistent://mytenant/ns1/ds1",
                 "sub");
 
-        cmdTopics.run(split("get-persistence persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopicsPolicies).getPersistence("persistent://myprop/clust/ns1/ds1");
-        cmdTopics.run(split("set-persistence persistent://myprop/clust/ns1/ds1 -e 2 -w 1 -a 1 -r 100.0"));
-        verify(mockTopicsPolicies).setPersistence("persistent://myprop/clust/ns1/ds1",
+        cmdTopics.run(split("get-persistence persistent://mytenant/ns1/ds1"));
+        verify(mockTopicsPolicies).getPersistence("persistent://mytenant/ns1/ds1");
+        cmdTopics.run(split("set-persistence persistent://mytenant/ns1/ds1 -e 2 -w 1 -a 1 -r 100.0"));
+        verify(mockTopicsPolicies).setPersistence("persistent://mytenant/ns1/ds1",
                 new PersistencePolicies(2, 1, 1, 100.0d));
-        cmdTopics.run(split("remove-persistence persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopicsPolicies).removePersistence("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("remove-persistence persistent://mytenant/ns1/ds1"));
+        verify(mockTopicsPolicies).removePersistence("persistent://mytenant/ns1/ds1");
 
-        cmdTopics.run(split("get-publish-rate persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopicsPolicies).getPublishRate("persistent://myprop/clust/ns1/ds1");
-        cmdTopics.run(split("set-publish-rate persistent://myprop/clust/ns1/ds1 -m 10 -b 100"));
-        verify(mockTopicsPolicies).setPublishRate("persistent://myprop/clust/ns1/ds1", new PublishRate(10, 100));
-        cmdTopics.run(split("remove-publish-rate persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopicsPolicies).removePublishRate("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("get-publish-rate persistent://mytenant/ns1/ds1"));
+        verify(mockTopicsPolicies).getPublishRate("persistent://mytenant/ns1/ds1");
+        cmdTopics.run(split("set-publish-rate persistent://mytenant/ns1/ds1 -m 10 -b 100"));
+        verify(mockTopicsPolicies).setPublishRate("persistent://mytenant/ns1/ds1", new PublishRate(10, 100));
+        cmdTopics.run(split("remove-publish-rate persistent://mytenant/ns1/ds1"));
+        verify(mockTopicsPolicies).removePublishRate("persistent://mytenant/ns1/ds1");
 
-        cmdTopics.run(split("get-subscribe-rate persistent://myprop/clust/ns1/ds1 -ap"));
-        verify(mockTopicsPolicies).getSubscribeRate("persistent://myprop/clust/ns1/ds1", true);
-        cmdTopics.run(split("set-subscribe-rate persistent://myprop/clust/ns1/ds1 -sr 10 -st 100"));
-        verify(mockTopicsPolicies).setSubscribeRate("persistent://myprop/clust/ns1/ds1", new SubscribeRate(10, 100));
-        cmdTopics.run(split("remove-subscribe-rate persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopicsPolicies).removeSubscribeRate("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("get-subscribe-rate persistent://mytenant/ns1/ds1 -ap"));
+        verify(mockTopicsPolicies).getSubscribeRate("persistent://mytenant/ns1/ds1", true);
+        cmdTopics.run(split("set-subscribe-rate persistent://mytenant/ns1/ds1 -sr 10 -st 100"));
+        verify(mockTopicsPolicies).setSubscribeRate("persistent://mytenant/ns1/ds1", new SubscribeRate(10, 100));
+        cmdTopics.run(split("remove-subscribe-rate persistent://mytenant/ns1/ds1"));
+        verify(mockTopicsPolicies).removeSubscribeRate("persistent://mytenant/ns1/ds1");
 
-        cmdTopics.run(split("get-max-message-size persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopicsPolicies).getMaxMessageSize("persistent://myprop/clust/ns1/ds1");
-        cmdTopics.run(split("set-max-message-size persistent://myprop/clust/ns1/ds1 -m 1000"));
-        verify(mockTopicsPolicies).setMaxMessageSize("persistent://myprop/clust/ns1/ds1", 1000);
-        cmdTopics.run(split("remove-max-message-size persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopicsPolicies).removeMaxMessageSize("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("get-max-message-size persistent://mytenant/ns1/ds1"));
+        verify(mockTopicsPolicies).getMaxMessageSize("persistent://mytenant/ns1/ds1");
+        cmdTopics.run(split("set-max-message-size persistent://mytenant/ns1/ds1 -m 1000"));
+        verify(mockTopicsPolicies).setMaxMessageSize("persistent://mytenant/ns1/ds1", 1000);
+        cmdTopics.run(split("remove-max-message-size persistent://mytenant/ns1/ds1"));
+        verify(mockTopicsPolicies).removeMaxMessageSize("persistent://mytenant/ns1/ds1");
 
-        cmdTopics.run(split("get-max-consumers persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopicsPolicies).getMaxConsumers("persistent://myprop/clust/ns1/ds1", false);
-        cmdTopics.run(split("remove-max-consumers persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopicsPolicies).removeMaxConsumers("persistent://myprop/clust/ns1/ds1");
-        cmdTopics.run(split("set-max-consumers persistent://myprop/clust/ns1/ds1 -c 99"));
-        verify(mockTopicsPolicies).setMaxConsumers("persistent://myprop/clust/ns1/ds1", 99);
+        cmdTopics.run(split("get-max-consumers persistent://mytenant/ns1/ds1"));
+        verify(mockTopicsPolicies).getMaxConsumers("persistent://mytenant/ns1/ds1", false);
+        cmdTopics.run(split("remove-max-consumers persistent://mytenant/ns1/ds1"));
+        verify(mockTopicsPolicies).removeMaxConsumers("persistent://mytenant/ns1/ds1");
+        cmdTopics.run(split("set-max-consumers persistent://mytenant/ns1/ds1 -c 99"));
+        verify(mockTopicsPolicies).setMaxConsumers("persistent://mytenant/ns1/ds1", 99);
 
-        cmdTopics.run(split("remove-max-unacked-messages-per-consumer persistent://myprop/clust/ns1/ds1"));
+        cmdTopics.run(split("remove-max-unacked-messages-per-consumer persistent://mytenant/ns1/ds1"));
         verify(mockTopicsPolicies, times(1)).removeMaxUnackedMessagesOnConsumer(
-                "persistent://myprop/clust/ns1/ds1");
-        cmdTopics.run(split("get-max-unacked-messages-per-consumer persistent://myprop/clust/ns1/ds1"));
+                "persistent://mytenant/ns1/ds1");
+        cmdTopics.run(split("get-max-unacked-messages-per-consumer persistent://mytenant/ns1/ds1"));
         verify(mockTopicsPolicies, times(1))
-                .getMaxUnackedMessagesOnConsumer("persistent://myprop/clust/ns1/ds1", false);
-        cmdTopics.run(split("set-max-unacked-messages-per-consumer persistent://myprop/clust/ns1/ds1 -m 999"));
+                .getMaxUnackedMessagesOnConsumer("persistent://mytenant/ns1/ds1", false);
+        cmdTopics.run(split("set-max-unacked-messages-per-consumer persistent://mytenant/ns1/ds1 -m 999"));
         verify(mockTopicsPolicies, times(1)).setMaxUnackedMessagesOnConsumer(
-                "persistent://myprop/clust/ns1/ds1", 999);
+                "persistent://mytenant/ns1/ds1", 999);
 
-        cmdTopics.run(split("get-message-ttl persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopicsPolicies).getMessageTTL("persistent://myprop/clust/ns1/ds1", false);
-        cmdTopics.run(split("set-message-ttl persistent://myprop/clust/ns1/ds1 -t 10"));
-        verify(mockTopicsPolicies).setMessageTTL("persistent://myprop/clust/ns1/ds1", 10);
-        cmdTopics.run(split("remove-message-ttl persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopicsPolicies).removeMessageTTL("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("get-message-ttl persistent://mytenant/ns1/ds1"));
+        verify(mockTopicsPolicies).getMessageTTL("persistent://mytenant/ns1/ds1", false);
+        cmdTopics.run(split("set-message-ttl persistent://mytenant/ns1/ds1 -t 10"));
+        verify(mockTopicsPolicies).setMessageTTL("persistent://mytenant/ns1/ds1", 10);
+        cmdTopics.run(split("remove-message-ttl persistent://mytenant/ns1/ds1"));
+        verify(mockTopicsPolicies).removeMessageTTL("persistent://mytenant/ns1/ds1");
 
-        cmdTopics.run(split("get-max-consumers-per-subscription persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopicsPolicies).getMaxConsumersPerSubscription("persistent://myprop/clust/ns1/ds1");
-        cmdTopics.run(split("set-max-consumers-per-subscription persistent://myprop/clust/ns1/ds1 -c 5"));
-        verify(mockTopicsPolicies).setMaxConsumersPerSubscription("persistent://myprop/clust/ns1/ds1", 5);
-        cmdTopics.run(split("remove-max-consumers-per-subscription persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopicsPolicies).removeMaxConsumersPerSubscription("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("get-max-consumers-per-subscription persistent://mytenant/ns1/ds1"));
+        verify(mockTopicsPolicies).getMaxConsumersPerSubscription("persistent://mytenant/ns1/ds1");
+        cmdTopics.run(split("set-max-consumers-per-subscription persistent://mytenant/ns1/ds1 -c 5"));
+        verify(mockTopicsPolicies).setMaxConsumersPerSubscription("persistent://mytenant/ns1/ds1", 5);
+        cmdTopics.run(split("remove-max-consumers-per-subscription persistent://mytenant/ns1/ds1"));
+        verify(mockTopicsPolicies).removeMaxConsumersPerSubscription("persistent://mytenant/ns1/ds1");
 
-        cmdTopics.run(split("get-max-unacked-messages-per-subscription persistent://myprop/clust/ns1/ds1"));
+        cmdTopics.run(split("get-max-unacked-messages-per-subscription persistent://mytenant/ns1/ds1"));
         verify(mockTopicsPolicies, times(1)).getMaxUnackedMessagesOnSubscription(
-                "persistent://myprop/clust/ns1/ds1", false);
-        cmdTopics.run(split("remove-max-unacked-messages-per-subscription persistent://myprop/clust/ns1/ds1"));
+                "persistent://mytenant/ns1/ds1", false);
+        cmdTopics.run(split("remove-max-unacked-messages-per-subscription persistent://mytenant/ns1/ds1"));
         verify(mockTopicsPolicies, times(1)).removeMaxUnackedMessagesOnSubscription(
-                "persistent://myprop/clust/ns1/ds1");
-        cmdTopics.run(split("set-max-unacked-messages-per-subscription persistent://myprop/clust/ns1/ds1 -m 99"));
+                "persistent://mytenant/ns1/ds1");
+        cmdTopics.run(split("set-max-unacked-messages-per-subscription persistent://mytenant/ns1/ds1 -m 99"));
         verify(mockTopicsPolicies, times(1)).setMaxUnackedMessagesOnSubscription(
-                "persistent://myprop/clust/ns1/ds1", 99);
+                "persistent://mytenant/ns1/ds1", 99);
 
-        cmdTopics.run(split("get-delayed-delivery persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopicsPolicies).getDelayedDeliveryPolicy("persistent://myprop/clust/ns1/ds1", false);
+        cmdTopics.run(split("get-delayed-delivery persistent://mytenant/ns1/ds1"));
+        verify(mockTopicsPolicies).getDelayedDeliveryPolicy("persistent://mytenant/ns1/ds1", false);
         cmdTopics.run(split(
-                "set-delayed-delivery persistent://myprop/clust/ns1/ds1 -t 10s --enable --maxDelay 5s"));
-        verify(mockTopicsPolicies).setDelayedDeliveryPolicy("persistent://myprop/clust/ns1/ds1",
+                "set-delayed-delivery persistent://mytenant/ns1/ds1 -t 10s --enable --maxDelay 5s"));
+        verify(mockTopicsPolicies).setDelayedDeliveryPolicy("persistent://mytenant/ns1/ds1",
                 DelayedDeliveryPolicies.builder().tickTime(10000).active(true)
                         .maxDeliveryDelayInMillis(5000).build());
-        cmdTopics.run(split("remove-delayed-delivery persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopicsPolicies).removeDelayedDeliveryPolicy("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("remove-delayed-delivery persistent://mytenant/ns1/ds1"));
+        verify(mockTopicsPolicies).removeDelayedDeliveryPolicy("persistent://mytenant/ns1/ds1");
 
-        cmdTopics.run(split("get-deduplication persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopicsPolicies).getDeduplicationStatus("persistent://myprop/clust/ns1/ds1");
-        cmdTopics.run(split("set-deduplication persistent://myprop/clust/ns1/ds1 --disable"));
-        verify(mockTopicsPolicies).setDeduplicationStatus("persistent://myprop/clust/ns1/ds1", false);
-        cmdTopics.run(split("remove-deduplication persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopicsPolicies).removeDeduplicationStatus("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("get-deduplication persistent://mytenant/ns1/ds1"));
+        verify(mockTopicsPolicies).getDeduplicationStatus("persistent://mytenant/ns1/ds1");
+        cmdTopics.run(split("set-deduplication persistent://mytenant/ns1/ds1 --disable"));
+        verify(mockTopicsPolicies).setDeduplicationStatus("persistent://mytenant/ns1/ds1", false);
+        cmdTopics.run(split("remove-deduplication persistent://mytenant/ns1/ds1"));
+        verify(mockTopicsPolicies).removeDeduplicationStatus("persistent://mytenant/ns1/ds1");
 
-        cmdTopics.run(split("get-max-subscriptions-per-topic persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopicsPolicies).getMaxSubscriptionsPerTopic("persistent://myprop/clust/ns1/ds1");
-        cmdTopics.run(split("set-max-subscriptions-per-topic persistent://myprop/clust/ns1/ds1 -s 1024"));
-        verify(mockTopicsPolicies).setMaxSubscriptionsPerTopic("persistent://myprop/clust/ns1/ds1", 1024);
-        cmdTopics.run(split("remove-max-subscriptions-per-topic persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopicsPolicies).removeMaxSubscriptionsPerTopic("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("get-max-subscriptions-per-topic persistent://mytenant/ns1/ds1"));
+        verify(mockTopicsPolicies).getMaxSubscriptionsPerTopic("persistent://mytenant/ns1/ds1");
+        cmdTopics.run(split("set-max-subscriptions-per-topic persistent://mytenant/ns1/ds1 -s 1024"));
+        verify(mockTopicsPolicies).setMaxSubscriptionsPerTopic("persistent://mytenant/ns1/ds1", 1024);
+        cmdTopics.run(split("remove-max-subscriptions-per-topic persistent://mytenant/ns1/ds1"));
+        verify(mockTopicsPolicies).removeMaxSubscriptionsPerTopic("persistent://mytenant/ns1/ds1");
 
-        cmdTopics.run(split("get-deduplication-snapshot-interval persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopicsPolicies).getDeduplicationSnapshotInterval("persistent://myprop/clust/ns1/ds1");
-        cmdTopics.run(split("set-deduplication-snapshot-interval persistent://myprop/clust/ns1/ds1 -i 100"));
-        verify(mockTopicsPolicies).setDeduplicationSnapshotInterval("persistent://myprop/clust/ns1/ds1", 100);
-        cmdTopics.run(split("remove-deduplication-snapshot-interval persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopicsPolicies).removeDeduplicationSnapshotInterval("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("get-deduplication-snapshot-interval persistent://mytenant/ns1/ds1"));
+        verify(mockTopicsPolicies).getDeduplicationSnapshotInterval("persistent://mytenant/ns1/ds1");
+        cmdTopics.run(split("set-deduplication-snapshot-interval persistent://mytenant/ns1/ds1 -i 100"));
+        verify(mockTopicsPolicies).setDeduplicationSnapshotInterval("persistent://mytenant/ns1/ds1", 100);
+        cmdTopics.run(split("remove-deduplication-snapshot-interval persistent://mytenant/ns1/ds1"));
+        verify(mockTopicsPolicies).removeDeduplicationSnapshotInterval("persistent://mytenant/ns1/ds1");
 
         // Reset the cmd, and check global option
         cmdTopics = new CmdTopicPolicies(() -> admin);
-        cmdTopics.run(split("get-retention persistent://myprop/clust/ns1/ds1 -g"));
-        verify(mockGlobalTopicsPolicies).getRetention("persistent://myprop/clust/ns1/ds1", false);
-        cmdTopics.run(split("set-retention persistent://myprop/clust/ns1/ds1 -t 10m -s 20M -g"));
-        verify(mockGlobalTopicsPolicies).setRetention("persistent://myprop/clust/ns1/ds1",
+        cmdTopics.run(split("get-retention persistent://mytenant/ns1/ds1 -g"));
+        verify(mockGlobalTopicsPolicies).getRetention("persistent://mytenant/ns1/ds1", false);
+        cmdTopics.run(split("set-retention persistent://mytenant/ns1/ds1 -t 10m -s 20M -g"));
+        verify(mockGlobalTopicsPolicies).setRetention("persistent://mytenant/ns1/ds1",
                 new RetentionPolicies(10, 20));
 
         cmdTopics = new CmdTopicPolicies(() -> admin);
-        cmdTopics.run(split("set-retention persistent://myprop/clust/ns1/ds1 -t 1440s -s 20M -g"));
-        verify(mockGlobalTopicsPolicies).setRetention("persistent://myprop/clust/ns1/ds1",
+        cmdTopics.run(split("set-retention persistent://mytenant/ns1/ds1 -t 1440s -s 20M -g"));
+        verify(mockGlobalTopicsPolicies).setRetention("persistent://mytenant/ns1/ds1",
                 new RetentionPolicies(24, 20));
 
         cmdTopics = new CmdTopicPolicies(() -> admin);
         reset(mockGlobalTopicsPolicies);
-        cmdTopics.run(split("set-retention persistent://myprop/clust/ns1/ds1 -t 1440 -s 20M -g"));
-        verify(mockGlobalTopicsPolicies).setRetention("persistent://myprop/clust/ns1/ds1",
+        cmdTopics.run(split("set-retention persistent://mytenant/ns1/ds1 -t 1440 -s 20M -g"));
+        verify(mockGlobalTopicsPolicies).setRetention("persistent://mytenant/ns1/ds1",
                 new RetentionPolicies(24, 20));
 
-        cmdTopics.run(split("remove-retention persistent://myprop/clust/ns1/ds1 -g"));
-        verify(mockGlobalTopicsPolicies).removeRetention("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("remove-retention persistent://mytenant/ns1/ds1 -g"));
+        verify(mockGlobalTopicsPolicies).removeRetention("persistent://mytenant/ns1/ds1");
 
-        cmdTopics.run(split("get-backlog-quota persistent://myprop/clust/ns1/ds1 -ap"));
-        verify(mockTopicsPolicies).getBacklogQuotaMap("persistent://myprop/clust/ns1/ds1", true);
-        cmdTopics.run(split("set-backlog-quota persistent://myprop/clust/ns1/ds1 -l 10 -p producer_request_hold"));
-        verify(mockTopicsPolicies).setBacklogQuota("persistent://myprop/clust/ns1/ds1",
+        cmdTopics.run(split("get-backlog-quota persistent://mytenant/ns1/ds1 -ap"));
+        verify(mockTopicsPolicies).getBacklogQuotaMap("persistent://mytenant/ns1/ds1", true);
+        cmdTopics.run(split("set-backlog-quota persistent://mytenant/ns1/ds1 -l 10 -p producer_request_hold"));
+        verify(mockTopicsPolicies).setBacklogQuota("persistent://mytenant/ns1/ds1",
                 BacklogQuota.builder()
                         .limitSize(10)
                         .retentionPolicy(RetentionPolicy.producer_request_hold)
@@ -1315,11 +1316,11 @@ public class PulsarAdminToolTest {
                 BacklogQuota.BacklogQuotaType.destination_storage);
         //cmd with option cannot be executed repeatedly.
         cmdTopics = new CmdTopicPolicies(() -> admin);
-        cmdTopics.run(split("set-message-ttl persistent://myprop/clust/ns1/ds1 -t 10h"));
-        verify(mockTopicsPolicies).setMessageTTL("persistent://myprop/clust/ns1/ds1", 10 * 60 * 60);
-        cmdTopics.run(split("set-backlog-quota persistent://myprop/clust/ns1/ds1 -lt 1w -p "
+        cmdTopics.run(split("set-message-ttl persistent://mytenant/ns1/ds1 -t 10h"));
+        verify(mockTopicsPolicies).setMessageTTL("persistent://mytenant/ns1/ds1", 10 * 60 * 60);
+        cmdTopics.run(split("set-backlog-quota persistent://mytenant/ns1/ds1 -lt 1w -p "
                 + "consumer_backlog_eviction -t message_age"));
-        verify(mockTopicsPolicies).setBacklogQuota("persistent://myprop/clust/ns1/ds1",
+        verify(mockTopicsPolicies).setBacklogQuota("persistent://mytenant/ns1/ds1",
                 BacklogQuota.builder()
                         .limitTime(60 * 60 * 24 * 7)
                         .retentionPolicy(RetentionPolicy.consumer_backlog_eviction)
@@ -1327,9 +1328,9 @@ public class PulsarAdminToolTest {
                 BacklogQuota.BacklogQuotaType.message_age);
         //cmd with option cannot be executed repeatedly.
         cmdTopics = new CmdTopicPolicies(() -> admin);
-        cmdTopics.run(split("set-backlog-quota persistent://myprop/clust/ns1/ds1 -lt 1000 -p "
+        cmdTopics.run(split("set-backlog-quota persistent://mytenant/ns1/ds1 -lt 1000 -p "
                 + "producer_request_hold -t message_age"));
-        verify(mockTopicsPolicies).setBacklogQuota("persistent://myprop/clust/ns1/ds1",
+        verify(mockTopicsPolicies).setBacklogQuota("persistent://mytenant/ns1/ds1",
                 BacklogQuota.builder()
                         .limitTime(1000)
                         .retentionPolicy(RetentionPolicy.producer_request_hold)
@@ -1337,221 +1338,221 @@ public class PulsarAdminToolTest {
                 BacklogQuota.BacklogQuotaType.message_age);
         //cmd with option cannot be executed repeatedly.
         cmdTopics = new CmdTopicPolicies(() -> admin);
-        Assert.assertFalse(cmdTopics.run(split("set-backlog-quota persistent://myprop/clust/ns1/ds1 "
+        Assert.assertFalse(cmdTopics.run(split("set-backlog-quota persistent://mytenant/ns1/ds1 "
                 + "-l 1000 -p producer_request_hold -t message_age")));
         cmdTopics = new CmdTopicPolicies(() -> admin);
-        Assert.assertFalse(cmdTopics.run(split("set-backlog-quota persistent://myprop/clust/ns1/ds1 "
+        Assert.assertFalse(cmdTopics.run(split("set-backlog-quota persistent://mytenant/ns1/ds1 "
                 + "-lt 60 -p producer_request_hold -t destination_storage")));
 
         //cmd with option cannot be executed repeatedly.
         cmdTopics = new CmdTopicPolicies(() -> admin);
-        cmdTopics.run(split("remove-backlog-quota persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopicsPolicies).removeBacklogQuota("persistent://myprop/clust/ns1/ds1",
+        cmdTopics.run(split("remove-backlog-quota persistent://mytenant/ns1/ds1"));
+        verify(mockTopicsPolicies).removeBacklogQuota("persistent://mytenant/ns1/ds1",
                 BacklogQuota.BacklogQuotaType.destination_storage);
         //cmd with option cannot be executed repeatedly.
         cmdTopics = new CmdTopicPolicies(() -> admin);
-        cmdTopics.run(split("remove-backlog-quota persistent://myprop/clust/ns1/ds1 -t message_age"));
-        verify(mockTopicsPolicies).removeBacklogQuota("persistent://myprop/clust/ns1/ds1",
+        cmdTopics.run(split("remove-backlog-quota persistent://mytenant/ns1/ds1 -t message_age"));
+        verify(mockTopicsPolicies).removeBacklogQuota("persistent://mytenant/ns1/ds1",
                 BacklogQuota.BacklogQuotaType.message_age);
 
-        cmdTopics.run(split("get-max-producers persistent://myprop/clust/ns1/ds1 -g"));
-        verify(mockGlobalTopicsPolicies).getMaxProducers("persistent://myprop/clust/ns1/ds1", false);
-        cmdTopics.run(split("remove-max-producers persistent://myprop/clust/ns1/ds1 -g"));
-        verify(mockGlobalTopicsPolicies).removeMaxProducers("persistent://myprop/clust/ns1/ds1");
-        cmdTopics.run(split("set-max-producers persistent://myprop/clust/ns1/ds1 -p 99 -g"));
-        verify(mockGlobalTopicsPolicies).setMaxProducers("persistent://myprop/clust/ns1/ds1", 99);
+        cmdTopics.run(split("get-max-producers persistent://mytenant/ns1/ds1 -g"));
+        verify(mockGlobalTopicsPolicies).getMaxProducers("persistent://mytenant/ns1/ds1", false);
+        cmdTopics.run(split("remove-max-producers persistent://mytenant/ns1/ds1 -g"));
+        verify(mockGlobalTopicsPolicies).removeMaxProducers("persistent://mytenant/ns1/ds1");
+        cmdTopics.run(split("set-max-producers persistent://mytenant/ns1/ds1 -p 99 -g"));
+        verify(mockGlobalTopicsPolicies).setMaxProducers("persistent://mytenant/ns1/ds1", 99);
 
-        cmdTopics.run(split("remove-max-unacked-messages-per-consumer persistent://myprop/clust/ns1/ds1 -g"));
+        cmdTopics.run(split("remove-max-unacked-messages-per-consumer persistent://mytenant/ns1/ds1 -g"));
         verify(mockGlobalTopicsPolicies, times(1))
-                .removeMaxUnackedMessagesOnConsumer("persistent://myprop/clust/ns1/ds1");
-        cmdTopics.run(split("get-max-unacked-messages-per-consumer persistent://myprop/clust/ns1/ds1 -g"));
+                .removeMaxUnackedMessagesOnConsumer("persistent://mytenant/ns1/ds1");
+        cmdTopics.run(split("get-max-unacked-messages-per-consumer persistent://mytenant/ns1/ds1 -g"));
         verify(mockGlobalTopicsPolicies, times(1))
-                .getMaxUnackedMessagesOnConsumer("persistent://myprop/clust/ns1/ds1", false);
-        cmdTopics.run(split("set-max-unacked-messages-per-consumer persistent://myprop/clust/ns1/ds1 -m 999 -g"));
+                .getMaxUnackedMessagesOnConsumer("persistent://mytenant/ns1/ds1", false);
+        cmdTopics.run(split("set-max-unacked-messages-per-consumer persistent://mytenant/ns1/ds1 -m 999 -g"));
         verify(mockGlobalTopicsPolicies, times(1))
-                .setMaxUnackedMessagesOnConsumer("persistent://myprop/clust/ns1/ds1", 999);
+                .setMaxUnackedMessagesOnConsumer("persistent://mytenant/ns1/ds1", 999);
 
-        cmdTopics.run(split("get-message-ttl persistent://myprop/clust/ns1/ds1 -g"));
-        verify(mockGlobalTopicsPolicies).getMessageTTL("persistent://myprop/clust/ns1/ds1", false);
-        cmdTopics.run(split("set-message-ttl persistent://myprop/clust/ns1/ds1 -t 10 -g"));
-        verify(mockGlobalTopicsPolicies).setMessageTTL("persistent://myprop/clust/ns1/ds1", 10);
-        cmdTopics.run(split("remove-message-ttl persistent://myprop/clust/ns1/ds1 -g"));
-        verify(mockGlobalTopicsPolicies).removeMessageTTL("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("get-message-ttl persistent://mytenant/ns1/ds1 -g"));
+        verify(mockGlobalTopicsPolicies).getMessageTTL("persistent://mytenant/ns1/ds1", false);
+        cmdTopics.run(split("set-message-ttl persistent://mytenant/ns1/ds1 -t 10 -g"));
+        verify(mockGlobalTopicsPolicies).setMessageTTL("persistent://mytenant/ns1/ds1", 10);
+        cmdTopics.run(split("remove-message-ttl persistent://mytenant/ns1/ds1 -g"));
+        verify(mockGlobalTopicsPolicies).removeMessageTTL("persistent://mytenant/ns1/ds1");
 
-        cmdTopics.run(split("get-persistence persistent://myprop/clust/ns1/ds1 -g"));
-        verify(mockGlobalTopicsPolicies).getPersistence("persistent://myprop/clust/ns1/ds1");
-        cmdTopics.run(split("set-persistence persistent://myprop/clust/ns1/ds1 -e 2 -w 1 -a 1 -r 100.0 -g"));
-        verify(mockGlobalTopicsPolicies).setPersistence("persistent://myprop/clust/ns1/ds1",
+        cmdTopics.run(split("get-persistence persistent://mytenant/ns1/ds1 -g"));
+        verify(mockGlobalTopicsPolicies).getPersistence("persistent://mytenant/ns1/ds1");
+        cmdTopics.run(split("set-persistence persistent://mytenant/ns1/ds1 -e 2 -w 1 -a 1 -r 100.0 -g"));
+        verify(mockGlobalTopicsPolicies).setPersistence("persistent://mytenant/ns1/ds1",
                 new PersistencePolicies(2, 1, 1, 100.0d));
-        cmdTopics.run(split("remove-persistence persistent://myprop/clust/ns1/ds1 -g"));
-        verify(mockGlobalTopicsPolicies).removePersistence("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("remove-persistence persistent://mytenant/ns1/ds1 -g"));
+        verify(mockGlobalTopicsPolicies).removePersistence("persistent://mytenant/ns1/ds1");
 
-        cmdTopics.run(split("get-max-unacked-messages-per-subscription persistent://myprop/clust/ns1/ds1 -g"));
+        cmdTopics.run(split("get-max-unacked-messages-per-subscription persistent://mytenant/ns1/ds1 -g"));
         verify(mockGlobalTopicsPolicies, times(1))
-                .getMaxUnackedMessagesOnSubscription("persistent://myprop/clust/ns1/ds1", false);
-        cmdTopics.run(split("remove-max-unacked-messages-per-subscription persistent://myprop/clust/ns1/ds1 -g"));
+                .getMaxUnackedMessagesOnSubscription("persistent://mytenant/ns1/ds1", false);
+        cmdTopics.run(split("remove-max-unacked-messages-per-subscription persistent://mytenant/ns1/ds1 -g"));
         verify(mockGlobalTopicsPolicies, times(1))
-                .removeMaxUnackedMessagesOnSubscription("persistent://myprop/clust/ns1/ds1");
-        cmdTopics.run(split("set-max-unacked-messages-per-subscription persistent://myprop/clust/ns1/ds1 -m 99 -g"));
+                .removeMaxUnackedMessagesOnSubscription("persistent://mytenant/ns1/ds1");
+        cmdTopics.run(split("set-max-unacked-messages-per-subscription persistent://mytenant/ns1/ds1 -m 99 -g"));
         verify(mockGlobalTopicsPolicies, times(1))
-                .setMaxUnackedMessagesOnSubscription("persistent://myprop/clust/ns1/ds1", 99);
+                .setMaxUnackedMessagesOnSubscription("persistent://mytenant/ns1/ds1", 99);
 
-        cmdTopics.run(split("get-inactive-topic-policies persistent://myprop/clust/ns1/ds1 -g"));
-        verify(mockGlobalTopicsPolicies).getInactiveTopicPolicies("persistent://myprop/clust/ns1/ds1", false);
-        cmdTopics.run(split("remove-inactive-topic-policies persistent://myprop/clust/ns1/ds1 -g"));
-        verify(mockGlobalTopicsPolicies).removeInactiveTopicPolicies("persistent://myprop/clust/ns1/ds1");
-        cmdTopics.run(split("set-inactive-topic-policies persistent://myprop/clust/ns1/ds1"
+        cmdTopics.run(split("get-inactive-topic-policies persistent://mytenant/ns1/ds1 -g"));
+        verify(mockGlobalTopicsPolicies).getInactiveTopicPolicies("persistent://mytenant/ns1/ds1", false);
+        cmdTopics.run(split("remove-inactive-topic-policies persistent://mytenant/ns1/ds1 -g"));
+        verify(mockGlobalTopicsPolicies).removeInactiveTopicPolicies("persistent://mytenant/ns1/ds1");
+        cmdTopics.run(split("set-inactive-topic-policies persistent://mytenant/ns1/ds1"
                 + " -e -t 1s -m delete_when_no_subscriptions -g"));
-        verify(mockGlobalTopicsPolicies).setInactiveTopicPolicies("persistent://myprop/clust/ns1/ds1",
+        verify(mockGlobalTopicsPolicies).setInactiveTopicPolicies("persistent://mytenant/ns1/ds1",
                 new InactiveTopicPolicies(InactiveTopicDeleteMode.delete_when_no_subscriptions, 1, true));
 
-        cmdTopics.run(split("get-dispatch-rate persistent://myprop/clust/ns1/ds1 -ap -g"));
-        verify(mockGlobalTopicsPolicies).getDispatchRate("persistent://myprop/clust/ns1/ds1", true);
-        cmdTopics.run(split("remove-dispatch-rate persistent://myprop/clust/ns1/ds1 -g"));
-        verify(mockGlobalTopicsPolicies).removeDispatchRate("persistent://myprop/clust/ns1/ds1");
-        cmdTopics.run(split("set-dispatch-rate persistent://myprop/clust/ns1/ds1 -md -1 -bd -1 -dt 2 -g"));
-        verify(mockGlobalTopicsPolicies).setDispatchRate("persistent://myprop/clust/ns1/ds1",
+        cmdTopics.run(split("get-dispatch-rate persistent://mytenant/ns1/ds1 -ap -g"));
+        verify(mockGlobalTopicsPolicies).getDispatchRate("persistent://mytenant/ns1/ds1", true);
+        cmdTopics.run(split("remove-dispatch-rate persistent://mytenant/ns1/ds1 -g"));
+        verify(mockGlobalTopicsPolicies).removeDispatchRate("persistent://mytenant/ns1/ds1");
+        cmdTopics.run(split("set-dispatch-rate persistent://mytenant/ns1/ds1 -md -1 -bd -1 -dt 2 -g"));
+        verify(mockGlobalTopicsPolicies).setDispatchRate("persistent://mytenant/ns1/ds1",
                 DispatchRate.builder()
                 .dispatchThrottlingRateInMsg(-1)
                 .dispatchThrottlingRateInByte(-1)
                 .ratePeriodInSecond(2)
                 .build());
 
-        cmdTopics.run(split("get-publish-rate persistent://myprop/clust/ns1/ds1 -g"));
-        verify(mockGlobalTopicsPolicies).getPublishRate("persistent://myprop/clust/ns1/ds1");
-        cmdTopics.run(split("set-publish-rate persistent://myprop/clust/ns1/ds1 -m 10 -b 100 -g"));
-        verify(mockGlobalTopicsPolicies).setPublishRate("persistent://myprop/clust/ns1/ds1",
+        cmdTopics.run(split("get-publish-rate persistent://mytenant/ns1/ds1 -g"));
+        verify(mockGlobalTopicsPolicies).getPublishRate("persistent://mytenant/ns1/ds1");
+        cmdTopics.run(split("set-publish-rate persistent://mytenant/ns1/ds1 -m 10 -b 100 -g"));
+        verify(mockGlobalTopicsPolicies).setPublishRate("persistent://mytenant/ns1/ds1",
                 new PublishRate(10, 100));
-        cmdTopics.run(split("remove-publish-rate persistent://myprop/clust/ns1/ds1 -g"));
-        verify(mockGlobalTopicsPolicies).removePublishRate("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("remove-publish-rate persistent://mytenant/ns1/ds1 -g"));
+        verify(mockGlobalTopicsPolicies).removePublishRate("persistent://mytenant/ns1/ds1");
 
-        cmdTopics.run(split("get-subscribe-rate persistent://myprop/clust/ns1/ds1 -ap -g"));
-        verify(mockGlobalTopicsPolicies).getSubscribeRate("persistent://myprop/clust/ns1/ds1", true);
-        cmdTopics.run(split("set-subscribe-rate persistent://myprop/clust/ns1/ds1 -sr 10 -st 100 -g"));
-        verify(mockGlobalTopicsPolicies).setSubscribeRate("persistent://myprop/clust/ns1/ds1",
+        cmdTopics.run(split("get-subscribe-rate persistent://mytenant/ns1/ds1 -ap -g"));
+        verify(mockGlobalTopicsPolicies).getSubscribeRate("persistent://mytenant/ns1/ds1", true);
+        cmdTopics.run(split("set-subscribe-rate persistent://mytenant/ns1/ds1 -sr 10 -st 100 -g"));
+        verify(mockGlobalTopicsPolicies).setSubscribeRate("persistent://mytenant/ns1/ds1",
                 new SubscribeRate(10, 100));
-        cmdTopics.run(split("remove-subscribe-rate persistent://myprop/clust/ns1/ds1 -g"));
-        verify(mockGlobalTopicsPolicies).removeSubscribeRate("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("remove-subscribe-rate persistent://mytenant/ns1/ds1 -g"));
+        verify(mockGlobalTopicsPolicies).removeSubscribeRate("persistent://mytenant/ns1/ds1");
 
-        cmdTopics.run(split("get-delayed-delivery persistent://myprop/clust/ns1/ds1 -g"));
-        verify(mockGlobalTopicsPolicies).getDelayedDeliveryPolicy("persistent://myprop/clust/ns1/ds1", false);
-        cmdTopics.run(split("set-delayed-delivery persistent://myprop/clust/ns1/ds1 -t 10s --enable -md 5s -g"));
-        verify(mockGlobalTopicsPolicies).setDelayedDeliveryPolicy("persistent://myprop/clust/ns1/ds1",
+        cmdTopics.run(split("get-delayed-delivery persistent://mytenant/ns1/ds1 -g"));
+        verify(mockGlobalTopicsPolicies).getDelayedDeliveryPolicy("persistent://mytenant/ns1/ds1", false);
+        cmdTopics.run(split("set-delayed-delivery persistent://mytenant/ns1/ds1 -t 10s --enable -md 5s -g"));
+        verify(mockGlobalTopicsPolicies).setDelayedDeliveryPolicy("persistent://mytenant/ns1/ds1",
                 DelayedDeliveryPolicies.builder().tickTime(10000).active(true)
                         .maxDeliveryDelayInMillis(5000).build());
-        cmdTopics.run(split("remove-delayed-delivery persistent://myprop/clust/ns1/ds1 -g"));
-        verify(mockGlobalTopicsPolicies).removeDelayedDeliveryPolicy("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("remove-delayed-delivery persistent://mytenant/ns1/ds1 -g"));
+        verify(mockGlobalTopicsPolicies).removeDelayedDeliveryPolicy("persistent://mytenant/ns1/ds1");
 
-        cmdTopics.run(split("get-max-message-size persistent://myprop/clust/ns1/ds1 -g"));
-        verify(mockGlobalTopicsPolicies).getMaxMessageSize("persistent://myprop/clust/ns1/ds1");
-        cmdTopics.run(split("set-max-message-size persistent://myprop/clust/ns1/ds1 -m 1000 -g"));
-        verify(mockGlobalTopicsPolicies).setMaxMessageSize("persistent://myprop/clust/ns1/ds1", 1000);
-        cmdTopics.run(split("remove-max-message-size persistent://myprop/clust/ns1/ds1 -g"));
-        verify(mockGlobalTopicsPolicies).removeMaxMessageSize("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("get-max-message-size persistent://mytenant/ns1/ds1 -g"));
+        verify(mockGlobalTopicsPolicies).getMaxMessageSize("persistent://mytenant/ns1/ds1");
+        cmdTopics.run(split("set-max-message-size persistent://mytenant/ns1/ds1 -m 1000 -g"));
+        verify(mockGlobalTopicsPolicies).setMaxMessageSize("persistent://mytenant/ns1/ds1", 1000);
+        cmdTopics.run(split("remove-max-message-size persistent://mytenant/ns1/ds1 -g"));
+        verify(mockGlobalTopicsPolicies).removeMaxMessageSize("persistent://mytenant/ns1/ds1");
 
-        cmdTopics.run(split("get-deduplication persistent://myprop/clust/ns1/ds1 -g"));
-        verify(mockGlobalTopicsPolicies).getDeduplicationStatus("persistent://myprop/clust/ns1/ds1");
-        cmdTopics.run(split("set-deduplication persistent://myprop/clust/ns1/ds1 --disable -g"));
-        verify(mockGlobalTopicsPolicies).setDeduplicationStatus("persistent://myprop/clust/ns1/ds1", false);
-        cmdTopics.run(split("remove-deduplication persistent://myprop/clust/ns1/ds1 -g"));
-        verify(mockGlobalTopicsPolicies).removeDeduplicationStatus("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("get-deduplication persistent://mytenant/ns1/ds1 -g"));
+        verify(mockGlobalTopicsPolicies).getDeduplicationStatus("persistent://mytenant/ns1/ds1");
+        cmdTopics.run(split("set-deduplication persistent://mytenant/ns1/ds1 --disable -g"));
+        verify(mockGlobalTopicsPolicies).setDeduplicationStatus("persistent://mytenant/ns1/ds1", false);
+        cmdTopics.run(split("remove-deduplication persistent://mytenant/ns1/ds1 -g"));
+        verify(mockGlobalTopicsPolicies).removeDeduplicationStatus("persistent://mytenant/ns1/ds1");
 
-        cmdTopics.run(split("get-deduplication-snapshot-interval persistent://myprop/clust/ns1/ds1 -g"));
-        verify(mockGlobalTopicsPolicies).getDeduplicationSnapshotInterval("persistent://myprop/clust/ns1/ds1");
-        cmdTopics.run(split("set-deduplication-snapshot-interval persistent://myprop/clust/ns1/ds1 -i 100 -g"));
-        verify(mockGlobalTopicsPolicies).setDeduplicationSnapshotInterval("persistent://myprop/clust/ns1/ds1", 100);
-        cmdTopics.run(split("remove-deduplication-snapshot-interval persistent://myprop/clust/ns1/ds1 -g"));
-        verify(mockGlobalTopicsPolicies).removeDeduplicationSnapshotInterval("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("get-deduplication-snapshot-interval persistent://mytenant/ns1/ds1 -g"));
+        verify(mockGlobalTopicsPolicies).getDeduplicationSnapshotInterval("persistent://mytenant/ns1/ds1");
+        cmdTopics.run(split("set-deduplication-snapshot-interval persistent://mytenant/ns1/ds1 -i 100 -g"));
+        verify(mockGlobalTopicsPolicies).setDeduplicationSnapshotInterval("persistent://mytenant/ns1/ds1", 100);
+        cmdTopics.run(split("remove-deduplication-snapshot-interval persistent://mytenant/ns1/ds1 -g"));
+        verify(mockGlobalTopicsPolicies).removeDeduplicationSnapshotInterval("persistent://mytenant/ns1/ds1");
 
-        cmdTopics.run(split("get-max-consumers-per-subscription persistent://myprop/clust/ns1/ds1 -g"));
-        verify(mockGlobalTopicsPolicies).getMaxConsumersPerSubscription("persistent://myprop/clust/ns1/ds1");
-        cmdTopics.run(split("set-max-consumers-per-subscription persistent://myprop/clust/ns1/ds1 -c 5 -g"));
-        verify(mockGlobalTopicsPolicies).setMaxConsumersPerSubscription("persistent://myprop/clust/ns1/ds1", 5);
-        cmdTopics.run(split("remove-max-consumers-per-subscription persistent://myprop/clust/ns1/ds1 -g"));
-        verify(mockGlobalTopicsPolicies).removeMaxConsumersPerSubscription("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("get-max-consumers-per-subscription persistent://mytenant/ns1/ds1 -g"));
+        verify(mockGlobalTopicsPolicies).getMaxConsumersPerSubscription("persistent://mytenant/ns1/ds1");
+        cmdTopics.run(split("set-max-consumers-per-subscription persistent://mytenant/ns1/ds1 -c 5 -g"));
+        verify(mockGlobalTopicsPolicies).setMaxConsumersPerSubscription("persistent://mytenant/ns1/ds1", 5);
+        cmdTopics.run(split("remove-max-consumers-per-subscription persistent://mytenant/ns1/ds1 -g"));
+        verify(mockGlobalTopicsPolicies).removeMaxConsumersPerSubscription("persistent://mytenant/ns1/ds1");
 
-        cmdTopics.run(split("set-subscription-types-enabled persistent://myprop/clust/ns1/ds1 -t "
+        cmdTopics.run(split("set-subscription-types-enabled persistent://mytenant/ns1/ds1 -t "
                 + "Shared,Failover -g"));
-        verify(mockGlobalTopicsPolicies).setSubscriptionTypesEnabled("persistent://myprop/clust/ns1/ds1",
+        verify(mockGlobalTopicsPolicies).setSubscriptionTypesEnabled("persistent://mytenant/ns1/ds1",
                 Sets.newHashSet(SubscriptionType.Shared, SubscriptionType.Failover));
-        cmdTopics.run(split("get-subscription-types-enabled persistent://myprop/clust/ns1/ds1 -g"));
-        verify(mockGlobalTopicsPolicies).getSubscriptionTypesEnabled("persistent://myprop/clust/ns1/ds1");
-        cmdTopics.run(split("remove-subscription-types-enabled persistent://myprop/clust/ns1/ds1 -g"));
-        verify(mockGlobalTopicsPolicies).removeSubscriptionTypesEnabled("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("get-subscription-types-enabled persistent://mytenant/ns1/ds1 -g"));
+        verify(mockGlobalTopicsPolicies).getSubscriptionTypesEnabled("persistent://mytenant/ns1/ds1");
+        cmdTopics.run(split("remove-subscription-types-enabled persistent://mytenant/ns1/ds1 -g"));
+        verify(mockGlobalTopicsPolicies).removeSubscriptionTypesEnabled("persistent://mytenant/ns1/ds1");
 
-        cmdTopics.run(split("get-max-consumers persistent://myprop/clust/ns1/ds1 -g"));
-        verify(mockGlobalTopicsPolicies).getMaxConsumers("persistent://myprop/clust/ns1/ds1", false);
-        cmdTopics.run(split("remove-max-consumers persistent://myprop/clust/ns1/ds1 -g"));
-        verify(mockGlobalTopicsPolicies).removeMaxConsumers("persistent://myprop/clust/ns1/ds1");
-        cmdTopics.run(split("set-max-consumers persistent://myprop/clust/ns1/ds1 -c 99 -g"));
-        verify(mockGlobalTopicsPolicies).setMaxConsumers("persistent://myprop/clust/ns1/ds1", 99);
+        cmdTopics.run(split("get-max-consumers persistent://mytenant/ns1/ds1 -g"));
+        verify(mockGlobalTopicsPolicies).getMaxConsumers("persistent://mytenant/ns1/ds1", false);
+        cmdTopics.run(split("remove-max-consumers persistent://mytenant/ns1/ds1 -g"));
+        verify(mockGlobalTopicsPolicies).removeMaxConsumers("persistent://mytenant/ns1/ds1");
+        cmdTopics.run(split("set-max-consumers persistent://mytenant/ns1/ds1 -c 99 -g"));
+        verify(mockGlobalTopicsPolicies).setMaxConsumers("persistent://mytenant/ns1/ds1", 99);
 
-        cmdTopics.run(split("get-compaction-threshold persistent://myprop/clust/ns1/ds1 -g"));
-        verify(mockGlobalTopicsPolicies).getCompactionThreshold("persistent://myprop/clust/ns1/ds1", false);
-        cmdTopics.run(split("set-compaction-threshold persistent://myprop/clust/ns1/ds1 -t 10k -g"));
-        verify(mockGlobalTopicsPolicies).setCompactionThreshold("persistent://myprop/clust/ns1/ds1", 10 * 1024);
-        cmdTopics.run(split("remove-compaction-threshold persistent://myprop/clust/ns1/ds1 -g"));
-        verify(mockGlobalTopicsPolicies).removeCompactionThreshold("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("get-compaction-threshold persistent://mytenant/ns1/ds1 -g"));
+        verify(mockGlobalTopicsPolicies).getCompactionThreshold("persistent://mytenant/ns1/ds1", false);
+        cmdTopics.run(split("set-compaction-threshold persistent://mytenant/ns1/ds1 -t 10k -g"));
+        verify(mockGlobalTopicsPolicies).setCompactionThreshold("persistent://mytenant/ns1/ds1", 10 * 1024);
+        cmdTopics.run(split("remove-compaction-threshold persistent://mytenant/ns1/ds1 -g"));
+        verify(mockGlobalTopicsPolicies).removeCompactionThreshold("persistent://mytenant/ns1/ds1");
 
-        cmdTopics.run(split("set-replicator-dispatch-rate persistent://myprop/clust/ns1/ds1 -md -1 -bd -1 "
+        cmdTopics.run(split("set-replicator-dispatch-rate persistent://mytenant/ns1/ds1 -md -1 -bd -1 "
                 + "-dt 2 -g"));
-        verify(mockGlobalTopicsPolicies).setReplicatorDispatchRate("persistent://myprop/clust/ns1/ds1",
+        verify(mockGlobalTopicsPolicies).setReplicatorDispatchRate("persistent://mytenant/ns1/ds1",
                 DispatchRate.builder()
                         .dispatchThrottlingRateInMsg(-1)
                         .dispatchThrottlingRateInByte(-1)
                         .ratePeriodInSecond(2)
                         .build());
-        cmdTopics.run(split("get-replicator-dispatch-rate persistent://myprop/clust/ns1/ds1 -g"));
-        verify(mockGlobalTopicsPolicies).getReplicatorDispatchRate("persistent://myprop/clust/ns1/ds1", false);
-        cmdTopics.run(split("remove-replicator-dispatch-rate persistent://myprop/clust/ns1/ds1 -g"));
-        verify(mockGlobalTopicsPolicies).removeReplicatorDispatchRate("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("get-replicator-dispatch-rate persistent://mytenant/ns1/ds1 -g"));
+        verify(mockGlobalTopicsPolicies).getReplicatorDispatchRate("persistent://mytenant/ns1/ds1", false);
+        cmdTopics.run(split("remove-replicator-dispatch-rate persistent://mytenant/ns1/ds1 -g"));
+        verify(mockGlobalTopicsPolicies).removeReplicatorDispatchRate("persistent://mytenant/ns1/ds1");
 
-        cmdTopics.run(split("set-subscription-dispatch-rate persistent://myprop/clust/ns1/ds1 -md -1 -bd -1 "
+        cmdTopics.run(split("set-subscription-dispatch-rate persistent://mytenant/ns1/ds1 -md -1 -bd -1 "
                 + "-dt 2 -g"));
-        verify(mockGlobalTopicsPolicies).setSubscriptionDispatchRate("persistent://myprop/clust/ns1/ds1",
+        verify(mockGlobalTopicsPolicies).setSubscriptionDispatchRate("persistent://mytenant/ns1/ds1",
                 DispatchRate.builder()
                         .dispatchThrottlingRateInMsg(-1)
                         .dispatchThrottlingRateInByte(-1)
                         .ratePeriodInSecond(2)
                         .build());
-        cmdTopics.run(split("get-subscription-dispatch-rate persistent://myprop/clust/ns1/ds1 -g"));
-        verify(mockGlobalTopicsPolicies).getSubscriptionDispatchRate("persistent://myprop/clust/ns1/ds1", false);
-        cmdTopics.run(split("remove-subscription-dispatch-rate persistent://myprop/clust/ns1/ds1 -g"));
-        verify(mockGlobalTopicsPolicies).removeSubscriptionDispatchRate("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("get-subscription-dispatch-rate persistent://mytenant/ns1/ds1 -g"));
+        verify(mockGlobalTopicsPolicies).getSubscriptionDispatchRate("persistent://mytenant/ns1/ds1", false);
+        cmdTopics.run(split("remove-subscription-dispatch-rate persistent://mytenant/ns1/ds1 -g"));
+        verify(mockGlobalTopicsPolicies).removeSubscriptionDispatchRate("persistent://mytenant/ns1/ds1");
 
         cmdTopics = new CmdTopicPolicies(() -> admin);
-        cmdTopics.run(split("set-subscription-dispatch-rate persistent://myprop/clust/ns1/ds1 -s sub -md -1 "
+        cmdTopics.run(split("set-subscription-dispatch-rate persistent://mytenant/ns1/ds1 -s sub -md -1 "
                 + "-bd -1 -dt 2 -g"));
-        verify(mockGlobalTopicsPolicies).setSubscriptionDispatchRate("persistent://myprop/clust/ns1/ds1", "sub",
+        verify(mockGlobalTopicsPolicies).setSubscriptionDispatchRate("persistent://mytenant/ns1/ds1", "sub",
                 DispatchRate.builder()
                         .dispatchThrottlingRateInMsg(-1)
                         .dispatchThrottlingRateInByte(-1)
                         .ratePeriodInSecond(2)
                         .build());
-        cmdTopics.run(split("get-subscription-dispatch-rate persistent://myprop/clust/ns1/ds1 -s sub -g"));
-        verify(mockGlobalTopicsPolicies).getSubscriptionDispatchRate("persistent://myprop/clust/ns1/ds1",
+        cmdTopics.run(split("get-subscription-dispatch-rate persistent://mytenant/ns1/ds1 -s sub -g"));
+        verify(mockGlobalTopicsPolicies).getSubscriptionDispatchRate("persistent://mytenant/ns1/ds1",
                 "sub", false);
-        cmdTopics.run(split("remove-subscription-dispatch-rate persistent://myprop/clust/ns1/ds1 -s sub -g"));
-        verify(mockGlobalTopicsPolicies).removeSubscriptionDispatchRate("persistent://myprop/clust/ns1/ds1",
+        cmdTopics.run(split("remove-subscription-dispatch-rate persistent://mytenant/ns1/ds1 -s sub -g"));
+        verify(mockGlobalTopicsPolicies).removeSubscriptionDispatchRate("persistent://mytenant/ns1/ds1",
                 "sub");
 
-        cmdTopics.run(split("get-max-subscriptions-per-topic persistent://myprop/clust/ns1/ds1 -g"));
-        verify(mockGlobalTopicsPolicies).getMaxSubscriptionsPerTopic("persistent://myprop/clust/ns1/ds1");
-        cmdTopics.run(split("set-max-subscriptions-per-topic persistent://myprop/clust/ns1/ds1 -s 1024 -g"));
-        verify(mockGlobalTopicsPolicies).setMaxSubscriptionsPerTopic("persistent://myprop/clust/ns1/ds1", 1024);
-        cmdTopics.run(split("remove-max-subscriptions-per-topic persistent://myprop/clust/ns1/ds1 -g"));
-        verify(mockGlobalTopicsPolicies).removeMaxSubscriptionsPerTopic("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("get-max-subscriptions-per-topic persistent://mytenant/ns1/ds1 -g"));
+        verify(mockGlobalTopicsPolicies).getMaxSubscriptionsPerTopic("persistent://mytenant/ns1/ds1");
+        cmdTopics.run(split("set-max-subscriptions-per-topic persistent://mytenant/ns1/ds1 -s 1024 -g"));
+        verify(mockGlobalTopicsPolicies).setMaxSubscriptionsPerTopic("persistent://mytenant/ns1/ds1", 1024);
+        cmdTopics.run(split("remove-max-subscriptions-per-topic persistent://mytenant/ns1/ds1 -g"));
+        verify(mockGlobalTopicsPolicies).removeMaxSubscriptionsPerTopic("persistent://mytenant/ns1/ds1");
 
-        cmdTopics.run(split("get-offload-policies persistent://myprop/clust/ns1/ds1 -g"));
-        verify(mockGlobalTopicsPolicies).getOffloadPolicies("persistent://myprop/clust/ns1/ds1", false);
+        cmdTopics.run(split("get-offload-policies persistent://mytenant/ns1/ds1 -g"));
+        verify(mockGlobalTopicsPolicies).getOffloadPolicies("persistent://mytenant/ns1/ds1", false);
 
-        cmdTopics.run(split("remove-offload-policies persistent://myprop/clust/ns1/ds1 -g"));
-        verify(mockGlobalTopicsPolicies).removeOffloadPolicies("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("remove-offload-policies persistent://mytenant/ns1/ds1 -g"));
+        verify(mockGlobalTopicsPolicies).removeOffloadPolicies("persistent://mytenant/ns1/ds1");
 
-        cmdTopics.run(split("set-offload-policies persistent://myprop/clust/ns1/ds1 -d s3 -r"
+        cmdTopics.run(split("set-offload-policies persistent://mytenant/ns1/ds1 -d s3 -r"
                 + " region -b bucket -e endpoint -m 8 -rb 9 -t 10 -ts 100 -orp tiered-storage-first -g"));
         verify(mockGlobalTopicsPolicies)
-                .setOffloadPolicies("persistent://myprop/clust/ns1/ds1", OffloadPoliciesImpl.create(
+                .setOffloadPolicies("persistent://mytenant/ns1/ds1", OffloadPoliciesImpl.create(
                         "s3", "region", "bucket" , "endpoint", null, null, null, null,
                                 8, 9, 10L, 100L, null,
                         OffloadedReadPriority.TIERED_STORAGE_FIRST));
@@ -1579,22 +1580,22 @@ public class PulsarAdminToolTest {
 
         // filesystem offload
         CmdTopics cmdTopics = new CmdTopics(() -> admin);
-        cmdTopics.run(split("set-offload-policies persistent://myprop/clust/ns1/ds1 -d filesystem -oat 100M "
+        cmdTopics.run(split("set-offload-policies persistent://mytenant/ns1/ds1 -d filesystem -oat 100M "
                 + "-oats 1h -oae 1h -orp bookkeeper-first"));
         OffloadPoliciesImpl offloadPolicies = OffloadPoliciesImpl.create("filesystem", null, null,
                 null, null, null, null, null, 64 * 1024 * 1024, 1024 * 1024,
           100 * 1024 * 1024L, 3600L, 3600 * 1000L,
                 OffloadedReadPriority.BOOKKEEPER_FIRST);
-        verify(mockTopics).setOffloadPolicies("persistent://myprop/clust/ns1/ds1", offloadPolicies);
+        verify(mockTopics).setOffloadPolicies("persistent://mytenant/ns1/ds1", offloadPolicies);
 
 //         S3 offload
         CmdTopics cmdTopics2 = new CmdTopics(() -> admin);
-        cmdTopics2.run(split("set-offload-policies persistent://myprop/clust/ns1/ds2 -d s3 -r region -b "
+        cmdTopics2.run(split("set-offload-policies persistent://mytenant/ns1/ds2 -d s3 -r region -b "
                 + "bucket -e endpoint -ts 50 -m 8 -rb 9 -t 10 -orp tiered-storage-first"));
         OffloadPoliciesImpl offloadPolicies2 = OffloadPoliciesImpl.create("s3", "region", "bucket",
                 "endpoint", null, null, null, null, 8, 9,
                 10L, 50L, null, OffloadedReadPriority.TIERED_STORAGE_FIRST);
-        verify(mockTopics).setOffloadPolicies("persistent://myprop/clust/ns1/ds2", offloadPolicies2);
+        verify(mockTopics).setOffloadPolicies("persistent://mytenant/ns1/ds2", offloadPolicies2);
     }
 
 
@@ -1610,57 +1611,57 @@ public class PulsarAdminToolTest {
 
         CmdTopics cmdTopics = new CmdTopics(() -> admin);
 
-        cmdTopics.run(split("truncate persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).truncate("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("truncate persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).truncate("persistent://mytenant/ns1/ds1");
 
-        cmdTopics.run(split("delete persistent://myprop/clust/ns1/ds1 -f"));
-        verify(mockTopics).delete("persistent://myprop/clust/ns1/ds1", true);
+        cmdTopics.run(split("delete persistent://mytenant/ns1/ds1 -f"));
+        verify(mockTopics).delete("persistent://mytenant/ns1/ds1", true);
 
-        cmdTopics.run(split("unload persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).unload("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("unload persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).unload("persistent://mytenant/ns1/ds1");
 
-        cmdTopics.run(split("permissions persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).getPermissions("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("permissions persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).getPermissions("persistent://mytenant/ns1/ds1");
 
         cmdTopics.run(split(
-                "grant-permission persistent://myprop/clust/ns1/ds1 --role admin --actions produce,consume"));
-        verify(mockTopics).grantPermission("persistent://myprop/clust/ns1/ds1", "admin",
+                "grant-permission persistent://mytenant/ns1/ds1 --role admin --actions produce,consume"));
+        verify(mockTopics).grantPermission("persistent://mytenant/ns1/ds1", "admin",
                 Sets.newHashSet(AuthAction.produce, AuthAction.consume));
 
-        cmdTopics.run(split("revoke-permission persistent://myprop/clust/ns1/ds1 --role admin"));
-        verify(mockTopics).revokePermissions("persistent://myprop/clust/ns1/ds1", "admin");
+        cmdTopics.run(split("revoke-permission persistent://mytenant/ns1/ds1 --role admin"));
+        verify(mockTopics).revokePermissions("persistent://mytenant/ns1/ds1", "admin");
 
-        cmdTopics.run(split("list myprop/clust/ns1"));
-        verify(mockTopics).getList("myprop/clust/ns1", null, ListTopicsOptions.EMPTY);
+        cmdTopics.run(split("list mytenant/ns1"));
+        verify(mockTopics).getList("mytenant/ns1", null, ListTopicsOptions.EMPTY);
 
-        cmdTopics.run(split("lookup persistent://myprop/clust/ns1/ds1"));
-        verify(mockLookup).lookupTopic("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("lookup persistent://mytenant/ns1/ds1"));
+        verify(mockLookup).lookupTopic("persistent://mytenant/ns1/ds1");
 
-        cmdTopics.run(split("partitioned-lookup persistent://myprop/clust/ns1/ds1"));
-        verify(mockLookup).lookupPartitionedTopic("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("partitioned-lookup persistent://mytenant/ns1/ds1"));
+        verify(mockLookup).lookupPartitionedTopic("persistent://mytenant/ns1/ds1");
 
-        cmdTopics.run(split("partitioned-lookup persistent://myprop/clust/ns1/ds1 --sort-by-broker"));
-        verify(mockLookup, times(2)).lookupPartitionedTopic("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("partitioned-lookup persistent://mytenant/ns1/ds1 --sort-by-broker"));
+        verify(mockLookup, times(2)).lookupPartitionedTopic("persistent://mytenant/ns1/ds1");
 
-        cmdTopics.run(split("bundle-range persistent://myprop/clust/ns1/ds1"));
-        verify(mockLookup).getBundleRange("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("bundle-range persistent://mytenant/ns1/ds1"));
+        verify(mockLookup).getBundleRange("persistent://mytenant/ns1/ds1");
 
-        cmdTopics.run(split("subscriptions persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).getSubscriptions("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("subscriptions persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).getSubscriptions("persistent://mytenant/ns1/ds1");
 
-        cmdTopics.run(split("unsubscribe persistent://myprop/clust/ns1/ds1 -s sub1"));
-        verify(mockTopics).deleteSubscription("persistent://myprop/clust/ns1/ds1", "sub1", false);
+        cmdTopics.run(split("unsubscribe persistent://mytenant/ns1/ds1 -s sub1"));
+        verify(mockTopics).deleteSubscription("persistent://mytenant/ns1/ds1", "sub1", false);
 
-        cmdTopics.run(split("stats persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).getStats("persistent://myprop/clust/ns1/ds1", false, true, false);
+        cmdTopics.run(split("stats persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).getStats("persistent://mytenant/ns1/ds1", false, true, false);
 
-        cmdTopics.run(split("stats-internal persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).getInternalStats("persistent://myprop/clust/ns1/ds1", false);
+        cmdTopics.run(split("stats-internal persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).getInternalStats("persistent://mytenant/ns1/ds1", false);
 
-        cmdTopics.run(split("get-backlog-quotas persistent://myprop/clust/ns1/ds1 -ap"));
-        verify(mockTopics).getBacklogQuotaMap("persistent://myprop/clust/ns1/ds1", true);
-        cmdTopics.run(split("set-backlog-quota persistent://myprop/clust/ns1/ds1 -l 10 -p producer_request_hold"));
-        verify(mockTopics).setBacklogQuota("persistent://myprop/clust/ns1/ds1",
+        cmdTopics.run(split("get-backlog-quotas persistent://mytenant/ns1/ds1 -ap"));
+        verify(mockTopics).getBacklogQuotaMap("persistent://mytenant/ns1/ds1", true);
+        cmdTopics.run(split("set-backlog-quota persistent://mytenant/ns1/ds1 -l 10 -p producer_request_hold"));
+        verify(mockTopics).setBacklogQuota("persistent://mytenant/ns1/ds1",
                 BacklogQuota.builder()
                         .limitSize(10)
                         .retentionPolicy(RetentionPolicy.producer_request_hold)
@@ -1669,8 +1670,8 @@ public class PulsarAdminToolTest {
         //cmd with option cannot be executed repeatedly.
         cmdTopics = new CmdTopics(() -> admin);
         cmdTopics.run(split(
-                "set-backlog-quota persistent://myprop/clust/ns1/ds1 -lt 5h -p consumer_backlog_eviction"));
-        verify(mockTopics).setBacklogQuota("persistent://myprop/clust/ns1/ds1",
+                "set-backlog-quota persistent://mytenant/ns1/ds1 -lt 5h -p consumer_backlog_eviction"));
+        verify(mockTopics).setBacklogQuota("persistent://mytenant/ns1/ds1",
                 BacklogQuota.builder()
                         .limitSize(-1)
                         .limitTime(5 * 60 * 60)
@@ -1679,9 +1680,9 @@ public class PulsarAdminToolTest {
                 BacklogQuota.BacklogQuotaType.destination_storage);
         //cmd with option cannot be executed repeatedly.
         cmdTopics = new CmdTopics(() -> admin);
-        cmdTopics.run(split("set-backlog-quota persistent://myprop/clust/ns1/ds1 -lt 1000 -p "
+        cmdTopics.run(split("set-backlog-quota persistent://mytenant/ns1/ds1 -lt 1000 -p "
                 + "producer_request_hold -t message_age"));
-        verify(mockTopics).setBacklogQuota("persistent://myprop/clust/ns1/ds1",
+        verify(mockTopics).setBacklogQuota("persistent://mytenant/ns1/ds1",
                 BacklogQuota.builder()
                         .limitSize(-1)
                         .limitTime(1000)
@@ -1690,349 +1691,349 @@ public class PulsarAdminToolTest {
                 BacklogQuota.BacklogQuotaType.message_age);
         //cmd with option cannot be executed repeatedly.
         cmdTopics = new CmdTopics(() -> admin);
-        cmdTopics.run(split("remove-backlog-quota persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).removeBacklogQuota("persistent://myprop/clust/ns1/ds1",
+        cmdTopics.run(split("remove-backlog-quota persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).removeBacklogQuota("persistent://mytenant/ns1/ds1",
                 BacklogQuota.BacklogQuotaType.destination_storage);
         //cmd with option cannot be executed repeatedly.
         cmdTopics = new CmdTopics(() -> admin);
-        cmdTopics.run(split("remove-backlog-quota persistent://myprop/clust/ns1/ds1 -t message_age"));
-        verify(mockTopics).removeBacklogQuota("persistent://myprop/clust/ns1/ds1",
+        cmdTopics.run(split("remove-backlog-quota persistent://mytenant/ns1/ds1 -t message_age"));
+        verify(mockTopics).removeBacklogQuota("persistent://mytenant/ns1/ds1",
                 BacklogQuota.BacklogQuotaType.message_age);
 
-        cmdTopics.run(split("info-internal persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).getInternalInfo("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("info-internal persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).getInternalInfo("persistent://mytenant/ns1/ds1");
 
-        cmdTopics.run(split("partitioned-stats persistent://myprop/clust/ns1/ds1 --per-partition"));
-        verify(mockTopics).getPartitionedStats("persistent://myprop/clust/ns1/ds1",
+        cmdTopics.run(split("partitioned-stats persistent://mytenant/ns1/ds1 --per-partition"));
+        verify(mockTopics).getPartitionedStats("persistent://mytenant/ns1/ds1",
                 true, false, true, false);
 
-        cmdTopics.run(split("partitioned-stats-internal persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).getPartitionedInternalStats("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("partitioned-stats-internal persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).getPartitionedInternalStats("persistent://mytenant/ns1/ds1");
 
-        cmdTopics.run(split("clear-backlog persistent://myprop/clust/ns1/ds1 -s sub1"));
-        verify(mockTopics).skipAllMessages("persistent://myprop/clust/ns1/ds1", "sub1");
+        cmdTopics.run(split("clear-backlog persistent://mytenant/ns1/ds1 -s sub1"));
+        verify(mockTopics).skipAllMessages("persistent://mytenant/ns1/ds1", "sub1");
 
-        cmdTopics.run(split("skip persistent://myprop/clust/ns1/ds1 -s sub1 -n 100"));
-        verify(mockTopics).skipMessages("persistent://myprop/clust/ns1/ds1", "sub1", 100);
+        cmdTopics.run(split("skip persistent://mytenant/ns1/ds1 -s sub1 -n 100"));
+        verify(mockTopics).skipMessages("persistent://mytenant/ns1/ds1", "sub1", 100);
 
-        cmdTopics.run(split("expire-messages persistent://myprop/clust/ns1/ds1 -s sub1 -t 100"));
-        verify(mockTopics).expireMessages("persistent://myprop/clust/ns1/ds1", "sub1", 100);
+        cmdTopics.run(split("expire-messages persistent://mytenant/ns1/ds1 -s sub1 -t 100"));
+        verify(mockTopics).expireMessages("persistent://mytenant/ns1/ds1", "sub1", 100);
 
-        cmdTopics.run(split("expire-messages-all-subscriptions persistent://myprop/clust/ns1/ds1 -t 100"));
-        verify(mockTopics).expireMessagesForAllSubscriptions("persistent://myprop/clust/ns1/ds1", 100);
+        cmdTopics.run(split("expire-messages-all-subscriptions persistent://mytenant/ns1/ds1 -t 100"));
+        verify(mockTopics).expireMessagesForAllSubscriptions("persistent://mytenant/ns1/ds1", 100);
 
-        cmdTopics.run(split("get-subscribe-rate persistent://myprop/clust/ns1/ds1 -ap"));
-        verify(mockTopics).getSubscribeRate("persistent://myprop/clust/ns1/ds1", true);
+        cmdTopics.run(split("get-subscribe-rate persistent://mytenant/ns1/ds1 -ap"));
+        verify(mockTopics).getSubscribeRate("persistent://mytenant/ns1/ds1", true);
 
-        cmdTopics.run(split("set-subscribe-rate persistent://myprop/clust/ns1/ds1 -sr 2 -st 60"));
-        verify(mockTopics).setSubscribeRate("persistent://myprop/clust/ns1/ds1", new SubscribeRate(2, 60));
+        cmdTopics.run(split("set-subscribe-rate persistent://mytenant/ns1/ds1 -sr 2 -st 60"));
+        verify(mockTopics).setSubscribeRate("persistent://mytenant/ns1/ds1", new SubscribeRate(2, 60));
 
-        cmdTopics.run(split("remove-subscribe-rate persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).removeSubscribeRate("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("remove-subscribe-rate persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).removeSubscribeRate("persistent://mytenant/ns1/ds1");
 
-        cmdTopics.run(split("set-replicated-subscription-status persistent://myprop/clust/ns1/ds1 -s sub1 -e"));
-        verify(mockTopics).setReplicatedSubscriptionStatus("persistent://myprop/clust/ns1/ds1", "sub1", true);
+        cmdTopics.run(split("set-replicated-subscription-status persistent://mytenant/ns1/ds1 -s sub1 -e"));
+        verify(mockTopics).setReplicatedSubscriptionStatus("persistent://mytenant/ns1/ds1", "sub1", true);
 
         //cmd with option cannot be executed repeatedly.
         cmdTopics = new CmdTopics(() -> admin);
-        cmdTopics.run(split("expire-messages persistent://myprop/clust/ns1/ds1 -s sub1 -p 1:1 -e"));
-        verify(mockTopics).expireMessages(eq("persistent://myprop/clust/ns1/ds1"), eq("sub1"),
+        cmdTopics.run(split("expire-messages persistent://mytenant/ns1/ds1 -s sub1 -p 1:1 -e"));
+        verify(mockTopics).expireMessages(eq("persistent://mytenant/ns1/ds1"), eq("sub1"),
                 eq(new MessageIdImpl(1, 1, -1)), eq(true));
 
-        cmdTopics.run(split("expire-messages-all-subscriptions persistent://myprop/clust/ns1/ds1 -t 1d"));
-        verify(mockTopics).expireMessagesForAllSubscriptions("persistent://myprop/clust/ns1/ds1", 60 * 60 * 24);
+        cmdTopics.run(split("expire-messages-all-subscriptions persistent://mytenant/ns1/ds1 -t 1d"));
+        verify(mockTopics).expireMessagesForAllSubscriptions("persistent://mytenant/ns1/ds1", 60 * 60 * 24);
 
-        cmdTopics.run(split("create-subscription persistent://myprop/clust/ns1/ds1 -s sub1 --messageId earliest"));
-        verify(mockTopics).createSubscription("persistent://myprop/clust/ns1/ds1", "sub1",
+        cmdTopics.run(split("create-subscription persistent://mytenant/ns1/ds1 -s sub1 --messageId earliest"));
+        verify(mockTopics).createSubscription("persistent://mytenant/ns1/ds1", "sub1",
                 MessageId.earliest, false, null);
 
-        cmdTopics.run(split("analyze-backlog persistent://myprop/clust/ns1/ds1 -s sub1"));
-        verify(mockTopics).analyzeSubscriptionBacklog("persistent://myprop/clust/ns1/ds1", "sub1",
+        cmdTopics.run(split("analyze-backlog persistent://mytenant/ns1/ds1 -s sub1"));
+        verify(mockTopics).analyzeSubscriptionBacklog("persistent://mytenant/ns1/ds1", "sub1",
                 Optional.empty());
 
-        cmdTopics.run(split("trim-topic persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).trimTopic("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("trim-topic persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).trimTopic("persistent://mytenant/ns1/ds1");
 
         // jcommander is stateful, you cannot parse the same command twice
         cmdTopics = new CmdTopics(() -> admin);
-        cmdTopics.run(split("create-subscription persistent://myprop/clust/ns1/ds1 -s sub1 "
+        cmdTopics.run(split("create-subscription persistent://mytenant/ns1/ds1 -s sub1 "
                 + "--messageId earliest --property a=b -p x=y,z"));
         Map<String, String> props = new HashMap<>();
         props.put("a", "b");
         props.put("x", "y,z");
-        verify(mockTopics).createSubscription("persistent://myprop/clust/ns1/ds1", "sub1",
+        verify(mockTopics).createSubscription("persistent://mytenant/ns1/ds1", "sub1",
                 MessageId.earliest, false, props);
 
         cmdTopics = new CmdTopics(() -> admin);
-        cmdTopics.run(split("create-subscription persistent://myprop/clust/ns1/ds1 -s sub1 "
+        cmdTopics.run(split("create-subscription persistent://mytenant/ns1/ds1 -s sub1 "
                 + "--messageId earliest -r"));
-        verify(mockTopics).createSubscription("persistent://myprop/clust/ns1/ds1", "sub1",
+        verify(mockTopics).createSubscription("persistent://mytenant/ns1/ds1", "sub1",
                 MessageId.earliest, true, null);
 
         cmdTopics = new CmdTopics(() -> admin);
-        cmdTopics.run(split("update-subscription-properties persistent://myprop/clust/ns1/ds1 -s sub1 --clear"));
-        verify(mockTopics).updateSubscriptionProperties("persistent://myprop/clust/ns1/ds1", "sub1",
+        cmdTopics.run(split("update-subscription-properties persistent://mytenant/ns1/ds1 -s sub1 --clear"));
+        verify(mockTopics).updateSubscriptionProperties("persistent://mytenant/ns1/ds1", "sub1",
                 new HashMap<>());
 
         cmdTopics = new CmdTopics(() -> admin);
-        cmdTopics.run(split("update-properties persistent://myprop/clust/ns1/ds1 --property a=b -p x=y,z"));
+        cmdTopics.run(split("update-properties persistent://mytenant/ns1/ds1 --property a=b -p x=y,z"));
         props = new HashMap<>();
         props.put("a", "b");
         props.put("x", "y,z");
-        verify(mockTopics).updateProperties("persistent://myprop/clust/ns1/ds1", props);
+        verify(mockTopics).updateProperties("persistent://mytenant/ns1/ds1", props);
 
         cmdTopics = new CmdTopics(() -> admin);
-        cmdTopics.run(split("remove-properties persistent://myprop/clust/ns1/ds1 --key a"));
-        verify(mockTopics).removeProperties("persistent://myprop/clust/ns1/ds1", "a");
+        cmdTopics.run(split("remove-properties persistent://mytenant/ns1/ds1 --key a"));
+        verify(mockTopics).removeProperties("persistent://mytenant/ns1/ds1", "a");
 
         cmdTopics = new CmdTopics(() -> admin);
-        cmdTopics.run(split("get-subscription-properties persistent://myprop/clust/ns1/ds1 -s sub1"));
-        verify(mockTopics).getSubscriptionProperties("persistent://myprop/clust/ns1/ds1", "sub1");
+        cmdTopics.run(split("get-subscription-properties persistent://mytenant/ns1/ds1 -s sub1"));
+        verify(mockTopics).getSubscriptionProperties("persistent://mytenant/ns1/ds1", "sub1");
 
         cmdTopics = new CmdTopics(() -> admin);
         props = new HashMap<>();
         props.put("a", "b");
         props.put("c", "d");
         props.put("x", "y,z");
-        cmdTopics.run(split("update-subscription-properties persistent://myprop/clust/ns1/ds1 -s "
+        cmdTopics.run(split("update-subscription-properties persistent://mytenant/ns1/ds1 -s "
                 + "sub1 -p a=b -p c=d -p x=y,z"));
-        verify(mockTopics).updateSubscriptionProperties("persistent://myprop/clust/ns1/ds1", "sub1", props);
+        verify(mockTopics).updateSubscriptionProperties("persistent://mytenant/ns1/ds1", "sub1", props);
 
-        cmdTopics.run(split("create-partitioned-topic persistent://myprop/clust/ns1/ds1 --partitions 32"));
-        verify(mockTopics).createPartitionedTopic("persistent://myprop/clust/ns1/ds1", 32, null);
+        cmdTopics.run(split("create-partitioned-topic persistent://mytenant/ns1/ds1 --partitions 32"));
+        verify(mockTopics).createPartitionedTopic("persistent://mytenant/ns1/ds1", 32, null);
 
-        cmdTopics.run(split("create-missed-partitions persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).createMissedPartitions("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("create-missed-partitions persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).createMissedPartitions("persistent://mytenant/ns1/ds1");
 
-        cmdTopics.run(split("create persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).createNonPartitionedTopic("persistent://myprop/clust/ns1/ds1", null);
+        cmdTopics.run(split("create persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).createNonPartitionedTopic("persistent://mytenant/ns1/ds1", null);
 
-        cmdTopics.run(split("list-partitioned-topics myprop/clust/ns1"));
-        verify(mockTopics).getPartitionedTopicList("myprop/clust/ns1", ListTopicsOptions.EMPTY);
+        cmdTopics.run(split("list-partitioned-topics mytenant/ns1"));
+        verify(mockTopics).getPartitionedTopicList("mytenant/ns1", ListTopicsOptions.EMPTY);
 
-        cmdTopics.run(split("update-partitioned-topic persistent://myprop/clust/ns1/ds1 -p 6"));
-        verify(mockTopics).updatePartitionedTopic("persistent://myprop/clust/ns1/ds1", 6, false, false);
+        cmdTopics.run(split("update-partitioned-topic persistent://mytenant/ns1/ds1 -p 6"));
+        verify(mockTopics).updatePartitionedTopic("persistent://mytenant/ns1/ds1", 6, false, false);
 
-        cmdTopics.run(split("get-partitioned-topic-metadata persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).getPartitionedTopicMetadata("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("get-partitioned-topic-metadata persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).getPartitionedTopicMetadata("persistent://mytenant/ns1/ds1");
 
-        cmdTopics.run(split("delete-partitioned-topic persistent://myprop/clust/ns1/ds1 -f"));
-        verify(mockTopics).deletePartitionedTopic("persistent://myprop/clust/ns1/ds1", true);
+        cmdTopics.run(split("delete-partitioned-topic persistent://mytenant/ns1/ds1 -f"));
+        verify(mockTopics).deletePartitionedTopic("persistent://mytenant/ns1/ds1", true);
 
-        cmdTopics.run(split("peek-messages persistent://myprop/clust/ns1/ds1 -s sub1 -n 3"));
-        verify(mockTopics).peekMessages("persistent://myprop/clust/ns1/ds1", "sub1", 3,
+        cmdTopics.run(split("peek-messages persistent://mytenant/ns1/ds1 -s sub1 -n 3"));
+        verify(mockTopics).peekMessages("persistent://mytenant/ns1/ds1", "sub1", 3,
                 false, TransactionIsolationLevel.READ_COMMITTED);
 
         MessageImpl message = mock(MessageImpl.class);
         when(message.getData()).thenReturn(new byte[]{});
         when(message.getMessageId()).thenReturn(new MessageIdImpl(1L, 1L, 1));
-        when(mockTopics.examineMessage("persistent://myprop/clust/ns1/ds1", "latest",
+        when(mockTopics.examineMessage("persistent://mytenant/ns1/ds1", "latest",
                 1)).thenReturn(message);
-        cmdTopics.run(split("examine-messages persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).examineMessage("persistent://myprop/clust/ns1/ds1", "latest", 1);
+        cmdTopics.run(split("examine-messages persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).examineMessage("persistent://mytenant/ns1/ds1", "latest", 1);
 
-        cmdTopics.run(split("enable-deduplication persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).enableDeduplication("persistent://myprop/clust/ns1/ds1", true);
+        cmdTopics.run(split("enable-deduplication persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).enableDeduplication("persistent://mytenant/ns1/ds1", true);
 
-        cmdTopics.run(split("disable-deduplication persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).enableDeduplication("persistent://myprop/clust/ns1/ds1", false);
+        cmdTopics.run(split("disable-deduplication persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).enableDeduplication("persistent://mytenant/ns1/ds1", false);
 
-        cmdTopics.run(split("set-deduplication persistent://myprop/clust/ns1/ds1 --disable"));
-        verify(mockTopics).setDeduplicationStatus("persistent://myprop/clust/ns1/ds1", false);
+        cmdTopics.run(split("set-deduplication persistent://mytenant/ns1/ds1 --disable"));
+        verify(mockTopics).setDeduplicationStatus("persistent://mytenant/ns1/ds1", false);
 
-        cmdTopics.run(split("set-subscription-dispatch-rate persistent://myprop/clust/ns1/ds1 -md -1 "
+        cmdTopics.run(split("set-subscription-dispatch-rate persistent://mytenant/ns1/ds1 -md -1 "
                 + "-bd -1 -dt 2"));
-        verify(mockTopics).setSubscriptionDispatchRate("persistent://myprop/clust/ns1/ds1",
+        verify(mockTopics).setSubscriptionDispatchRate("persistent://mytenant/ns1/ds1",
                 DispatchRate.builder()
                         .dispatchThrottlingRateInMsg(-1)
                         .dispatchThrottlingRateInByte(-1)
                         .ratePeriodInSecond(2)
                         .build());
-        cmdTopics.run(split("get-subscription-dispatch-rate persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).getSubscriptionDispatchRate("persistent://myprop/clust/ns1/ds1", false);
-        cmdTopics.run(split("remove-subscription-dispatch-rate persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).removeSubscriptionDispatchRate("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("get-subscription-dispatch-rate persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).getSubscriptionDispatchRate("persistent://mytenant/ns1/ds1", false);
+        cmdTopics.run(split("remove-subscription-dispatch-rate persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).removeSubscriptionDispatchRate("persistent://mytenant/ns1/ds1");
 
-        cmdTopics.run(split("remove-deduplication persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).removeDeduplicationStatus("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("remove-deduplication persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).removeDeduplicationStatus("persistent://mytenant/ns1/ds1");
 
-        cmdTopics.run(split("get-replicator-dispatch-rate persistent://myprop/clust/ns1/ds1 -ap"));
-        verify(mockTopics).getReplicatorDispatchRate("persistent://myprop/clust/ns1/ds1", true);
+        cmdTopics.run(split("get-replicator-dispatch-rate persistent://mytenant/ns1/ds1 -ap"));
+        verify(mockTopics).getReplicatorDispatchRate("persistent://mytenant/ns1/ds1", true);
 
-        cmdTopics.run(split("set-subscription-types-enabled persistent://myprop/clust/ns1/ds1 -t "
+        cmdTopics.run(split("set-subscription-types-enabled persistent://mytenant/ns1/ds1 -t "
                 + "Shared,Failover"));
-        verify(mockTopics).setSubscriptionTypesEnabled("persistent://myprop/clust/ns1/ds1",
+        verify(mockTopics).setSubscriptionTypesEnabled("persistent://mytenant/ns1/ds1",
                 Sets.newHashSet(SubscriptionType.Shared, SubscriptionType.Failover));
 
-        cmdTopics.run(split("get-subscription-types-enabled persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).getSubscriptionTypesEnabled("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("get-subscription-types-enabled persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).getSubscriptionTypesEnabled("persistent://mytenant/ns1/ds1");
 
-        cmdTopics.run(split("remove-subscription-types-enabled persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).removeSubscriptionTypesEnabled("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("remove-subscription-types-enabled persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).removeSubscriptionTypesEnabled("persistent://mytenant/ns1/ds1");
 
-        cmdTopics.run(split("set-replicator-dispatch-rate persistent://myprop/clust/ns1/ds1 -md 10 "
+        cmdTopics.run(split("set-replicator-dispatch-rate persistent://mytenant/ns1/ds1 -md 10 "
                 + "-bd 11 -dt 12"));
-        verify(mockTopics).setReplicatorDispatchRate("persistent://myprop/clust/ns1/ds1",
+        verify(mockTopics).setReplicatorDispatchRate("persistent://mytenant/ns1/ds1",
                 DispatchRate.builder()
                         .dispatchThrottlingRateInMsg(10)
                         .dispatchThrottlingRateInByte(11)
                         .ratePeriodInSecond(12)
                         .build());
 
-        cmdTopics.run(split("remove-replicator-dispatch-rate persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).removeReplicatorDispatchRate("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("remove-replicator-dispatch-rate persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).removeReplicatorDispatchRate("persistent://mytenant/ns1/ds1");
 
-        cmdTopics.run(split("get-deduplication-enabled persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).getDeduplicationStatus("persistent://myprop/clust/ns1/ds1");
-        cmdTopics.run(split("get-deduplication persistent://myprop/clust/ns1/ds1"));
+        cmdTopics.run(split("get-deduplication-enabled persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).getDeduplicationStatus("persistent://mytenant/ns1/ds1");
+        cmdTopics.run(split("get-deduplication persistent://mytenant/ns1/ds1"));
         verify(mockTopics, times(2)).getDeduplicationStatus(
-                "persistent://myprop/clust/ns1/ds1");
+                "persistent://mytenant/ns1/ds1");
 
-        cmdTopics.run(split("get-offload-policies persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).getOffloadPolicies("persistent://myprop/clust/ns1/ds1", false);
+        cmdTopics.run(split("get-offload-policies persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).getOffloadPolicies("persistent://mytenant/ns1/ds1", false);
 
-        cmdTopics.run(split("remove-offload-policies persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).removeOffloadPolicies("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("remove-offload-policies persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).removeOffloadPolicies("persistent://mytenant/ns1/ds1");
 
-        cmdTopics.run(split("get-delayed-delivery persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).getDelayedDeliveryPolicy("persistent://myprop/clust/ns1/ds1", false);
-        cmdTopics.run(split("set-delayed-delivery persistent://myprop/clust/ns1/ds1 -t 10s -md 5s --enable"));
-        verify(mockTopics).setDelayedDeliveryPolicy("persistent://myprop/clust/ns1/ds1",
+        cmdTopics.run(split("get-delayed-delivery persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).getDelayedDeliveryPolicy("persistent://mytenant/ns1/ds1", false);
+        cmdTopics.run(split("set-delayed-delivery persistent://mytenant/ns1/ds1 -t 10s -md 5s --enable"));
+        verify(mockTopics).setDelayedDeliveryPolicy("persistent://mytenant/ns1/ds1",
                 DelayedDeliveryPolicies.builder().tickTime(10000).active(true)
                         .maxDeliveryDelayInMillis(5000).build());
-        cmdTopics.run(split("remove-delayed-delivery persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).removeDelayedDeliveryPolicy("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("remove-delayed-delivery persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).removeDelayedDeliveryPolicy("persistent://mytenant/ns1/ds1");
 
-        cmdTopics.run(split("set-offload-policies persistent://myprop/clust/ns1/ds1 -d s3 -r region -b "
+        cmdTopics.run(split("set-offload-policies persistent://mytenant/ns1/ds1 -d s3 -r region -b "
                 + "bucket -e endpoint -ts 50 -m 8 -rb 9 -t 10 -orp tiered-storage-first"));
         OffloadPoliciesImpl offloadPolicies = OffloadPoliciesImpl.create("s3", "region", "bucket"
                 , "endpoint", null, null, null, null,
                 8, 9, 10L, 50L, null,
                 OffloadedReadPriority.TIERED_STORAGE_FIRST);
-        verify(mockTopics).setOffloadPolicies("persistent://myprop/clust/ns1/ds1", offloadPolicies);
+        verify(mockTopics).setOffloadPolicies("persistent://mytenant/ns1/ds1", offloadPolicies);
 
-        cmdTopics.run(split("get-max-unacked-messages-on-consumer persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).getMaxUnackedMessagesOnConsumer("persistent://myprop/clust/ns1/ds1", false);
-        cmdTopics.run(split("get-max-unacked-messages-per-consumer persistent://myprop/clust/ns1/ds1"));
+        cmdTopics.run(split("get-max-unacked-messages-on-consumer persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).getMaxUnackedMessagesOnConsumer("persistent://mytenant/ns1/ds1", false);
+        cmdTopics.run(split("get-max-unacked-messages-per-consumer persistent://mytenant/ns1/ds1"));
         verify(mockTopics, times(2))
-                .getMaxUnackedMessagesOnConsumer("persistent://myprop/clust/ns1/ds1", false);
-        cmdTopics.run(split("remove-max-unacked-messages-on-consumer persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).removeMaxUnackedMessagesOnConsumer("persistent://myprop/clust/ns1/ds1");
-        cmdTopics.run(split("remove-max-unacked-messages-per-consumer persistent://myprop/clust/ns1/ds1"));
+                .getMaxUnackedMessagesOnConsumer("persistent://mytenant/ns1/ds1", false);
+        cmdTopics.run(split("remove-max-unacked-messages-on-consumer persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).removeMaxUnackedMessagesOnConsumer("persistent://mytenant/ns1/ds1");
+        cmdTopics.run(split("remove-max-unacked-messages-per-consumer persistent://mytenant/ns1/ds1"));
         verify(mockTopics, times(2)).removeMaxUnackedMessagesOnConsumer(
-                "persistent://myprop/clust/ns1/ds1");
-        cmdTopics.run(split("set-max-unacked-messages-on-consumer persistent://myprop/clust/ns1/ds1 -m 999"));
-        verify(mockTopics).setMaxUnackedMessagesOnConsumer("persistent://myprop/clust/ns1/ds1", 999);
-        cmdTopics.run(split("set-max-unacked-messages-per-consumer persistent://myprop/clust/ns1/ds1 -m 999"));
+                "persistent://mytenant/ns1/ds1");
+        cmdTopics.run(split("set-max-unacked-messages-on-consumer persistent://mytenant/ns1/ds1 -m 999"));
+        verify(mockTopics).setMaxUnackedMessagesOnConsumer("persistent://mytenant/ns1/ds1", 999);
+        cmdTopics.run(split("set-max-unacked-messages-per-consumer persistent://mytenant/ns1/ds1 -m 999"));
         verify(mockTopics, times(2)).setMaxUnackedMessagesOnConsumer(
-                "persistent://myprop/clust/ns1/ds1", 999);
+                "persistent://mytenant/ns1/ds1", 999);
 
-        cmdTopics.run(split("get-max-unacked-messages-on-subscription persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).getMaxUnackedMessagesOnSubscription("persistent://myprop/clust/ns1/ds1", false);
-        cmdTopics.run(split("get-max-unacked-messages-per-subscription persistent://myprop/clust/ns1/ds1"));
+        cmdTopics.run(split("get-max-unacked-messages-on-subscription persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).getMaxUnackedMessagesOnSubscription("persistent://mytenant/ns1/ds1", false);
+        cmdTopics.run(split("get-max-unacked-messages-per-subscription persistent://mytenant/ns1/ds1"));
         verify(mockTopics, times(2)).getMaxUnackedMessagesOnSubscription(
-                "persistent://myprop/clust/ns1/ds1", false);
-        cmdTopics.run(split("remove-max-unacked-messages-on-subscription persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).removeMaxUnackedMessagesOnSubscription("persistent://myprop/clust/ns1/ds1");
-        cmdTopics.run(split("remove-max-unacked-messages-per-subscription persistent://myprop/clust/ns1/ds1"));
+                "persistent://mytenant/ns1/ds1", false);
+        cmdTopics.run(split("remove-max-unacked-messages-on-subscription persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).removeMaxUnackedMessagesOnSubscription("persistent://mytenant/ns1/ds1");
+        cmdTopics.run(split("remove-max-unacked-messages-per-subscription persistent://mytenant/ns1/ds1"));
         verify(mockTopics, times(2)).removeMaxUnackedMessagesOnSubscription(
-                "persistent://myprop/clust/ns1/ds1");
-        cmdTopics.run(split("get-publish-rate persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).getPublishRate("persistent://myprop/clust/ns1/ds1");
-        cmdTopics.run(split("set-publish-rate persistent://myprop/clust/ns1/ds1 -m 100 -b 10240"));
-        verify(mockTopics).setPublishRate("persistent://myprop/clust/ns1/ds1", new PublishRate(100, 10240L));
-        cmdTopics.run(split("remove-publish-rate persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).removePublishRate("persistent://myprop/clust/ns1/ds1");
-        cmdTopics.run(split("set-max-unacked-messages-on-subscription persistent://myprop/clust/ns1/ds1 -m 99"));
-        verify(mockTopics).setMaxUnackedMessagesOnSubscription("persistent://myprop/clust/ns1/ds1", 99);
-        cmdTopics.run(split("set-max-unacked-messages-per-subscription persistent://myprop/clust/ns1/ds1 -m 99"));
+                "persistent://mytenant/ns1/ds1");
+        cmdTopics.run(split("get-publish-rate persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).getPublishRate("persistent://mytenant/ns1/ds1");
+        cmdTopics.run(split("set-publish-rate persistent://mytenant/ns1/ds1 -m 100 -b 10240"));
+        verify(mockTopics).setPublishRate("persistent://mytenant/ns1/ds1", new PublishRate(100, 10240L));
+        cmdTopics.run(split("remove-publish-rate persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).removePublishRate("persistent://mytenant/ns1/ds1");
+        cmdTopics.run(split("set-max-unacked-messages-on-subscription persistent://mytenant/ns1/ds1 -m 99"));
+        verify(mockTopics).setMaxUnackedMessagesOnSubscription("persistent://mytenant/ns1/ds1", 99);
+        cmdTopics.run(split("set-max-unacked-messages-per-subscription persistent://mytenant/ns1/ds1 -m 99"));
         verify(mockTopics, times(2)).setMaxUnackedMessagesOnSubscription(
-                "persistent://myprop/clust/ns1/ds1", 99);
+                "persistent://mytenant/ns1/ds1", 99);
 
-        cmdTopics.run(split("get-compaction-threshold persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).getCompactionThreshold("persistent://myprop/clust/ns1/ds1", false);
-        cmdTopics.run(split("set-compaction-threshold persistent://myprop/clust/ns1/ds1 -t 10k"));
-        verify(mockTopics).setCompactionThreshold("persistent://myprop/clust/ns1/ds1", 10 * 1024);
-        cmdTopics.run(split("remove-compaction-threshold persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).removeCompactionThreshold("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("get-compaction-threshold persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).getCompactionThreshold("persistent://mytenant/ns1/ds1", false);
+        cmdTopics.run(split("set-compaction-threshold persistent://mytenant/ns1/ds1 -t 10k"));
+        verify(mockTopics).setCompactionThreshold("persistent://mytenant/ns1/ds1", 10 * 1024);
+        cmdTopics.run(split("remove-compaction-threshold persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).removeCompactionThreshold("persistent://mytenant/ns1/ds1");
 
-        cmdTopics.run(split("get-max-message-size persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).getMaxMessageSize("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("get-max-message-size persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).getMaxMessageSize("persistent://mytenant/ns1/ds1");
 
-        cmdTopics.run(split("remove-max-message-size persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).removeMaxMessageSize("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("remove-max-message-size persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).removeMaxMessageSize("persistent://mytenant/ns1/ds1");
 
-        cmdTopics.run(split("get-max-consumers-per-subscription persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).getMaxConsumersPerSubscription("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("get-max-consumers-per-subscription persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).getMaxConsumersPerSubscription("persistent://mytenant/ns1/ds1");
 
-        cmdTopics.run(split("set-max-consumers-per-subscription persistent://myprop/clust/ns1/ds1 -c 5"));
-        verify(mockTopics).setMaxConsumersPerSubscription("persistent://myprop/clust/ns1/ds1", 5);
+        cmdTopics.run(split("set-max-consumers-per-subscription persistent://mytenant/ns1/ds1 -c 5"));
+        verify(mockTopics).setMaxConsumersPerSubscription("persistent://mytenant/ns1/ds1", 5);
 
-        cmdTopics.run(split("remove-max-consumers-per-subscription persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).removeMaxConsumersPerSubscription("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("remove-max-consumers-per-subscription persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).removeMaxConsumersPerSubscription("persistent://mytenant/ns1/ds1");
 
-        cmdTopics.run(split("set-max-message-size persistent://myprop/clust/ns1/ds1 -m 99"));
-        verify(mockTopics).setMaxMessageSize("persistent://myprop/clust/ns1/ds1", 99);
+        cmdTopics.run(split("set-max-message-size persistent://mytenant/ns1/ds1 -m 99"));
+        verify(mockTopics).setMaxMessageSize("persistent://mytenant/ns1/ds1", 99);
 
-        cmdTopics.run(split("get-message-by-id persistent://myprop/clust/ns1/ds1 -l 10 -e 2"));
-        verify(mockTopics).getMessageById("persistent://myprop/clust/ns1/ds1", 10, 2);
+        cmdTopics.run(split("get-message-by-id persistent://mytenant/ns1/ds1 -l 10 -e 2"));
+        verify(mockTopics).getMessageById("persistent://mytenant/ns1/ds1", 10, 2);
 
-        cmdTopics.run(split("get-dispatch-rate persistent://myprop/clust/ns1/ds1 -ap"));
-        verify(mockTopics).getDispatchRate("persistent://myprop/clust/ns1/ds1", true);
-        cmdTopics.run(split("remove-dispatch-rate persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).removeDispatchRate("persistent://myprop/clust/ns1/ds1");
-        cmdTopics.run(split("set-dispatch-rate persistent://myprop/clust/ns1/ds1 -md -1 -bd -1 -dt 2"));
-        verify(mockTopics).setDispatchRate("persistent://myprop/clust/ns1/ds1", DispatchRate.builder()
+        cmdTopics.run(split("get-dispatch-rate persistent://mytenant/ns1/ds1 -ap"));
+        verify(mockTopics).getDispatchRate("persistent://mytenant/ns1/ds1", true);
+        cmdTopics.run(split("remove-dispatch-rate persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).removeDispatchRate("persistent://mytenant/ns1/ds1");
+        cmdTopics.run(split("set-dispatch-rate persistent://mytenant/ns1/ds1 -md -1 -bd -1 -dt 2"));
+        verify(mockTopics).setDispatchRate("persistent://mytenant/ns1/ds1", DispatchRate.builder()
                 .dispatchThrottlingRateInMsg(-1)
                 .dispatchThrottlingRateInByte(-1)
                 .ratePeriodInSecond(2)
                 .build());
 
-        cmdTopics.run(split("get-max-producers persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).getMaxProducers("persistent://myprop/clust/ns1/ds1", false);
-        cmdTopics.run(split("remove-max-producers persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).removeMaxProducers("persistent://myprop/clust/ns1/ds1");
-        cmdTopics.run(split("set-max-producers persistent://myprop/clust/ns1/ds1 -p 99"));
-        verify(mockTopics).setMaxProducers("persistent://myprop/clust/ns1/ds1", 99);
+        cmdTopics.run(split("get-max-producers persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).getMaxProducers("persistent://mytenant/ns1/ds1", false);
+        cmdTopics.run(split("remove-max-producers persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).removeMaxProducers("persistent://mytenant/ns1/ds1");
+        cmdTopics.run(split("set-max-producers persistent://mytenant/ns1/ds1 -p 99"));
+        verify(mockTopics).setMaxProducers("persistent://mytenant/ns1/ds1", 99);
 
-        cmdTopics.run(split("get-max-consumers persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).getMaxConsumers("persistent://myprop/clust/ns1/ds1", false);
-        cmdTopics.run(split("remove-max-consumers persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).removeMaxConsumers("persistent://myprop/clust/ns1/ds1");
-        cmdTopics.run(split("set-max-consumers persistent://myprop/clust/ns1/ds1 -c 99"));
-        verify(mockTopics).setMaxConsumers("persistent://myprop/clust/ns1/ds1", 99);
+        cmdTopics.run(split("get-max-consumers persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).getMaxConsumers("persistent://mytenant/ns1/ds1", false);
+        cmdTopics.run(split("remove-max-consumers persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).removeMaxConsumers("persistent://mytenant/ns1/ds1");
+        cmdTopics.run(split("set-max-consumers persistent://mytenant/ns1/ds1 -c 99"));
+        verify(mockTopics).setMaxConsumers("persistent://mytenant/ns1/ds1", 99);
 
-        cmdTopics.run(split("get-deduplication-snapshot-interval persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).getDeduplicationSnapshotInterval("persistent://myprop/clust/ns1/ds1");
-        cmdTopics.run(split("remove-deduplication-snapshot-interval persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).removeDeduplicationSnapshotInterval("persistent://myprop/clust/ns1/ds1");
-        cmdTopics.run(split("set-deduplication-snapshot-interval persistent://myprop/clust/ns1/ds1 -i 99"));
-        verify(mockTopics).setDeduplicationSnapshotInterval("persistent://myprop/clust/ns1/ds1", 99);
+        cmdTopics.run(split("get-deduplication-snapshot-interval persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).getDeduplicationSnapshotInterval("persistent://mytenant/ns1/ds1");
+        cmdTopics.run(split("remove-deduplication-snapshot-interval persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).removeDeduplicationSnapshotInterval("persistent://mytenant/ns1/ds1");
+        cmdTopics.run(split("set-deduplication-snapshot-interval persistent://mytenant/ns1/ds1 -i 99"));
+        verify(mockTopics).setDeduplicationSnapshotInterval("persistent://mytenant/ns1/ds1", 99);
 
-        cmdTopics.run(split("get-inactive-topic-policies persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).getInactiveTopicPolicies("persistent://myprop/clust/ns1/ds1", false);
-        cmdTopics.run(split("remove-inactive-topic-policies persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).removeInactiveTopicPolicies("persistent://myprop/clust/ns1/ds1");
-        cmdTopics.run(split("set-inactive-topic-policies persistent://myprop/clust/ns1/ds1"
+        cmdTopics.run(split("get-inactive-topic-policies persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).getInactiveTopicPolicies("persistent://mytenant/ns1/ds1", false);
+        cmdTopics.run(split("remove-inactive-topic-policies persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).removeInactiveTopicPolicies("persistent://mytenant/ns1/ds1");
+        cmdTopics.run(split("set-inactive-topic-policies persistent://mytenant/ns1/ds1"
                         + " -e -t 1s -m delete_when_no_subscriptions"));
-        verify(mockTopics).setInactiveTopicPolicies("persistent://myprop/clust/ns1/ds1",
+        verify(mockTopics).setInactiveTopicPolicies("persistent://mytenant/ns1/ds1",
                 new InactiveTopicPolicies(InactiveTopicDeleteMode.delete_when_no_subscriptions,
                         1, true));
 
-        cmdTopics.run(split("get-max-subscriptions persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).getMaxSubscriptionsPerTopic("persistent://myprop/clust/ns1/ds1");
-        cmdTopics.run(split("set-max-subscriptions persistent://myprop/clust/ns1/ds1 -m 100"));
-        verify(mockTopics).setMaxSubscriptionsPerTopic("persistent://myprop/clust/ns1/ds1", 100);
-        cmdTopics.run(split("remove-max-subscriptions persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).removeMaxSubscriptionsPerTopic("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("get-max-subscriptions persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).getMaxSubscriptionsPerTopic("persistent://mytenant/ns1/ds1");
+        cmdTopics.run(split("set-max-subscriptions persistent://mytenant/ns1/ds1 -m 100"));
+        verify(mockTopics).setMaxSubscriptionsPerTopic("persistent://mytenant/ns1/ds1", 100);
+        cmdTopics.run(split("remove-max-subscriptions persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).removeMaxSubscriptionsPerTopic("persistent://mytenant/ns1/ds1");
 
-        cmdTopics.run(split("get-persistence persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).getPersistence("persistent://myprop/clust/ns1/ds1");
-        cmdTopics.run(split("set-persistence persistent://myprop/clust/ns1/ds1 -e 2 -w 1 -a 1 -r 100.0"));
-        verify(mockTopics).setPersistence("persistent://myprop/clust/ns1/ds1",
+        cmdTopics.run(split("get-persistence persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).getPersistence("persistent://mytenant/ns1/ds1");
+        cmdTopics.run(split("set-persistence persistent://mytenant/ns1/ds1 -e 2 -w 1 -a 1 -r 100.0"));
+        verify(mockTopics).setPersistence("persistent://mytenant/ns1/ds1",
                 new PersistencePolicies(2, 1, 1, 100.0d));
-        cmdTopics.run(split("remove-persistence persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).removePersistence("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("remove-persistence persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).removePersistence("persistent://mytenant/ns1/ds1");
 
         // argument matcher for the timestamp in reset cursor. Since we can't verify exact timestamp, we check for a
         // range of +/- 1 second of the expected timestamp
@@ -2046,138 +2047,138 @@ public class PulsarAdminToolTest {
                 return false;
             }
         }
-        cmdTopics.run(split("reset-cursor persistent://myprop/clust/ns1/ds1 -s sub1 -t 1m"));
-        verify(mockTopics).resetCursor(eq("persistent://myprop/clust/ns1/ds1"), eq("sub1"),
+        cmdTopics.run(split("reset-cursor persistent://mytenant/ns1/ds1 -s sub1 -t 1m"));
+        verify(mockTopics).resetCursor(eq("persistent://mytenant/ns1/ds1"), eq("sub1"),
                 longThat(new TimestampMatcher()));
 
-        when(mockTopics.terminateTopicAsync("persistent://myprop/clust/ns1/ds1"))
+        when(mockTopics.terminateTopicAsync("persistent://mytenant/ns1/ds1"))
                 .thenReturn(CompletableFuture.completedFuture(new MessageIdImpl(1L, 1L, 1)));
-        cmdTopics.run(split("terminate persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).terminateTopicAsync("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("terminate persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).terminateTopicAsync("persistent://mytenant/ns1/ds1");
 
         Map<Integer, MessageId> results = new HashMap<>();
         results.put(0, new MessageIdImpl(1, 1, 0));
-        when(mockTopics.terminatePartitionedTopic("persistent://myprop/clust/ns1/ds1")).thenReturn(results);
-        cmdTopics.run(split("partitioned-terminate persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).terminatePartitionedTopic("persistent://myprop/clust/ns1/ds1");
+        when(mockTopics.terminatePartitionedTopic("persistent://mytenant/ns1/ds1")).thenReturn(results);
+        cmdTopics.run(split("partitioned-terminate persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).terminatePartitionedTopic("persistent://mytenant/ns1/ds1");
 
-        cmdTopics.run(split("compact persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).triggerCompaction("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("compact persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).triggerCompaction("persistent://mytenant/ns1/ds1");
 
-        when(mockTopics.compactionStatus("persistent://myprop/clust/ns1/ds1"))
+        when(mockTopics.compactionStatus("persistent://mytenant/ns1/ds1"))
                 .thenReturn(new LongRunningProcessStatus());
-        cmdTopics.run(split("compaction-status persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).compactionStatus("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("compaction-status persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).compactionStatus("persistent://mytenant/ns1/ds1");
 
         PersistentTopicInternalStats stats = new PersistentTopicInternalStats();
         stats.ledgers = new ArrayList<>();
         stats.ledgers.add(newLedger(0, 10, 1000));
         stats.ledgers.add(newLedger(1, 10, 2000));
         stats.ledgers.add(newLedger(2, 10, 3000));
-        when(mockTopics.getInternalStats("persistent://myprop/clust/ns1/ds1", false))
+        when(mockTopics.getInternalStats("persistent://mytenant/ns1/ds1", false))
                 .thenReturn(stats);
-        cmdTopics.run(split("offload persistent://myprop/clust/ns1/ds1 -s 1k"));
-        verify(mockTopics).triggerOffload("persistent://myprop/clust/ns1/ds1", new MessageIdImpl(2, 0, -1));
+        cmdTopics.run(split("offload persistent://mytenant/ns1/ds1 -s 1k"));
+        verify(mockTopics).triggerOffload("persistent://mytenant/ns1/ds1", new MessageIdImpl(2, 0, -1));
 
-        when(mockTopics.offloadStatus("persistent://myprop/clust/ns1/ds1"))
+        when(mockTopics.offloadStatus("persistent://mytenant/ns1/ds1"))
                 .thenReturn(new OffloadProcessStatusImpl());
-        cmdTopics.run(split("offload-status persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).offloadStatus("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("offload-status persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).offloadStatus("persistent://mytenant/ns1/ds1");
 
-        cmdTopics.run(split("last-message-id persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).getLastMessageId(eq("persistent://myprop/clust/ns1/ds1"));
+        cmdTopics.run(split("last-message-id persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).getLastMessageId(eq("persistent://mytenant/ns1/ds1"));
 
-        cmdTopics.run(split("get-message-ttl persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).getMessageTTL("persistent://myprop/clust/ns1/ds1", false);
+        cmdTopics.run(split("get-message-ttl persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).getMessageTTL("persistent://mytenant/ns1/ds1", false);
 
-        cmdTopics.run(split("set-message-ttl persistent://myprop/clust/ns1/ds1 -t 10"));
-        verify(mockTopics).setMessageTTL("persistent://myprop/clust/ns1/ds1", 10);
+        cmdTopics.run(split("set-message-ttl persistent://mytenant/ns1/ds1 -t 10"));
+        verify(mockTopics).setMessageTTL("persistent://mytenant/ns1/ds1", 10);
 
-        cmdTopics.run(split("remove-message-ttl persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).removeMessageTTL("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("remove-message-ttl persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).removeMessageTTL("persistent://mytenant/ns1/ds1");
 
-        cmdTopics.run(split("set-replicated-subscription-status persistent://myprop/clust/ns1/ds1 -s sub1 -d"));
-        verify(mockTopics).setReplicatedSubscriptionStatus("persistent://myprop/clust/ns1/ds1", "sub1", false);
+        cmdTopics.run(split("set-replicated-subscription-status persistent://mytenant/ns1/ds1 -s sub1 -d"));
+        verify(mockTopics).setReplicatedSubscriptionStatus("persistent://mytenant/ns1/ds1", "sub1", false);
 
-        cmdTopics.run(split("get-replicated-subscription-status persistent://myprop/clust/ns1/ds1 -s sub1"));
-        verify(mockTopics).getReplicatedSubscriptionStatus("persistent://myprop/clust/ns1/ds1", "sub1");
+        cmdTopics.run(split("get-replicated-subscription-status persistent://mytenant/ns1/ds1 -s sub1"));
+        verify(mockTopics).getReplicatedSubscriptionStatus("persistent://mytenant/ns1/ds1", "sub1");
 
         //cmd with option cannot be executed repeatedly.
         cmdTopics = new CmdTopics(() -> admin);
 
-        cmdTopics.run(split("get-max-unacked-messages-on-subscription persistent://myprop/clust/ns1/ds1 -ap"));
-        verify(mockTopics).getMaxUnackedMessagesOnSubscription("persistent://myprop/clust/ns1/ds1", true);
-        cmdTopics.run(split("reset-cursor persistent://myprop/clust/ns1/ds2 -s sub1 -m 1:1 -e"));
-        verify(mockTopics).resetCursor(eq("persistent://myprop/clust/ns1/ds2"), eq("sub1")
+        cmdTopics.run(split("get-max-unacked-messages-on-subscription persistent://mytenant/ns1/ds1 -ap"));
+        verify(mockTopics).getMaxUnackedMessagesOnSubscription("persistent://mytenant/ns1/ds1", true);
+        cmdTopics.run(split("reset-cursor persistent://mytenant/ns1/ds2 -s sub1 -m 1:1 -e"));
+        verify(mockTopics).resetCursor(eq("persistent://mytenant/ns1/ds2"), eq("sub1")
                 , eq(new MessageIdImpl(1, 1, -1)), eq(true));
 
-        cmdTopics.run(split("get-maxProducers persistent://myprop/clust/ns1/ds1 -ap"));
-        verify(mockTopics).getMaxProducers("persistent://myprop/clust/ns1/ds1", true);
+        cmdTopics.run(split("get-maxProducers persistent://mytenant/ns1/ds1 -ap"));
+        verify(mockTopics).getMaxProducers("persistent://mytenant/ns1/ds1", true);
 
-        cmdTopics.run(split("set-maxProducers persistent://myprop/clust/ns1/ds1 -p 3"));
-        verify(mockTopics).setMaxProducers("persistent://myprop/clust/ns1/ds1", 3);
+        cmdTopics.run(split("set-maxProducers persistent://mytenant/ns1/ds1 -p 3"));
+        verify(mockTopics).setMaxProducers("persistent://mytenant/ns1/ds1", 3);
 
-        cmdTopics.run(split("remove-maxProducers persistent://myprop/clust/ns1/ds2"));
-        verify(mockTopics).removeMaxProducers("persistent://myprop/clust/ns1/ds2");
+        cmdTopics.run(split("remove-maxProducers persistent://mytenant/ns1/ds2"));
+        verify(mockTopics).removeMaxProducers("persistent://mytenant/ns1/ds2");
 
-        cmdTopics.run(split("set-message-ttl persistent://myprop/clust/ns1/ds1 -t 30m"));
-        verify(mockTopics).setMessageTTL("persistent://myprop/clust/ns1/ds1", 30 * 60);
+        cmdTopics.run(split("set-message-ttl persistent://mytenant/ns1/ds1 -t 30m"));
+        verify(mockTopics).setMessageTTL("persistent://mytenant/ns1/ds1", 30 * 60);
 
-        cmdTopics.run(split("get-message-ttl persistent://myprop/clust/ns1/ds1 -ap"));
-        verify(mockTopics).getMessageTTL("persistent://myprop/clust/ns1/ds1", true);
+        cmdTopics.run(split("get-message-ttl persistent://mytenant/ns1/ds1 -ap"));
+        verify(mockTopics).getMessageTTL("persistent://mytenant/ns1/ds1", true);
 
-        cmdTopics.run(split("get-offload-policies persistent://myprop/clust/ns1/ds1 -ap"));
-        verify(mockTopics).getOffloadPolicies("persistent://myprop/clust/ns1/ds1", true);
-        cmdTopics.run(split("get-max-unacked-messages-on-consumer persistent://myprop/clust/ns1/ds1 -ap"));
-        verify(mockTopics).getMaxUnackedMessagesOnConsumer("persistent://myprop/clust/ns1/ds1", true);
+        cmdTopics.run(split("get-offload-policies persistent://mytenant/ns1/ds1 -ap"));
+        verify(mockTopics).getOffloadPolicies("persistent://mytenant/ns1/ds1", true);
+        cmdTopics.run(split("get-max-unacked-messages-on-consumer persistent://mytenant/ns1/ds1 -ap"));
+        verify(mockTopics).getMaxUnackedMessagesOnConsumer("persistent://mytenant/ns1/ds1", true);
 
-        cmdTopics.run(split("get-inactive-topic-policies persistent://myprop/clust/ns1/ds1 -ap"));
-        verify(mockTopics).getInactiveTopicPolicies("persistent://myprop/clust/ns1/ds1", true);
+        cmdTopics.run(split("get-inactive-topic-policies persistent://mytenant/ns1/ds1 -ap"));
+        verify(mockTopics).getInactiveTopicPolicies("persistent://mytenant/ns1/ds1", true);
 
-        cmdTopics.run(split("get-delayed-delivery persistent://myprop/clust/ns1/ds1 --applied"));
-        verify(mockTopics).getDelayedDeliveryPolicy("persistent://myprop/clust/ns1/ds1", true);
+        cmdTopics.run(split("get-delayed-delivery persistent://mytenant/ns1/ds1 --applied"));
+        verify(mockTopics).getDelayedDeliveryPolicy("persistent://mytenant/ns1/ds1", true);
 
-        cmdTopics.run(split("get-max-consumers persistent://myprop/clust/ns1/ds1 -ap"));
-        verify(mockTopics).getMaxConsumers("persistent://myprop/clust/ns1/ds1", true);
+        cmdTopics.run(split("get-max-consumers persistent://mytenant/ns1/ds1 -ap"));
+        verify(mockTopics).getMaxConsumers("persistent://mytenant/ns1/ds1", true);
 
-        cmdTopics.run(split("get-replication-clusters persistent://myprop/clust/ns1/ds1 --applied"));
-        verify(mockTopics).getReplicationClusters("persistent://myprop/clust/ns1/ds1", true);
+        cmdTopics.run(split("get-replication-clusters persistent://mytenant/ns1/ds1 --applied"));
+        verify(mockTopics).getReplicationClusters("persistent://mytenant/ns1/ds1", true);
 
-        cmdTopics.run(split("set-replication-clusters persistent://myprop/clust/ns1/ds1 -c test"));
-        verify(mockTopics).setReplicationClusters("persistent://myprop/clust/ns1/ds1", Lists.newArrayList("test"));
+        cmdTopics.run(split("set-replication-clusters persistent://mytenant/ns1/ds1 -c test"));
+        verify(mockTopics).setReplicationClusters("persistent://mytenant/ns1/ds1", Lists.newArrayList("test"));
 
-        cmdTopics.run(split("remove-replication-clusters persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).removeReplicationClusters("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("remove-replication-clusters persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).removeReplicationClusters("persistent://mytenant/ns1/ds1");
 
-        cmdTopics.run(split("get-shadow-topics persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).getShadowTopics("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("get-shadow-topics persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).getShadowTopics("persistent://mytenant/ns1/ds1");
 
-        cmdTopics.run(split("set-shadow-topics persistent://myprop/clust/ns1/ds1 -t test"));
-        verify(mockTopics).setShadowTopics("persistent://myprop/clust/ns1/ds1", Lists.newArrayList("test"));
+        cmdTopics.run(split("set-shadow-topics persistent://mytenant/ns1/ds1 -t test"));
+        verify(mockTopics).setShadowTopics("persistent://mytenant/ns1/ds1", Lists.newArrayList("test"));
 
-        cmdTopics.run(split("remove-shadow-topics persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).removeShadowTopics("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("remove-shadow-topics persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).removeShadowTopics("persistent://mytenant/ns1/ds1");
 
-        cmdTopics.run(split("create-shadow-topic -s persistent://myprop/clust/ns1/source "
-                + "persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).createShadowTopic("persistent://myprop/clust/ns1/ds1",
-                "persistent://myprop/clust/ns1/source", null);
+        cmdTopics.run(split("create-shadow-topic -s persistent://mytenant/ns1/source "
+                + "persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).createShadowTopic("persistent://mytenant/ns1/ds1",
+                "persistent://mytenant/ns1/source", null);
 
         cmdTopics = new CmdTopics(() -> admin);
-        cmdTopics.run(split("create-shadow-topic -p a=aa,b=bb,c=cc -s persistent://myprop/clust/ns1/source "
-                + "persistent://myprop/clust/ns1/ds1"));
+        cmdTopics.run(split("create-shadow-topic -p a=aa,b=bb,c=cc -s persistent://mytenant/ns1/source "
+                + "persistent://mytenant/ns1/ds1"));
         HashMap<String, String> p = new HashMap<>();
         p.put("a", "aa");
         p.put("b", "bb");
         p.put("c", "cc");
-        verify(mockTopics).createShadowTopic("persistent://myprop/clust/ns1/ds1",
-                "persistent://myprop/clust/ns1/source", p);
+        verify(mockTopics).createShadowTopic("persistent://mytenant/ns1/ds1",
+                "persistent://mytenant/ns1/source", p);
 
-        cmdTopics.run(split("get-shadow-source persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).getShadowSource("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("get-shadow-source persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).getShadowSource("persistent://mytenant/ns1/ds1");
 
-        cmdTopics.run(split("get-message-id-by-index persistent://myprop/clust/ns1/ds1 -i 0"));
-        verify(mockTopics).getMessageIdByIndex("persistent://myprop/clust/ns1/ds1", 0);
+        cmdTopics.run(split("get-message-id-by-index persistent://mytenant/ns1/ds1 -i 0"));
+        verify(mockTopics).getMessageIdByIndex("persistent://mytenant/ns1/ds1", 0);
 
     }
 
@@ -2197,89 +2198,89 @@ public class PulsarAdminToolTest {
 
         CmdPersistentTopics topics = new CmdPersistentTopics(() -> admin);
 
-        topics.run(split("truncate persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).truncate("persistent://myprop/clust/ns1/ds1");
+        topics.run(split("truncate persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).truncate("persistent://mytenant/ns1/ds1");
 
-        topics.run(split("delete persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).delete("persistent://myprop/clust/ns1/ds1", false);
+        topics.run(split("delete persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).delete("persistent://mytenant/ns1/ds1", false);
 
-        topics.run(split("unload persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).unload("persistent://myprop/clust/ns1/ds1");
+        topics.run(split("unload persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).unload("persistent://mytenant/ns1/ds1");
 
-        topics.run(split("list myprop/clust/ns1"));
-        verify(mockTopics).getList("myprop/clust/ns1");
+        topics.run(split("list mytenant/ns1"));
+        verify(mockTopics).getList("mytenant/ns1");
 
-        topics.run(split("subscriptions persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).getSubscriptions("persistent://myprop/clust/ns1/ds1");
+        topics.run(split("subscriptions persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).getSubscriptions("persistent://mytenant/ns1/ds1");
 
-        topics.run(split("unsubscribe persistent://myprop/clust/ns1/ds1 -s sub1"));
-        verify(mockTopics).deleteSubscription("persistent://myprop/clust/ns1/ds1", "sub1", false);
+        topics.run(split("unsubscribe persistent://mytenant/ns1/ds1 -s sub1"));
+        verify(mockTopics).deleteSubscription("persistent://mytenant/ns1/ds1", "sub1", false);
 
-        topics.run(split("stats persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).getStats("persistent://myprop/clust/ns1/ds1", false);
+        topics.run(split("stats persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).getStats("persistent://mytenant/ns1/ds1", false);
 
-        topics.run(split("stats-internal persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).getInternalStats("persistent://myprop/clust/ns1/ds1", false);
+        topics.run(split("stats-internal persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).getInternalStats("persistent://mytenant/ns1/ds1", false);
 
-        topics.run(split("info-internal persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).getInternalInfo("persistent://myprop/clust/ns1/ds1");
+        topics.run(split("info-internal persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).getInternalInfo("persistent://mytenant/ns1/ds1");
 
-        topics.run(split("partitioned-stats persistent://myprop/clust/ns1/ds1 --per-partition"));
-        verify(mockTopics).getPartitionedStats("persistent://myprop/clust/ns1/ds1", true);
+        topics.run(split("partitioned-stats persistent://mytenant/ns1/ds1 --per-partition"));
+        verify(mockTopics).getPartitionedStats("persistent://mytenant/ns1/ds1", true);
 
-        topics.run(split("partitioned-stats-internal persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).getPartitionedInternalStats("persistent://myprop/clust/ns1/ds1");
+        topics.run(split("partitioned-stats-internal persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).getPartitionedInternalStats("persistent://mytenant/ns1/ds1");
 
-        topics.run(split("skip-all persistent://myprop/clust/ns1/ds1 -s sub1"));
-        verify(mockTopics).skipAllMessages("persistent://myprop/clust/ns1/ds1", "sub1");
+        topics.run(split("skip-all persistent://mytenant/ns1/ds1 -s sub1"));
+        verify(mockTopics).skipAllMessages("persistent://mytenant/ns1/ds1", "sub1");
 
-        topics.run(split("skip persistent://myprop/clust/ns1/ds1 -s sub1 -n 100"));
-        verify(mockTopics).skipMessages("persistent://myprop/clust/ns1/ds1", "sub1", 100);
+        topics.run(split("skip persistent://mytenant/ns1/ds1 -s sub1 -n 100"));
+        verify(mockTopics).skipMessages("persistent://mytenant/ns1/ds1", "sub1", 100);
 
-        topics.run(split("expire-messages persistent://myprop/clust/ns1/ds1 -s sub1 -t 100"));
-        verify(mockTopics).expireMessages("persistent://myprop/clust/ns1/ds1", "sub1", 100);
+        topics.run(split("expire-messages persistent://mytenant/ns1/ds1 -s sub1 -t 100"));
+        verify(mockTopics).expireMessages("persistent://mytenant/ns1/ds1", "sub1", 100);
 
-        topics.run(split("expire-messages-all-subscriptions persistent://myprop/clust/ns1/ds1 -t 100"));
-        verify(mockTopics).expireMessagesForAllSubscriptions("persistent://myprop/clust/ns1/ds1", 100);
+        topics.run(split("expire-messages-all-subscriptions persistent://mytenant/ns1/ds1 -t 100"));
+        verify(mockTopics).expireMessagesForAllSubscriptions("persistent://mytenant/ns1/ds1", 100);
 
-        topics.run(split("create-subscription persistent://myprop/clust/ns1/ds1 -s sub1 "
+        topics.run(split("create-subscription persistent://mytenant/ns1/ds1 -s sub1 "
                 + "--messageId earliest -p a=b --property c=d -p x=y,z"));
         Map<String, String> props = new HashMap<>();
         props.put("a", "b");
         props.put("c", "d");
         props.put("x", "y,z");
-        verify(mockTopics).createSubscription("persistent://myprop/clust/ns1/ds1", "sub1",
+        verify(mockTopics).createSubscription("persistent://mytenant/ns1/ds1", "sub1",
                 MessageId.earliest, false, props);
 
         // jcommander is stateful, you cannot parse the same command twice
         topics = new CmdPersistentTopics(() -> admin);
-        topics.run(split("create-subscription persistent://myprop/clust/ns1/ds1 -s sub1 --messageId earliest"));
-        verify(mockTopics).createSubscription("persistent://myprop/clust/ns1/ds1", "sub1",
+        topics.run(split("create-subscription persistent://mytenant/ns1/ds1 -s sub1 --messageId earliest"));
+        verify(mockTopics).createSubscription("persistent://mytenant/ns1/ds1", "sub1",
                 MessageId.earliest, false, null);
 
-        topics.run(split("create-partitioned-topic persistent://myprop/clust/ns1/ds1 --partitions 32"));
-        verify(mockTopics).createPartitionedTopic("persistent://myprop/clust/ns1/ds1", 32);
+        topics.run(split("create-partitioned-topic persistent://mytenant/ns1/ds1 --partitions 32"));
+        verify(mockTopics).createPartitionedTopic("persistent://mytenant/ns1/ds1", 32);
 
-        topics.run(split("list-partitioned-topics myprop/clust/ns1"));
-        verify(mockTopics).getPartitionedTopicList("myprop/clust/ns1");
+        topics.run(split("list-partitioned-topics mytenant/ns1"));
+        verify(mockTopics).getPartitionedTopicList("mytenant/ns1");
 
-        topics.run(split("get-partitioned-topic-metadata persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).getPartitionedTopicMetadata("persistent://myprop/clust/ns1/ds1");
+        topics.run(split("get-partitioned-topic-metadata persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).getPartitionedTopicMetadata("persistent://mytenant/ns1/ds1");
 
-        topics.run(split("delete-partitioned-topic persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).deletePartitionedTopic("persistent://myprop/clust/ns1/ds1", false);
+        topics.run(split("delete-partitioned-topic persistent://mytenant/ns1/ds1"));
+        verify(mockTopics).deletePartitionedTopic("persistent://mytenant/ns1/ds1", false);
 
-        topics.run(split("peek-messages persistent://myprop/clust/ns1/ds1 -s sub1 -n 3"));
-        verify(mockTopics).peekMessages("persistent://myprop/clust/ns1/ds1", "sub1", 3);
+        topics.run(split("peek-messages persistent://mytenant/ns1/ds1 -s sub1 -n 3"));
+        verify(mockTopics).peekMessages("persistent://mytenant/ns1/ds1", "sub1", 3);
 
         // cmd with option cannot be executed repeatedly
         topics = new CmdPersistentTopics(() -> admin);
 
-        topics.run(split("expire-messages persistent://myprop/clust/ns1/ds1 -s sub1 -t 2h"));
-        verify(mockTopics).expireMessages("persistent://myprop/clust/ns1/ds1", "sub1", 2 * 60 * 60);
+        topics.run(split("expire-messages persistent://mytenant/ns1/ds1 -s sub1 -t 2h"));
+        verify(mockTopics).expireMessages("persistent://mytenant/ns1/ds1", "sub1", 2 * 60 * 60);
 
-        topics.run(split("expire-messages-all-subscriptions persistent://myprop/clust/ns1/ds1 -t 3d"));
-        verify(mockTopics).expireMessagesForAllSubscriptions("persistent://myprop/clust/ns1/ds1",
+        topics.run(split("expire-messages-all-subscriptions persistent://mytenant/ns1/ds1 -t 3d"));
+        verify(mockTopics).expireMessagesForAllSubscriptions("persistent://mytenant/ns1/ds1",
                 3 * 60 * 60 * 24);
 
         // argument matcher for the timestamp in reset cursor. Since we can't verify exact timestamp, we check for a
@@ -2294,8 +2295,8 @@ public class PulsarAdminToolTest {
                 return false;
             }
         }
-        topics.run(split("reset-cursor persistent://myprop/clust/ns1/ds1 -s sub1 -t 1m"));
-        verify(mockTopics).resetCursor(eq("persistent://myprop/clust/ns1/ds1"), eq("sub1"),
+        topics.run(split("reset-cursor persistent://mytenant/ns1/ds1 -s sub1 -t 1m"));
+        verify(mockTopics).resetCursor(eq("persistent://mytenant/ns1/ds1"), eq("sub1"),
                 longThat(new TimestampMatcher()));
     }
 
@@ -2323,8 +2324,8 @@ public class PulsarAdminToolTest {
         when(admin.nonPersistentTopics()).thenReturn(mockNonPersistentTopics);
 
         CmdNonPersistentTopics nonPersistentTopics = new CmdNonPersistentTopics(() -> admin);
-        nonPersistentTopics.run(split("list-in-bundle myprop/clust/ns1 --bundle 0x23d70a30_0x26666658"));
-        verify(mockNonPersistentTopics).getListInBundle("myprop/clust/ns1", "0x23d70a30_0x26666658");
+        nonPersistentTopics.run(split("list-in-bundle mytenant/ns1 --bundle 0x23d70a30_0x26666658"));
+        verify(mockNonPersistentTopics).getListInBundle("mytenant/ns1", "0x23d70a30_0x26666658");
     }
 
     @Test

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/client/cli/PulsarClientToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/client/cli/PulsarClientToolTest.java
@@ -433,7 +433,7 @@ public class PulsarClientToolTest extends BrokerTestBase {
     }
 
     private static String getTopicWithRandomSuffix(String localNameBase) {
-        return String.format("persistent://prop/ns-abc/test/%s-%s", localNameBase, UUID.randomUUID().toString());
+        return String.format("persistent://tenant/ns-abc/test/%s-%s", localNameBase, UUID.randomUUID().toString());
     }
 
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdBrokerStats.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdBrokerStats.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.stream.JsonWriter;
 import java.io.OutputStreamWriter;
@@ -47,21 +48,23 @@ public class CmdBrokerStats extends CmdBase {
         @Override
         void run() throws Exception {
             String s = getAdmin().brokerStats().getMetrics();
-            JsonArray metrics = new Gson().fromJson(s, JsonArray.class);
-
-            try (Writer out = new OutputStreamWriter(System.out, StandardCharsets.UTF_8);
-                 JsonWriter jsonWriter = new JsonWriter(out)) {
-                for (int i = 0; i < metrics.size(); i++) {
-                    JsonObject m = (JsonObject) metrics.get(i);
-                    if (indent) {
-                        jsonWriter.setIndent(DEFAULT_INDENTATION);
-                        new Gson().toJson(m, jsonWriter);
-                        out.write('\n');
-                        out.write('\n');
-                    } else {
-                        new Gson().toJson(m, jsonWriter);
+            JsonElement result = new Gson().fromJson(s, JsonElement.class);
+            if (result.isJsonArray()) {
+                JsonArray metrics = result.getAsJsonArray();
+                try (Writer out = new OutputStreamWriter(System.out, StandardCharsets.UTF_8);
+                     JsonWriter jsonWriter = new JsonWriter(out)) {
+                    for (int i = 0; i < metrics.size(); i++) {
+                        JsonObject m = (JsonObject) metrics.get(i);
+                        if (indent) {
+                            jsonWriter.setIndent(DEFAULT_INDENTATION);
+                            new Gson().toJson(m, jsonWriter);
+                            out.write('\n');
+                            out.write('\n');
+                        } else {
+                            new Gson().toJson(m, jsonWriter);
+                        }
+                        out.flush();
                     }
-                    out.flush();
                 }
             }
         }
@@ -75,7 +78,7 @@ public class CmdBrokerStats extends CmdBase {
         @Override
         void run() throws Exception {
             String s = getAdmin().brokerStats().getMBeans();
-            JsonArray result = new Gson().fromJson(s, JsonArray.class);
+            JsonElement result = new Gson().fromJson(s, JsonElement.class);
             try (Writer out = new OutputStreamWriter(System.out, StandardCharsets.UTF_8);
                  JsonWriter jsonWriter = new JsonWriter(out)) {
                 if (indent) {
@@ -105,7 +108,7 @@ public class CmdBrokerStats extends CmdBase {
         @Override
         void run() throws Exception {
             String s = getAdmin().brokerStats().getTopics();
-            JsonObject result = new Gson().fromJson(s, JsonObject.class);
+            JsonElement result = new Gson().fromJson(s, JsonElement.class);
             try (Writer out = new OutputStreamWriter(System.out, StandardCharsets.UTF_8);
                  JsonWriter jsonWriter = new JsonWriter(out)) {
                 if (indent) {

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/TestRunMain.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/TestRunMain.java
@@ -98,7 +98,7 @@ public class TestRunMain {
         printWriter.close();
         testConfigFile.deleteOnExit();
 
-        String argStrTemp = "%s %s --admin-url https://url:4443 " + "topics stats persistent://prop/cluster/ns/t1";
+        String argStrTemp = "%s %s --admin-url https://url:4443 " + "topics stats persistent://tenant/ns/t1";
         boolean prevValue = PulsarAdminTool.allowSystemExit;
         PulsarAdminTool.allowSystemExit = false;
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/naming/NamespaceName.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/naming/NamespaceName.java
@@ -211,7 +211,7 @@ public class NamespaceName implements ServiceUnitId {
     }
 
     /**
-     * Returns true if this is a V2 namespace prop/namespace-name.
+     * Returns true if this is a V2 namespace tenant/namespace-name.
      * @return true if v2
      */
     public boolean isV2() {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/naming/TopicName.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/naming/TopicName.java
@@ -263,9 +263,9 @@ public class TopicName implements ServiceUnitId {
      * For partitions in a topic, return the base partitioned topic name.
      * Eg:
      * <ul>
-     *  <li><code>persistent://prop/cluster/ns/my-topic-partition-1</code> -->
-     *  <code>persistent://prop/cluster/ns/my-topic</code>
-     *  <li><code>persistent://prop/cluster/ns/my-topic</code> --> <code>persistent://prop/cluster/ns/my-topic</code>
+     *  <li><code>persistent://tenant/ns/my-topic-partition-1</code> -->
+     *  <code>persistent://tenant/ns/my-topic</code>
+     *  <li><code>persistent://tenant/ns/my-topic</code> --> <code>persistent://tenant/ns/my-topic</code>
      * </ul>
      */
     public String getPartitionedTopicName() {
@@ -437,7 +437,7 @@ public class TopicName implements ServiceUnitId {
     }
 
     /**
-     * Returns true if this a V2 topic name prop/ns/topic-name.
+     * Returns true if this a V2 topic name tenant/ns/topic-name.
      * @return true if V2
      */
     public boolean isV2() {

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/naming/NamespaceNameTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/naming/NamespaceNameTest.java
@@ -63,49 +63,48 @@ public class NamespaceNameTest {
 
     @Test
     public void namespace_persistentTopic() {
-        assertEquals(NamespaceName.get("prop/cluster/ns").getPersistentTopicName("ds"),
-                "persistent://prop/cluster/ns/ds");
+        assertEquals(NamespaceName.get("tenant/ns").getPersistentTopicName("ds"),
+                "persistent://tenant/ns/ds");
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void namespace_topicNameNullDomain() {
-        NamespaceName.get("prop/cluster/ns").getTopicName(null, "ds");
+        NamespaceName.get("tenant/ns").getTopicName(null, "ds");
     }
 
     @Test
     public void namespace_persistentTopicExplicitDomain() {
-        assertEquals(NamespaceName.get("prop/cluster/ns").getTopicName(TopicDomain.persistent, "ds"),
-                "persistent://prop/cluster/ns/ds");
+        assertEquals(NamespaceName.get("tenant/ns").getTopicName(TopicDomain.persistent, "ds"),
+                "persistent://tenant/ns/ds");
     }
 
     @Test
     public void namespace_equals() {
-        assertEquals(NamespaceName.get("prop/cluster/ns"), NamespaceName.get("prop/cluster/ns"));
+        assertEquals(NamespaceName.get("tenant/ns"), NamespaceName.get("tenant/ns"));
     }
 
     @Test
     public void namespace_toString() {
-        assertEquals(NamespaceName.get("prop/cluster/ns").toString(), "prop/cluster/ns");
+        assertEquals(NamespaceName.get("tenant/ns").toString(), "tenant/ns");
     }
 
     @SuppressWarnings("AssertBetweenInconvertibleTypes")
     @Test
     public void namespace_equalsCheckType() {
-        assertNotEquals(NamespaceName.get("prop/cluster/ns"), "prop/cluster/ns");
+        assertNotEquals(NamespaceName.get("tenant/ns"), "tenant/ns");
     }
 
     @Test
     public void namespace_vargEquivalentToParse() {
-        assertEquals(NamespaceName.get("prop", "cluster", "ns"), NamespaceName.get("prop/cluster/ns"));
+        assertEquals(NamespaceName.get("tenant", "ns"), NamespaceName.get("tenant/ns"));
     }
 
-    // Deprecation warning suppressed as this test targets deprecated methods
-    @SuppressWarnings("deprecation")
     @Test
     public void namespace_members() {
-        assertEquals(NamespaceName.get("prop/cluster/ns").getTenant(), "prop");
-        assertEquals(NamespaceName.get("prop/cluster/ns").getCluster(), "cluster");
-        assertEquals(NamespaceName.get("prop/cluster/ns").getLocalName(), "ns");
+        NamespaceName ns = NamespaceName.get("tenant/ns");
+        assertEquals(ns.getTenant(), "tenant");
+        assertTrue(ns.isV2());
+        assertEquals(ns.getLocalName(), "ns");
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -168,22 +167,13 @@ public class NamespaceNameTest {
     // Deprecation warning suppressed as this test targets deprecated methods
     @SuppressWarnings("deprecation")
     @Test
-    public void namespace_v2Namespace() {
-        NamespaceName v2Namespace = NamespaceName.get("pulsar/colo1/testns-1");
-        assertEquals(v2Namespace.getTenant(), "pulsar");
-        assertEquals(v2Namespace.getCluster(), "colo1");
-        assertEquals(v2Namespace.getLocalName(), "testns-1");
-    }
-
-    // Deprecation warning suppressed as this test targets deprecated methods
-    @SuppressWarnings("deprecation")
-    @Test
     void testNewScheme() {
         NamespaceName ns = NamespaceName.get("my-tenant/my-namespace");
         assertEquals(ns.getTenant(), "my-tenant");
         assertEquals(ns.getLocalName(), "my-namespace");
         assertTrue(ns.isGlobal());
         assertNull(ns.getCluster());
+        assertTrue(ns.isV2());
         assertEquals(ns.getPersistentTopicName("my-topic"), "persistent://my-tenant/my-namespace/my-topic");
     }
 }

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/naming/TopicNameTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/naming/TopicNameTest.java
@@ -216,14 +216,14 @@ public class TopicNameTest {
                 .get("persistent://tenant/cluster/namespace/$#3rpa/table/1");
         assertEquals(nameWithRandomCharacters.getEncodedLocalName(), Codec.encode("$#3rpa/table/1"));
 
-        TopicName topicName = TopicName.get("persistent://myprop/mycolo/myns/mytopic");
-        assertEquals(topicName.getPartition(0).toString(), "persistent://myprop/mycolo/myns/mytopic-partition-0");
+        TopicName topicName = TopicName.get("persistent://mytenant/mycolo/myns/mytopic");
+        assertEquals(topicName.getPartition(0).toString(), "persistent://mytenant/mycolo/myns/mytopic-partition-0");
 
-        TopicName partitionedDn = TopicName.get("persistent://myprop/mycolo/myns/mytopic").getPartition(2);
+        TopicName partitionedDn = TopicName.get("persistent://mytenant/mycolo/myns/mytopic").getPartition(2);
         assertEquals(partitionedDn.getPartitionIndex(), 2);
         assertEquals(topicName.getPartitionIndex(), -1);
 
-        assertEquals(TopicName.getPartitionIndex("persistent://myprop/mycolo/myns/mytopic-partition-4"), 4);
+        assertEquals(TopicName.getPartitionIndex("persistent://mytenant/mycolo/myns/mytopic-partition-4"), 4);
 
         // Following behavior is not right actually, none partitioned topic, partition index is -1
         assertEquals(TopicName.getPartitionIndex("mytopic-partition--1"), -1);
@@ -253,12 +253,12 @@ public class TopicNameTest {
         assertEquals(Codec.decode(encodedName), rawName);
         assertEquals(Codec.encode(rawName), encodedName);
 
-        String topicName = "persistent://prop/colo/ns/" + rawName;
+        String topicName = "persistent://tenant/colo/ns/" + rawName;
         TopicName name = TopicName.get(topicName);
 
         assertEquals(name.getLocalName(), rawName);
         assertEquals(name.getEncodedLocalName(), encodedName);
-        assertEquals(name.getPersistenceNamingEncoding(), "prop/colo/ns/persistent/" + encodedName);
+        assertEquals(name.getPersistenceNamingEncoding(), "tenant/colo/ns/persistent/" + encodedName);
     }
 
     @Test

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyTest.java
@@ -134,6 +134,8 @@ public class ProxyTest extends MockedPulsarServiceBaseTest {
                 Collections.singleton(conf.getClusterName()));
         admin.tenants().createTenant("public", tenantInfo);
         admin.namespaces().createNamespace("public/default");
+        admin.tenants().createTenant("sample", tenantInfo);
+        admin.namespaces().createNamespace("sample/local");
     }
 
     protected void initializeProxyConfig() throws Exception {
@@ -174,7 +176,7 @@ public class ProxyTest extends MockedPulsarServiceBaseTest {
 
         @Cleanup
         Producer<byte[]> producer = client.newProducer()
-            .topic("persistent://sample/test/local/producer-topic")
+            .topic("persistent://sample/local/producer-topic")
             .create();
 
         for (int i = 0; i < 10; i++) {
@@ -190,7 +192,7 @@ public class ProxyTest extends MockedPulsarServiceBaseTest {
 
         @Cleanup
         Producer<byte[]> producer = client.newProducer()
-                .topic("persistent://sample/test/local/producer-topic2")
+                .topic("persistent://sample/local/producer-topic2")
                 .create();
 
         MutableBoolean found = new MutableBoolean(false);
@@ -218,7 +220,7 @@ public class ProxyTest extends MockedPulsarServiceBaseTest {
 
         @Cleanup
         Producer<byte[]> producer = client.newProducer(Schema.BYTES)
-            .topic("persistent://sample/test/local/producer-consumer-topic")
+            .topic("persistent://sample/local/producer-consumer-topic")
             .enableBatching(false)
             .messageRoutingMode(MessageRoutingMode.SinglePartition)
             .create();
@@ -226,7 +228,7 @@ public class ProxyTest extends MockedPulsarServiceBaseTest {
         // Create a consumer directly attached to broker
         @Cleanup
         Consumer<byte[]> consumer = pulsarClient.newConsumer()
-                .topic("persistent://sample/test/local/producer-consumer-topic").subscriptionName("my-sub").subscribe();
+                .topic("persistent://sample/local/producer-consumer-topic").subscriptionName("my-sub").subscribe();
 
         for (int i = 0; i < 10; i++) {
             producer.send("test".getBytes());
@@ -244,22 +246,20 @@ public class ProxyTest extends MockedPulsarServiceBaseTest {
 
     @Test
     public void testPartitions() throws Exception {
-        TenantInfoImpl tenantInfo = createDefaultTenantInfo();
-        admin.tenants().createTenant("sample", tenantInfo);
         @Cleanup
         PulsarClient client = PulsarClient.builder().serviceUrl(proxyService.getServiceUrl())
                 .build();
-        admin.topics().createPartitionedTopic("persistent://sample/test/local/partitioned-topic", 2);
+        admin.topics().createPartitionedTopic("persistent://sample/local/partitioned-topic", 2);
 
         @Cleanup
         Producer<byte[]> producer = client.newProducer(Schema.BYTES)
-            .topic("persistent://sample/test/local/partitioned-topic")
+            .topic("persistent://sample/local/partitioned-topic")
             .enableBatching(false)
             .messageRoutingMode(MessageRoutingMode.RoundRobinPartition).create();
 
         // Create a consumer directly attached to broker
         @Cleanup
-        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic("persistent://sample/test/local/partitioned-topic")
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic("persistent://sample/local/partitioned-topic")
                 .subscriptionName("my-sub").subscribe();
 
         for (int i = 0; i < 10; i++) {
@@ -287,7 +287,7 @@ public class ProxyTest extends MockedPulsarServiceBaseTest {
             @Cleanup
             PulsarClient client = PulsarClient.builder().serviceUrl(proxyService.getServiceUrl())
               .build();
-            String topic = "persistent://sample/test/local/partitioned-proxy-topic";
+            String topic = "persistent://sample/local/partitioned-proxy-topic";
             CompletableFuture<List<String>> partitionNamesFuture = client.getPartitionsForTopic(topic);
             List<String> partitionNames = partitionNamesFuture.get(30000, TimeUnit.MILLISECONDS);
             assertEquals(partitionNames.size(), defaultPartition);
@@ -305,12 +305,12 @@ public class ProxyTest extends MockedPulsarServiceBaseTest {
 
         // create two topics by subscribing to a topic and closing it
         try (Consumer<byte[]> ignored = client.newConsumer()
-            .topic("persistent://sample/test/local/regex-sub-topic1")
+            .topic("persistent://sample/local/regex-sub-topic1")
             .subscriptionName("proxy-ignored")
             .subscribe()) {
         }
         try (Consumer<byte[]> ignored = client.newConsumer()
-            .topic("persistent://sample/test/local/regex-sub-topic2")
+            .topic("persistent://sample/local/regex-sub-topic2")
             .subscriptionName("proxy-ignored")
             .subscribe()) {
         }
@@ -318,7 +318,7 @@ public class ProxyTest extends MockedPulsarServiceBaseTest {
         String subName = "regex-sub-proxy-test-" + System.currentTimeMillis();
 
         // make sure regex subscription
-        String regexSubscriptionPattern = "persistent://sample/test/local/regex-sub-topic.*";
+        String regexSubscriptionPattern = "persistent://sample/local/regex-sub-topic.*";
         log.info("Regex subscribe to topics {}", regexSubscriptionPattern);
         try (Consumer<byte[]> consumer = client.newConsumer()
             .topicsPattern(regexSubscriptionPattern)
@@ -330,7 +330,7 @@ public class ProxyTest extends MockedPulsarServiceBaseTest {
             final int numMessages = 20;
 
             try (Producer<byte[]> producer = client.newProducer(Schema.BYTES)
-                .topic("persistent://sample/test/local/regex-sub-topic1")
+                .topic("persistent://sample/local/regex-sub-topic1")
                 .create()) {
                 for (int i = 0; i < numMessages; i++) {
                     producer.send(("message-" + i).getBytes(UTF_8));
@@ -415,7 +415,7 @@ public class ProxyTest extends MockedPulsarServiceBaseTest {
                 .build();
         Schema<Foo> schema = Schema.AVRO(Foo.class);
         try {
-            try (Producer<Foo> ignored = client.newProducer(schema).topic("persistent://sample/test/local/get-schema")
+            try (Producer<Foo> ignored = client.newProducer(schema).topic("persistent://sample/local/get-schema")
                 .create()) {
             }
         } catch (Exception ex) {
@@ -427,14 +427,14 @@ public class ProxyTest extends MockedPulsarServiceBaseTest {
             schemaVersion[i] = b;
         }
         SchemaInfo schemaInfo = ((PulsarClientImpl) client).getLookup()
-                .getSchema(TopicName.get("persistent://sample/test/local/get-schema"), schemaVersion)
+                .getSchema(TopicName.get("persistent://sample/local/get-schema"), schemaVersion)
                 .get().orElse(null);
         assertEquals(new String(schemaInfo.getSchema()), new String(schema.getSchemaInfo().getSchema()));
     }
 
     @Test
     public void testProtocolVersionAdvertisement() throws Exception {
-        final String topic = "persistent://sample/test/local/protocol-version-advertisement";
+        final String topic = "persistent://sample/local/protocol-version-advertisement";
         final String sub = "my-sub";
 
         ClientConfigurationData conf = new ClientConfigurationData();
@@ -497,7 +497,7 @@ public class ProxyTest extends MockedPulsarServiceBaseTest {
         PulsarClient client = PulsarClient.builder().serviceUrl(proxyService.getServiceUrl())
                 .build();
 
-        String topic = BrokerTestUtil.newUniqueName("persistent://sample/test/local/testGetClientVersion");
+        String topic = BrokerTestUtil.newUniqueName("persistent://sample/local/testGetClientVersion");
         String subName = "test-sub";
 
         @Cleanup

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceTopicListArguments.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceTopicListArguments.java
@@ -30,7 +30,7 @@ import picocli.CommandLine.Parameters;
  */
 public abstract class PerformanceTopicListArguments extends PerformanceBaseArguments {
 
-    @Parameters(description = "persistent://prop/ns/my-topic", arity = "1")
+    @Parameters(description = "persistent://tenant/ns/my-topic", arity = "1")
     public List<String> topics;
 
     @Option(names = { "-t", "--num-topics", "--num-topic" }, description = "Number of topics.  Must match"


### PR DESCRIPTION
- **[fix][client] Close orphan producer or consumer when the creation is interrupted (#24539)**
- **Don't use V1 topic names for tests, update production code javadocs**
