### PR TITLE
[improve][build] Upgrade Athenz to 1.12.42

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -97,7 +97,7 @@ hdrHistogram = "2.1.9"
 perfmark = "0.26.0"
 # Auth
 jsonwebtoken = "0.13.0"
-athenz = "1.10.62"
+athenz = "1.12.42"
 jose4j = "0.9.6"
 nimbus-jose-jwt = "9.37.4"
 auth0-java-jwt = "4.5.2"


### PR DESCRIPTION
### Motivation

The Athenz client/server libraries (`com.yahoo.athenz`) used by the
`pulsar-client-auth-athenz` and `pulsar-broker-auth-athenz` authentication
plugins were pinned to **1.10.62**, which is several years old. Upgrading to
**1.12.42** picks up upstream bug fixes, dependency/security updates, and keeps
the integration on a maintained release line.

### Modifications

- Bump `athenz` in `gradle/libs.versions.toml` from `1.10.62` to `1.12.42`.
  This single version ref governs all four Athenz artifacts used by Pulsar:
  `athenz-zts-java-client`, `athenz-zpe-java-client`, `athenz-cert-refresher`
  and `athenz-auth-core`.

**No source changes are required.** Every Athenz API used by Pulsar keeps an
identical signature in 1.12.42. The breaking changes introduced in Athenz
**1.11.0** — the ZTS client is no longer shaded, Jersey/JAX-RS was replaced by
Apache HttpClient5, JDK 11+ is required, and `athenz-zts-java-client-core` plus
`ZTSClient.setProperty()`/`getClientBuilder()` were removed — do **not** affect
Pulsar: it uses none of the removed APIs/artifact and targets JDK 17/21.

**No LICENSE/NOTICE changes are required.** The Athenz auth modules are
standalone plugins and are not bundled in any Pulsar binary distribution
(server/shell), so the per-jar `LICENSE.bin.txt` accounting is unaffected by the
Athenz version change. The new transitive dependencies pulled in by 1.12.x
(e.g. Apache HttpClient5) are likewise not bundled.

> [!NOTE]
> The ZTS client's HTTP transport changed internally from Jersey to Apache
> HttpClient5 in the 1.11.x line. The public API is unchanged, but this is a
> behavior-surface change; the existing unit tests mock `ZTSClient`, so a full
> CI run (including any Athenz integration coverage) is the real end-to-end
> check.

### Verifying this change

This change is already covered by existing tests:

- `pulsar-client-auth-athenz` — `AuthenticationAthenzTest` (8/8 pass against 1.12.42)
- `pulsar-broker-auth-athenz` — `AuthenticationProviderAthenzTest` (4/4 pass against 1.12.42)

Both modules compile cleanly (`compileJava` + `compileTestJava`) and all 12 unit
tests pass locally against Athenz 1.12.42 with no deprecation/removal warnings.

### Does this pull request potentially affect one of the following parts:

- [x] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
