### PR TITLE
[fix][broker] Fix topic policies loading consistency

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -196,8 +196,13 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener {
         this.topic = topic;
         this.log = LOG.with().attr("topic", topic).build();
         this.namespace = TopicName.get(topic).getNamespaceObject();
-        this.topicPoliciesNotifyThread =
-                brokerService.getTopicOrderedExecutor().chooseThread(TopicName.getPartitionedTopicName(topic));
+        // Pin a per-topic policies-notify thread from the topic-ordered executor. A running broker always has
+        // this executor; guard against null so unit tests that construct topics with a mock BrokerService
+        // (without stubbing getTopicOrderedExecutor()) don't fail in the constructor.
+        var topicOrderedExecutor = brokerService.getTopicOrderedExecutor();
+        this.topicPoliciesNotifyThread = topicOrderedExecutor != null
+                ? topicOrderedExecutor.chooseThread(TopicName.getPartitionedTopicName(topic))
+                : null;
         this.clock = brokerService.getClock();
         this.brokerService = brokerService;
         this.producers = new ConcurrentHashMap<>();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -44,6 +44,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
@@ -189,11 +190,14 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener {
     protected final Clock clock;
 
     protected Set<String> additionalSystemCursorNames = new TreeSet<>();
+    private final ExecutorService topicPoliciesNotifyThread;
 
     public AbstractTopic(String topic, BrokerService brokerService) {
         this.topic = topic;
         this.log = LOG.with().attr("topic", topic).build();
         this.namespace = TopicName.get(topic).getNamespaceObject();
+        this.topicPoliciesNotifyThread =
+                brokerService.getTopicOrderedExecutor().chooseThread(TopicName.getPartitionedTopicName(topic));
         this.clock = brokerService.getClock();
         this.brokerService = brokerService;
         this.producers = new ConcurrentHashMap<>();
@@ -1481,5 +1485,9 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener {
         } else {
             return Collections.emptyMap();
         }
+    }
+
+    protected ExecutorService getPoliciesNotifyThread() {
+        return topicPoliciesNotifyThread;
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -557,14 +557,18 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener {
                 && maxProducers <= USER_CREATED_PRODUCER_COUNTER_UPDATER.get(this);
     }
 
+    protected TopicPolicyListener getTopicPolicyListener() {
+        return this;
+    }
+
     protected void registerTopicPolicyListener() {
         brokerService.getPulsar().getTopicPoliciesService()
-                .registerListenerAsync(TopicName.getPartitionedTopicName(topic), this);
+                .registerListenerAsync(TopicName.getPartitionedTopicName(topic), getTopicPolicyListener());
     }
 
     protected void unregisterTopicPolicyListener() {
         brokerService.getPulsar().getTopicPoliciesService()
-                .unregisterListener(TopicName.getPartitionedTopicName(topic), this);
+                .unregisterListener(TopicName.getPartitionedTopicName(topic), getTopicPolicyListener());
     }
 
     protected boolean isSameAddressProducersExceeded(Producer producer) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -2880,13 +2880,22 @@ public class BrokerService implements Closeable {
                             .log("Updating namespace with policies");
 
                     topics.forEach((name, topicFuture) -> {
-                        if (namespace.includes(TopicName.get(name))) {
+                        TopicName topicName = TopicName.get(name);
+                        if (namespace.includes(topicName)) {
                             // If the topic is already created, immediately apply the updated policies, otherwise
                             // once the topic is created it'll apply the policies update
                             topicFuture.thenAccept(topic -> {
                                 log.debug().attr("topic", name).log("Notifying topic that policies have changed");
 
-                                topic.ifPresent(t -> t.onPoliciesUpdate(policies));
+                                topic.ifPresent(t -> {
+                                    if (t instanceof AbstractTopic abstractTopic) {
+                                        abstractTopic.getPoliciesNotifyThread().execute(() -> {
+                                            t.onPoliciesUpdate(policies);
+                                        });
+                                    } else {
+                                        t.onPoliciesUpdate(policies);
+                                    }
+                                });
                             });
                         }
                     });

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -285,6 +285,7 @@ public class BrokerService implements Closeable {
             .register();
 
     private final SingleThreadNonConcurrentFixedRateScheduler inactivityMonitor;
+    @Getter
     private final SingleThreadNonConcurrentFixedRateScheduler messageExpiryMonitor;
     private final SingleThreadNonConcurrentFixedRateScheduler compactionMonitor;
     private final SingleThreadNonConcurrentFixedRateScheduler consumedLedgersMonitor;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
@@ -496,16 +496,7 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
         if (msg.getValue() == null) {
             TopicName topicName = TopicName.get(TopicPoliciesService.unwrapEventKey(msg.getKey())
                     .getPartitionedTopicName());
-            List<TopicPolicyListener> listeners = this.listeners.get(topicName);
-            if (listeners != null) {
-                for (TopicPolicyListener listener : listeners) {
-                    try {
-                        listener.onUpdate(null);
-                    } catch (Throwable error) {
-                        log.error().attr("topic", topicName).exception(error).log("call listener error.");
-                    }
-                }
-            }
+            notifyListeners(topicName, null);
             return;
         }
 
@@ -515,17 +506,37 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
         TopicPoliciesEvent event = msg.getValue().getTopicPoliciesEvent();
         TopicName topicName = TopicName.get(event.getDomain(), event.getTenant(),
                 event.getNamespace(), event.getTopic());
-        List<TopicPolicyListener> listeners = this.listeners.get(topicName);
-        if (listeners != null) {
-            TopicPolicies policies = event.getPolicies();
-            for (TopicPolicyListener listener : listeners) {
+        notifyListeners(topicName, event.getPolicies());
+    }
+
+    /**
+     * Notifies the topic-policy listeners registered for {@code topicName} of a policy update.
+     *
+     * <p>The {@link TopicPolicyListener#onUpdate} calls are dispatched to the per-topic ordered executor
+     * rather than run inline. The reader callbacks that drive notifications (the {@link #initPolicesCache}
+     * replay loop and {@link #readMorePoliciesAsync}) run on the single, process-wide shared
+     * {@code broker-client-shared-internal-executor} thread. A listener (e.g.
+     * {@code PersistentTopic.onUpdate} -> {@code applyUpdatedTopicPolicies}) can perform non-trivial and
+     * even blocking work, so running it inline serializes and can stall topic-policy loading for every
+     * namespace (issue #26037). Keying {@code executeOrdered} by {@code topicName} preserves per-topic
+     * notification ordering.
+     */
+    private void notifyListeners(TopicName topicName, @Nullable TopicPolicies policies) {
+        // The per-topic value is a CopyOnWriteArrayList, so iterating it later on the executor thread stays
+        // safe even if a listener is registered/unregistered between dispatch and execution.
+        List<TopicPolicyListener> topicListeners = listeners.get(topicName);
+        if (topicListeners == null) {
+            return;
+        }
+        pulsarService.getBrokerService().getTopicOrderedExecutor().executeOrdered(topicName, () -> {
+            for (TopicPolicyListener listener : topicListeners) {
                 try {
                     listener.onUpdate(policies);
                 } catch (Throwable error) {
                     log.error().attr("topic", topicName).exception(error).log("call listener error.");
                 }
             }
-        }
+        });
     }
 
     @Override
@@ -855,17 +866,7 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
                         .log("Reach the end of the system topic.");
 
                 // replay policy message
-                policiesCache.forEach(((topicName, topicPolicies) -> {
-                    if (listeners.get(topicName) != null) {
-                        for (TopicPolicyListener listener : listeners.get(topicName)) {
-                            try {
-                                listener.onUpdate(topicPolicies);
-                            } catch (Throwable error) {
-                                log.error().attr("topic", topicName).exception(error).log("call listener error.");
-                            }
-                        }
-                    }
-                }));
+                policiesCache.forEach((topicName, topicPolicies) -> notifyListeners(topicName, topicPolicies));
 
                 future.complete(null);
             }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
@@ -35,6 +35,7 @@ import java.util.PriorityQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -496,7 +497,7 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
         if (msg.getValue() == null) {
             TopicName topicName = TopicName.get(TopicPoliciesService.unwrapEventKey(msg.getKey())
                     .getPartitionedTopicName());
-            notifyListeners(topicName, null);
+            notifyListenersForTopic(topicName, null);
             return;
         }
 
@@ -506,7 +507,7 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
         TopicPoliciesEvent event = msg.getValue().getTopicPoliciesEvent();
         TopicName topicName = TopicName.get(event.getDomain(), event.getTenant(),
                 event.getNamespace(), event.getTopic());
-        notifyListeners(topicName, event.getPolicies());
+        notifyListenersForTopic(topicName, event.getPolicies());
     }
 
     /**
@@ -521,7 +522,7 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
      * namespace (issue #26037). Keying {@code executeOrdered} by {@code topicName} preserves per-topic
      * notification ordering.
      */
-    private void notifyListeners(TopicName topicName, @Nullable TopicPolicies policies) {
+    private void notifyListenersForTopic(TopicName topicName, @Nullable TopicPolicies policies) {
         // The per-topic value is a CopyOnWriteArrayList, so iterating it later on the executor thread stays
         // safe even if a listener is registered/unregistered between dispatch and execution.
         List<TopicPolicyListener> topicListeners = listeners.get(topicName);
@@ -529,14 +530,36 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
             return;
         }
         pulsarService.getBrokerService().getTopicOrderedExecutor().executeOrdered(topicName, () -> {
-            for (TopicPolicyListener listener : topicListeners) {
-                try {
-                    listener.onUpdate(policies);
-                } catch (Throwable error) {
-                    log.error().attr("topic", topicName).exception(error).log("call listener error.");
-                }
-            }
+            internalNotifyTopicListeners(topicName, policies, topicListeners);
         });
+    }
+
+    // this method should only be called from the topic ordered executor thread
+    // use notifyListenersForTopic/notifyListenersForTopicAsync instead
+    private static void internalNotifyTopicListeners(TopicName topicName, @Nullable TopicPolicies policies,
+                                  List<TopicPolicyListener> topicListeners) {
+        for (TopicPolicyListener listener : topicListeners) {
+            try {
+                listener.onUpdate(policies);
+            } catch (Throwable error) {
+                log.error().attr("topic", topicName).attr("listener", listener).exception(error)
+                        .log("Error in notifying listener on topic policy update.");
+            }
+        }
+    }
+
+    private CompletableFuture<Void> notifyListenersForTopicAsync(TopicName topicName, @Nullable TopicPolicies policies) {
+        // The per-topic value is a CopyOnWriteArrayList, so iterating it later on the executor thread stays
+        // safe even if a listener is registered/unregistered between dispatch and execution.
+        List<TopicPolicyListener> topicListeners = listeners.get(topicName);
+        if (topicListeners == null) {
+            return CompletableFuture.completedFuture(null);
+        }
+        ExecutorService pinnedTopicOrderedExecutor =
+                pulsarService.getBrokerService().getTopicOrderedExecutor().chooseThread(topicName);
+        return CompletableFuture.runAsync(() -> {
+            internalNotifyTopicListeners(topicName, policies, topicListeners);
+        }, pinnedTopicOrderedExecutor);
     }
 
     @Override
@@ -866,9 +889,13 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
                         .log("Reach the end of the system topic.");
 
                 // replay policy message
-                policiesCache.forEach((topicName, topicPolicies) -> notifyListeners(topicName, topicPolicies));
-
-                future.complete(null);
+                List<CompletableFuture<Void>> notifyFutures = new ArrayList<>();
+                for(Map.Entry<TopicName, TopicPolicies> entry : policiesCache.entrySet()) {
+                    TopicName topicName = entry.getKey();
+                    TopicPolicies policies = entry.getValue();
+                    notifyFutures.add(notifyListenersForTopicAsync(topicName, policies));
+                }
+                FutureUtil.completeAfter(future, FutureUtil.waitForAll(notifyFutures));
             }
         });
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
@@ -548,7 +548,8 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
         }
     }
 
-    private CompletableFuture<Void> notifyListenersForTopicAsync(TopicName topicName, @Nullable TopicPolicies policies) {
+    private CompletableFuture<Void> notifyListenersForTopicAsync(TopicName topicName,
+                                                                 @Nullable TopicPolicies policies) {
         // The per-topic value is a CopyOnWriteArrayList, so iterating it later on the executor thread stays
         // safe even if a listener is registered/unregistered between dispatch and execution.
         List<TopicPolicyListener> topicListeners = listeners.get(topicName);
@@ -890,7 +891,7 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
 
                 // replay policy message
                 List<CompletableFuture<Void>> notifyFutures = new ArrayList<>();
-                for(Map.Entry<TopicName, TopicPolicies> entry : policiesCache.entrySet()) {
+                for (Map.Entry<TopicName, TopicPolicies> entry : policiesCache.entrySet()) {
                     TopicName topicName = entry.getKey();
                     TopicPolicies policies = entry.getValue();
                     notifyFutures.add(notifyListenersForTopicAsync(topicName, policies));

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/TopicPolicyListenerWrapper.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/TopicPolicyListenerWrapper.java
@@ -42,13 +42,18 @@ public class TopicPolicyListenerWrapper implements TopicPolicyListener {
     public synchronized void onUpdate(TopicPolicies data) {
         if (initialized) {
             realTopicListener.onUpdate(data);
-        } else {
+        } else if (data != null) {
+            // Buffer the latest policies received during initialization so they can be applied
+            // (preferring them over the loaded values) in completeInitialization.
             if (data.isGlobalPolicies()) {
                 latestGlobalPolicies = data;
             } else {
                 latestLocalPolicies = data;
             }
         }
+        // A null update is a delete signal; onUpdate(null) is a no-op for the real listeners, so there is
+        // nothing to buffer during initialization. Guarding against null also avoids an NPE on the
+        // data.isGlobalPolicies() call when a delete event arrives before initialization completes (#26037).
     }
 
     /**

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/TopicPolicyListenerWrapper.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/TopicPolicyListenerWrapper.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.broker.service;
+
+import org.apache.pulsar.common.policies.data.TopicPolicies;
+
+/**
+ * This TopicPolicyListener is used as a wrapper for the real TopicPolicyListener.
+ * This prevents a race condition in initialization where the topic policy state can change while the
+ * topic policy state is being applied to the topic in PersistentTopic#initTopicPolicy() method or in
+ * NonPersistentTopic#initialize method. The impact of the race conditions is that the topic policy state would
+ * be left in an inconsistent state until another update arrives. This is a rare corner case, but possible.
+ */
+public class TopicPolicyListenerWrapper implements TopicPolicyListener {
+    private final TopicPolicyListener realTopicListener;
+    private TopicPolicies latestGlobalPolicies;
+    private TopicPolicies latestLocalPolicies;
+    private boolean initialized;
+
+    public TopicPolicyListenerWrapper(TopicPolicyListener realTopicListener) {
+        this.realTopicListener = realTopicListener;
+    }
+
+    @Override
+    public synchronized void onUpdate(TopicPolicies data) {
+        if (initialized) {
+            realTopicListener.onUpdate(data);
+        } else {
+            if (data.isGlobalPolicies()) {
+                latestGlobalPolicies = data;
+            } else {
+                latestLocalPolicies = data;
+            }
+        }
+    }
+
+    /**
+     * Complete initialization of the TopicPolicyListenerWrapper and emit the latest policies to the real listener.
+     * @param loadedGlobalPolicies the loaded global policies
+     * @param loadedLocalPolicies the loaded local policies
+     */
+    public synchronized void completeInitialization(TopicPolicies loadedGlobalPolicies,
+                                                    TopicPolicies loadedLocalPolicies) {
+        // the listener might have received a newer value than the loaded one while the loading was happening
+        // use the latest values received by the listener, fallback to use the loaded values
+
+        if (latestGlobalPolicies != null) {
+            realTopicListener.onUpdate(latestGlobalPolicies);
+            latestGlobalPolicies = null;
+        } else if (loadedGlobalPolicies != null) {
+            realTopicListener.onUpdate(loadedGlobalPolicies);
+        }
+
+        if (latestLocalPolicies != null) {
+            realTopicListener.onUpdate(latestLocalPolicies);
+            latestLocalPolicies = null;
+        } else if (loadedLocalPolicies != null) {
+            realTopicListener.onUpdate(loadedLocalPolicies);
+        }
+
+        initialized = true;
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
@@ -67,6 +67,7 @@ import org.apache.pulsar.broker.service.SubscriptionOption;
 import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.broker.service.TopicAttributes;
 import org.apache.pulsar.broker.service.TopicPolicyListener;
+import org.apache.pulsar.broker.service.TopicPolicyListenerWrapper;
 import org.apache.pulsar.broker.service.TransportCnx;
 import org.apache.pulsar.broker.service.schema.exceptions.IncompatibleSchemaException;
 import org.apache.pulsar.broker.service.schema.exceptions.NotExistSchemaException;
@@ -131,6 +132,9 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
             TOPIC_ATTRIBUTES_FIELD_UPDATER = AtomicReferenceFieldUpdater.newUpdater(
                     NonPersistentTopic.class, TopicAttributes.class, "topicAttributes");
 
+    // prevents race conditions in topic policy initialization
+    private final TopicPolicyListenerWrapper topicPolicyListener = new TopicPolicyListenerWrapper(this);
+
     private static class TopicStats {
         public double averageMsgSize;
         public double aggMsgRateIn;
@@ -169,7 +173,7 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
     public CompletableFuture<Void> initialize() {
         return brokerService.pulsar().getPulsarResources().getNamespaceResources()
                 .getPoliciesAsync(TopicName.get(topic).getNamespaceObject())
-                .thenCompose(optPolicies -> {
+                .thenComposeAsync(optPolicies -> {
                     final Policies policies;
                     if (optPolicies.isEmpty()) {
                         log.warn("Policies not present and isEncryptionRequired will be set to false");
@@ -186,7 +190,7 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
                     updatePublishRateLimiter();
                     updateResourceGroupLimiter(policies);
                     return updateClusterMigrated();
-                });
+                }, getPoliciesNotifyThread());
     }
 
     @Override
@@ -1323,5 +1327,10 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
         }
         return TOPIC_ATTRIBUTES_FIELD_UPDATER.updateAndGet(this,
                 old -> old != null ? old : new TopicAttributes(TopicName.get(topic)));
+    }
+
+    @Override
+    public TopicPolicyListener getTopicPolicyListener() {
+        return topicPolicyListener;
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
@@ -190,7 +190,14 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
                     updatePublishRateLimiter();
                     updateResourceGroupLimiter(policies);
                     return updateClusterMigrated();
-                }, getPoliciesNotifyThread());
+                }, getPoliciesNotifyThread())
+                // Complete the topic-policy listener wrapper so buffered and future topic-level policy
+                // updates are forwarded to this topic. Without this the wrapper stays uninitialized forever
+                // and all topic-level policy updates are silently dropped. Unlike PersistentTopic,
+                // non-persistent topics don't load initial topic policies (matching the previous behavior),
+                // so the loaded values are passed as null.
+                .thenRunAsync(() -> topicPolicyListener.completeInitialization(null, null),
+                        getPoliciesNotifyThread());
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -60,6 +60,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
+import java.util.function.Function;
 import lombok.Getter;
 import lombok.Value;
 import org.apache.bookkeeper.client.BKException.BKNoSuchLedgerExistsException;
@@ -136,6 +137,8 @@ import org.apache.pulsar.broker.service.Subscription;
 import org.apache.pulsar.broker.service.SubscriptionOption;
 import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.broker.service.TopicPoliciesService;
+import org.apache.pulsar.broker.service.TopicPolicyListener;
+import org.apache.pulsar.broker.service.TopicPolicyListenerWrapper;
 import org.apache.pulsar.broker.service.TransportCnx;
 import org.apache.pulsar.broker.service.schema.BookkeeperSchemaStorage;
 import org.apache.pulsar.broker.service.schema.exceptions.IncompatibleSchemaException;
@@ -296,6 +299,10 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
     // Record the last time max read position is moved forward, unless it's a marker message.
     @Getter
     private volatile long lastMaxReadPositionMovedForwardTimestamp = 0;
+
+    // prevents race conditions in topic policy initialization
+    private final TopicPolicyListenerWrapper topicPolicyListener = new TopicPolicyListenerWrapper(this);
+
     @Getter
     private final ExecutorService orderedExecutor;
 
@@ -4925,22 +4932,29 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         final var topicPoliciesService = brokerService.pulsar().getTopicPoliciesService();
         final var partitionedTopicName = TopicName.getPartitionedTopicName(topic);
 
-        return topicPoliciesService.registerListenerAsync(partitionedTopicName, this).thenCompose(registered -> {
-            if (!registered) {
-                return CompletableFuture.completedFuture(null);
-            }
-            if (ExtensibleLoadManagerImpl.isInternalTopic(topic)) {
-                return CompletableFuture.completedFuture(null);
-            }
-            return topicPoliciesService.getTopicPoliciesAsync(partitionedTopicName,
-                    TopicPoliciesService.GetType.GLOBAL_ONLY)
-            .thenAcceptAsync(optionalPolicies -> optionalPolicies.ifPresent(this::onUpdate),
-                    getTopicPoliciesNotifyThread())
-            .thenCompose(__ -> topicPoliciesService.getTopicPoliciesAsync(partitionedTopicName,
-                    TopicPoliciesService.GetType.LOCAL_ONLY))
-            .thenAcceptAsync(optionalPolicies -> optionalPolicies.ifPresent(this::onUpdate),
-                    getTopicPoliciesNotifyThread());
-        });
+        return topicPoliciesService.registerListenerAsync(partitionedTopicName, topicPolicyListener)
+                .thenCompose(registered -> {
+                    if (!registered) {
+                        return CompletableFuture.completedFuture(null);
+                    }
+                    if (ExtensibleLoadManagerImpl.isInternalTopic(topic)) {
+                        return CompletableFuture.completedFuture(null);
+                    }
+                    // future for fetching global topic policies
+                    CompletableFuture<Optional<TopicPolicies>> globalPoliciesFuture =
+                            topicPoliciesService.getTopicPoliciesAsync(partitionedTopicName,
+                                    TopicPoliciesService.GetType.GLOBAL_ONLY);
+                    // future for fetching local topic policies
+                    CompletableFuture<Optional<TopicPolicies>> localPoliciesFuture =
+                            topicPoliciesService.getTopicPoliciesAsync(partitionedTopicName,
+                                    TopicPoliciesService.GetType.LOCAL_ONLY);
+                    return globalPoliciesFuture.thenCombine(localPoliciesFuture, (global, local) -> {
+                        return CompletableFuture.runAsync(() -> {
+                            // finally update the topic policies with the latest value or loaded value
+                            topicPolicyListener.completeInitialization(global.orElse(null), local.orElse(null));
+                        }, getTopicPoliciesNotifyThread());
+                    }).thenCompose(Function.identity());
+                });
     }
 
     private ExecutorService getTopicPoliciesNotifyThread() {
@@ -5120,5 +5134,10 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         }
 
         return future;
+    }
+
+    @Override
+    public TopicPolicyListener getTopicPolicyListener() {
+        return topicPolicyListener;
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -510,7 +510,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
 
                     isAllowAutoUpdateSchema = policies.is_allow_auto_update_schema;
                     isAllowAutoUpdateSchemaWithReplicator = policies.is_allow_auto_update_schema_with_replicator;
-                }, getOrderedExecutor())
+                }, getPoliciesNotifyThread())
                 .thenCompose(ignore -> initTopicPolicy())
                 .thenCompose(ignore -> removeOrphanReplicationCursors())
                 .exceptionally(ex -> {
@@ -4952,13 +4952,9 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                         return CompletableFuture.runAsync(() -> {
                             // finally update the topic policies with the latest value or loaded value
                             topicPolicyListener.completeInitialization(global.orElse(null), local.orElse(null));
-                        }, getTopicPoliciesNotifyThread());
+                        }, getPoliciesNotifyThread());
                     }).thenCompose(Function.identity());
                 });
-    }
-
-    private ExecutorService getTopicPoliciesNotifyThread() {
-        return brokerService.getTopicOrderedExecutor().chooseThread(TopicName.getPartitionedTopicName(topic));
     }
 
     @VisibleForTesting

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -4924,6 +4924,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
     protected CompletableFuture<Void> initTopicPolicy() {
         final var topicPoliciesService = brokerService.pulsar().getTopicPoliciesService();
         final var partitionedTopicName = TopicName.getPartitionedTopicName(topic);
+
         return topicPoliciesService.registerListenerAsync(partitionedTopicName, this).thenCompose(registered -> {
             if (!registered) {
                 return CompletableFuture.completedFuture(null);
@@ -4934,12 +4935,16 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
             return topicPoliciesService.getTopicPoliciesAsync(partitionedTopicName,
                     TopicPoliciesService.GetType.GLOBAL_ONLY)
             .thenAcceptAsync(optionalPolicies -> optionalPolicies.ifPresent(this::onUpdate),
-                    brokerService.getTopicOrderedExecutor())
+                    getTopicPoliciesNotifyThread())
             .thenCompose(__ -> topicPoliciesService.getTopicPoliciesAsync(partitionedTopicName,
                     TopicPoliciesService.GetType.LOCAL_ONLY))
             .thenAcceptAsync(optionalPolicies -> optionalPolicies.ifPresent(this::onUpdate),
-                            brokerService.getTopicOrderedExecutor());
+                    getTopicPoliciesNotifyThread());
         });
+    }
+
+    private ExecutorService getTopicPoliciesNotifyThread() {
+        return brokerService.getTopicOrderedExecutor().chooseThread(TopicName.getPartitionedTopicName(topic));
     }
 
     @VisibleForTesting

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -231,6 +231,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
     private final TopicName shadowSourceTopic;
 
     public static final String DEDUPLICATION_CURSOR_NAME = "pulsar.dedup";
+    private volatile int lastMessageTtlInSeconds;
 
     public static boolean isDedupCursorName(String name) {
         return DEDUPLICATION_CURSOR_NAME.equals(name);
@@ -3888,8 +3889,9 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         });
         producers.values().forEach(producer -> applyPoliciesFutureList.add(
                 producer.checkPermissionsAsync().thenRun(producer::checkEncryption)));
-        // Check message expiry.
-        applyPoliciesFutureList.add(FutureUtil.runWithCurrentThread(() -> checkMessageExpiry()));
+
+        // Check message expiry in the background so that it doesn't block updating or loading topic policies.
+        maybeCheckMessageExpiryOnPolicyUpdateInBackground();
 
         // Update rate limiters.
         applyPoliciesFutureList.add(FutureUtil.runWithCurrentThread(() -> updateDispatchRateLimiter()));
@@ -3912,6 +3914,19 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                 () -> updateBrokerDispatchPauseOnAckStatePersistentEnabled()));
 
         return applyPoliciesFutureList;
+    }
+    
+    private void maybeCheckMessageExpiryOnPolicyUpdateInBackground() {
+        int messageTtlInSeconds = topicPolicies.getMessageTTLInSeconds().get();
+        // don't check if the message expiry hasn't changed
+        if (messageTtlInSeconds > 0) {
+            if (lastMessageTtlInSeconds != messageTtlInSeconds) {
+                lastMessageTtlInSeconds = messageTtlInSeconds;
+                brokerService.getMessageExpiryMonitor().execute(this::checkMessageExpiry);
+            }
+        } else {
+            lastMessageTtlInSeconds = messageTtlInSeconds;
+        }
     }
 
     /**

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -3915,7 +3915,14 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
 
         return applyPoliciesFutureList;
     }
-    
+
+    /**
+     * Triggers a message-expiry check on a policy update, but only when the message TTL actually changed, and
+     * runs it on the messageExpiryMonitor thread (the same thread the periodic expiry check uses) so it never
+     * blocks updating or loading topic policies. Unlike before, the expiry check is no longer part of the
+     * returned {@link #applyUpdatedTopicPolicies()} futures, so callers no longer wait for it; the periodic
+     * monitor provides eventual coverage and the check is idempotent.
+     */
     private void maybeCheckMessageExpiryOnPolicyUpdateInBackground() {
         int messageTtlInSeconds = topicPolicies.getMessageTTLInSeconds().get();
         // don't check if the message expiry hasn't changed
@@ -4953,7 +4960,12 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                         return CompletableFuture.completedFuture(null);
                     }
                     if (ExtensibleLoadManagerImpl.isInternalTopic(topic)) {
-                        return CompletableFuture.completedFuture(null);
+                        // Internal topics don't load topic-level policies, but the listener wrapper must
+                        // still be initialized so any buffered/future updates are forwarded to the topic
+                        // instead of being silently dropped.
+                        return CompletableFuture.runAsync(
+                                () -> topicPolicyListener.completeInitialization(null, null),
+                                getPoliciesNotifyThread());
                     }
                     // future for fetching global topic policies
                     CompletableFuture<Optional<TopicPolicies>> globalPoliciesFuture =

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/AbstractTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/AbstractTopicTest.java
@@ -25,9 +25,11 @@ import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
 import static org.testng.Assert.assertEquals;
 import java.util.concurrent.ConcurrentHashMap;
+import org.apache.bookkeeper.common.util.OrderedExecutor;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.qos.AsyncTokenBucket;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -35,6 +37,7 @@ import org.testng.annotations.Test;
 public class AbstractTopicTest {
     private AbstractSubscription subscription;
     private AbstractTopic topic;
+    private OrderedExecutor topicOrderedExecutor;
 
     @BeforeMethod
     public void beforeMethod() {
@@ -49,6 +52,9 @@ public class AbstractTopicTest {
         when(pulsarService.getConfiguration()).thenReturn(serviceConfiguration);
         when(brokerService.getBacklogQuotaManager()).thenReturn(backlogQuotaManager);
         doReturn(AsyncTokenBucket.DEFAULT_SNAPSHOT_CLOCK).when(pulsarService).getMonotonicClock();
+        // AbstractTopic's constructor pins a per-topic policies-notify thread from the topic-ordered executor.
+        topicOrderedExecutor = OrderedExecutor.newBuilder().numThreads(1).name("test-topic-workers").build();
+        doReturn(topicOrderedExecutor).when(brokerService).getTopicOrderedExecutor();
 
         topic = mock(AbstractTopic.class, withSettings()
                 .useConstructor("topic", brokerService)
@@ -57,6 +63,14 @@ public class AbstractTopicTest {
         final var subscriptions = new ConcurrentHashMap<String, Subscription>();
         subscriptions.put("subscription", subscription);
         when(topic.getSubscriptions()).thenAnswer(invocation -> subscriptions);
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void afterMethod() {
+        if (topicOrderedExecutor != null) {
+            topicOrderedExecutor.shutdownNow();
+            topicOrderedExecutor = null;
+        }
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesServiceTest.java
@@ -134,6 +134,36 @@ public class SystemTopicBasedTopicPoliciesServiceTest extends MockedPulsarServic
     }
 
     @Test
+    public void testListenerNotificationRunsOffSharedReaderThread() throws Exception {
+        // Regression test for #26037: topic-policy listener callbacks must not run on the single,
+        // process-wide shared "broker-client-shared-internal-executor" reader thread. A slow or blocking
+        // onUpdate there serializes — and can stall — topic-policy loading for every namespace. The
+        // notification must instead be dispatched to the per-topic ordered executor ("broker-topic-workers").
+
+        // Initialize the policy cache and start the change-events reader for the namespace.
+        systemTopicBasedTopicPoliciesService.updateTopicPoliciesAsync(TOPIC1, false, false, topicPolicies ->
+                topicPolicies.setMaxConsumerPerTopic(10)).get();
+        Awaitility.await().untilAsserted(() -> Assert.assertTrue(systemTopicBasedTopicPoliciesService
+                .getPoliciesCacheInit(TOPIC1.getNamespaceObject()).isDone()));
+
+        // Register a listener that records the thread its onUpdate runs on.
+        CompletableFuture<String> onUpdateThreadName = new CompletableFuture<>();
+        TopicPolicyListener listener = data -> onUpdateThreadName.complete(Thread.currentThread().getName());
+        systemTopicBasedTopicPoliciesService.registerListenerAsync(TOPIC1, listener).get();
+
+        // A live policy update flows through readMorePoliciesAsync -> notifyListener -> listener.onUpdate.
+        systemTopicBasedTopicPoliciesService.updateTopicPoliciesAsync(TOPIC1, false, false, topicPolicies ->
+                topicPolicies.setMaxConsumerPerTopic(20)).get();
+
+        String threadName = onUpdateThreadName.get(30, TimeUnit.SECONDS);
+        assertFalse("listener.onUpdate must not run on the shared broker-client reader thread, but ran on: "
+                        + threadName,
+                threadName.contains("broker-client-shared-internal-executor"));
+        assertTrue("listener.onUpdate should run on the per-topic ordered executor, but ran on: " + threadName,
+                threadName.contains("broker-topic-workers"));
+    }
+
+    @Test
     public void testGetPolicy() throws Exception {
 
         systemTopicBasedTopicPoliciesService.updateTopicPoliciesAsync(TOPIC1, false, false, topicPolicies ->

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TopicPolicyListenerWrapperTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TopicPolicyListenerWrapperTest.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.pulsar.common.policies.data.TopicPolicies;
+import org.testng.annotations.Test;
+
+@Test(groups = "broker")
+public class TopicPolicyListenerWrapperTest {
+
+    private static TopicPolicies globalPolicies() {
+        return TopicPolicies.builder().isGlobal(true).build();
+    }
+
+    private static TopicPolicies localPolicies() {
+        return TopicPolicies.builder().isGlobal(false).build();
+    }
+
+    private static final class RecordingListener implements TopicPolicyListener {
+        final List<TopicPolicies> updates = new ArrayList<>();
+
+        @Override
+        public void onUpdate(TopicPolicies data) {
+            updates.add(data);
+        }
+    }
+
+    @Test
+    public void shouldBufferUpdatesUntilInitializedThenForwardLive() {
+        RecordingListener real = new RecordingListener();
+        TopicPolicyListenerWrapper wrapper = new TopicPolicyListenerWrapper(real);
+
+        // Updates received before initialization are buffered, not forwarded.
+        TopicPolicies bufferedLocal = localPolicies();
+        wrapper.onUpdate(bufferedLocal);
+        assertThat(real.updates).isEmpty();
+
+        // On completion, the buffered local value wins over the loaded local value; the loaded global value
+        // is applied since none was buffered.
+        TopicPolicies loadedGlobal = globalPolicies();
+        wrapper.completeInitialization(loadedGlobal, localPolicies());
+        assertThat(real.updates).containsExactly(loadedGlobal, bufferedLocal);
+
+        // After initialization, updates are forwarded immediately.
+        TopicPolicies liveUpdate = localPolicies();
+        wrapper.onUpdate(liveUpdate);
+        assertThat(real.updates).containsExactly(loadedGlobal, bufferedLocal, liveUpdate);
+    }
+
+    @Test
+    public void shouldPreferBufferedOverLoadedForBothScopes() {
+        RecordingListener real = new RecordingListener();
+        TopicPolicyListenerWrapper wrapper = new TopicPolicyListenerWrapper(real);
+
+        TopicPolicies bufferedGlobal = globalPolicies();
+        TopicPolicies bufferedLocal = localPolicies();
+        wrapper.onUpdate(bufferedGlobal);
+        wrapper.onUpdate(bufferedLocal);
+
+        wrapper.completeInitialization(globalPolicies(), localPolicies());
+        assertThat(real.updates).containsExactly(bufferedGlobal, bufferedLocal);
+    }
+
+    @Test
+    public void shouldApplyLoadedWhenNothingBuffered() {
+        RecordingListener real = new RecordingListener();
+        TopicPolicyListenerWrapper wrapper = new TopicPolicyListenerWrapper(real);
+
+        TopicPolicies loadedGlobal = globalPolicies();
+        TopicPolicies loadedLocal = localPolicies();
+        wrapper.completeInitialization(loadedGlobal, loadedLocal);
+        assertThat(real.updates).containsExactly(loadedGlobal, loadedLocal);
+    }
+
+    @Test
+    public void shouldNotThrowOnNullDeleteBeforeInitialization() {
+        RecordingListener real = new RecordingListener();
+        TopicPolicyListenerWrapper wrapper = new TopicPolicyListenerWrapper(real);
+
+        // A delete (null) arriving before initialization must not NPE and must not be forwarded (#26037).
+        assertThatCode(() -> wrapper.onUpdate(null)).doesNotThrowAnyException();
+        assertThat(real.updates).isEmpty();
+
+        wrapper.completeInitialization(null, null);
+        assertThat(real.updates).isEmpty();
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/ReplicatedSubscriptionsControllerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/ReplicatedSubscriptionsControllerTest.java
@@ -38,6 +38,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import lombok.Cleanup;
+import org.apache.bookkeeper.common.util.OrderedExecutor;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.DeleteCursorCallback;
 import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.bookkeeper.mledger.PositionFactory;
@@ -55,10 +56,21 @@ import org.apache.pulsar.common.protocol.Commands;
 import org.apache.pulsar.common.protocol.Markers;
 import org.mockito.Mockito;
 import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
 @Test(groups = "broker-replication")
 public class ReplicatedSubscriptionsControllerTest {
+
+    private OrderedExecutor topicOrderedExecutor;
+
+    @AfterMethod(alwaysRun = true)
+    public void cleanup() {
+        if (topicOrderedExecutor != null) {
+            topicOrderedExecutor.shutdownNow();
+            topicOrderedExecutor = null;
+        }
+    }
 
     @Test
     @SuppressWarnings("unchecked")
@@ -88,6 +100,9 @@ public class ReplicatedSubscriptionsControllerTest {
         when(brokerService.pulsar()).thenReturn(pulsar);
         when(brokerService.getPulsar()).thenReturn(pulsar);
         when(brokerService.getBacklogQuotaManager()).thenReturn(backlogQuotaManager);
+        // AbstractTopic's constructor pins a per-topic policies-notify thread from the topic-ordered executor.
+        topicOrderedExecutor = OrderedExecutor.newBuilder().numThreads(1).name("test-topic-workers").build();
+        when(brokerService.getTopicOrderedExecutor()).thenReturn(topicOrderedExecutor);
 
         when(pulsar.getExecutor()).thenReturn(executor);
         when(pulsar.getConfiguration()).thenReturn(config);


### PR DESCRIPTION
- **Notify listeners on the topic ordered executor**
- **Notify topics of a namespace in parallel**
- **Run on correct thread**
- **Add the solution to prevent races**
- **Run policy updates on fixed thread**
- **Only run message expiry check on policy update when the ttl value has changed since the last run, schedule on messageExpiryMonitor thread**
- **Initialize topic policy listener wrapper for non-persistent and internal topics**
- **Guard against NPE in TopicPolicyListenerWrapper on policy delete during initialization**
- **Fix checkstyle violations in SystemTopicBasedTopicPoliciesService**
