### PR TITLE
[fix][broker] Run the message expiry check off the topic policy update path

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -285,6 +285,7 @@ public class BrokerService implements Closeable {
             .register();
 
     private final SingleThreadNonConcurrentFixedRateScheduler inactivityMonitor;
+    @Getter
     private final SingleThreadNonConcurrentFixedRateScheduler messageExpiryMonitor;
     private final SingleThreadNonConcurrentFixedRateScheduler compactionMonitor;
     private final SingleThreadNonConcurrentFixedRateScheduler consumedLedgersMonitor;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -228,6 +228,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
     private final TopicName shadowSourceTopic;
 
     public static final String DEDUPLICATION_CURSOR_NAME = "pulsar.dedup";
+    private volatile int lastMessageTtlInSeconds;
 
     public static boolean isDedupCursorName(String name) {
         return DEDUPLICATION_CURSOR_NAME.equals(name);
@@ -3881,8 +3882,9 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         });
         producers.values().forEach(producer -> applyPoliciesFutureList.add(
                 producer.checkPermissionsAsync().thenRun(producer::checkEncryption)));
-        // Check message expiry.
-        applyPoliciesFutureList.add(FutureUtil.runWithCurrentThread(() -> checkMessageExpiry()));
+
+        // Check message expiry in the background so that it doesn't block updating or loading topic policies.
+        maybeCheckMessageExpiryOnPolicyUpdateInBackground();
 
         // Update rate limiters.
         applyPoliciesFutureList.add(FutureUtil.runWithCurrentThread(() -> updateDispatchRateLimiter()));
@@ -3905,6 +3907,26 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                 () -> updateBrokerDispatchPauseOnAckStatePersistentEnabled()));
 
         return applyPoliciesFutureList;
+    }
+
+    /**
+     * Triggers a message-expiry check on a policy update, but only when the message TTL actually changed, and
+     * runs it on the messageExpiryMonitor thread (the same thread the periodic expiry check uses) so it never
+     * blocks updating or loading topic policies. Unlike before, the expiry check is no longer part of the
+     * returned {@link #applyUpdatedTopicPolicies()} futures, so callers no longer wait for it; the periodic
+     * monitor provides eventual coverage and the check is idempotent.
+     */
+    private void maybeCheckMessageExpiryOnPolicyUpdateInBackground() {
+        int messageTtlInSeconds = topicPolicies.getMessageTTLInSeconds().get();
+        // don't check if the message expiry hasn't changed
+        if (messageTtlInSeconds > 0) {
+            if (lastMessageTtlInSeconds != messageTtlInSeconds) {
+                lastMessageTtlInSeconds = messageTtlInSeconds;
+                brokerService.getMessageExpiryMonitor().execute(this::checkMessageExpiry);
+            }
+        } else {
+            lastMessageTtlInSeconds = messageTtlInSeconds;
+        }
     }
 
     /**

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/MessageTTLTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/MessageTTLTest.java
@@ -19,7 +19,7 @@
 package org.apache.pulsar.broker.service;
 
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
@@ -136,12 +136,13 @@ public class MessageTTLTest extends BrokerTestBase {
         Policies policies = admin.namespaces().getPolicies(namespace);
         policies.message_ttl_in_seconds = 10;
         topicRefMock.onPoliciesUpdate(policies);
-        verify(topicRefMock, times(1)).checkMessageExpiry();
+        // checkMessageExpiry now runs asynchronously on the messageExpiryMonitor thread, so wait for it.
+        verify(topicRefMock, timeout(5000).times(1)).checkMessageExpiry();
 
         TopicPolicies topicPolicies = new TopicPolicies();
         topicPolicies.setMessageTTLInSeconds(5);
         topicRefMock.onUpdate(topicPolicies);
-        verify(topicRefMock, times(2)).checkMessageExpiry();
+        verify(topicRefMock, timeout(5000).times(2)).checkMessageExpiry();
     }
 
     @Test


### PR DESCRIPTION
Main Issue: #26037

### Motivation

When topic policies are applied (`PersistentTopic.onUpdate` / `onPoliciesUpdate` → `applyUpdatedTopicPolicies`),
the message-expiry check (`checkMessageExpiry`) was run inline on the calling thread. That check can block: it
walks subscription cursors and can wait on metadata operations
(`...getNthEntry` → `counter.await(metadataOperationsTimeoutSeconds)`, default 60s).

For topic-policy updates this inline work runs on the single, process-wide shared
`broker-client-shared-internal-executor` reader thread (the thread reported in #26037), so a single topic whose
oldest ledger is temporarily inaccessible could block topic-policy loading/updates. The check was also executed
on every policy update, even when the message TTL had not changed.

### Modifications

- `applyUpdatedTopicPolicies` no longer runs `checkMessageExpiry` inline. Instead,
  `maybeCheckMessageExpiryOnPolicyUpdateInBackground` schedules it on the dedicated `messageExpiryMonitor`
  thread — the same thread the periodic expiry check already uses — so it never blocks applying or loading
  topic policies. The check is idempotent and the periodic monitor still provides eventual coverage, so it is
  no longer part of the futures returned by `applyUpdatedTopicPolicies` (callers no longer wait for it).
- The check now runs only when the effective message TTL actually changed since the last run (tracked via a
  new `volatile int lastMessageTtlInSeconds`), avoiding redundant scans on unrelated policy updates.
- Exposed `BrokerService.messageExpiryMonitor` via `@Getter` so the topic can schedule on it.

### Verifying this change

This change is already covered by existing tests:
- `MessageTTLTest` — `testTTLPoliciesUpdate` was updated to wait for the now-asynchronous expiry check using
  Mockito `timeout` verification (the previous synchronous `verify(times(N))` would otherwise race the
  background execution).
- `PersistentMessageExpiryMonitorMockTest`.

### Does this pull request potentially affect one of the following parts:

- [x] The threading model

The message-expiry check triggered by a topic-policy update now runs asynchronously on the
`messageExpiryMonitor` thread instead of synchronously on the policy-application thread.
