### PR TITLE
[improve][broker] Load topic policies on non-persistent topic load and gate the policy replay

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -1994,6 +1994,15 @@ public class ServiceConfiguration implements PulsarConfiguration {
 
     @FieldContext(
             category = CATEGORY_SERVER,
+            doc = "When enabled, all registered topic-policy listeners in a namespace are re-notified with the current"
+                    + " topic policies after the namespace's topic-policy cache finishes its initial load. Topics load"
+                    + " and apply their own policies when they are loaded, so this broadcast is normally redundant; it"
+                    + " is only needed for custom plugins that register TopicPolicyListeners and depend on it for"
+                    + " backwards compatibility. Disabled by default.")
+    private boolean topicPolicyListenerReplayEnabled = false;
+
+    @FieldContext(
+            category = CATEGORY_SERVER,
             doc = """
                     The class name of the topic policies service. There are 2 built-in implementations:
                     1. "org.apache.pulsar.broker.service.SystemTopicBasedTopicPoliciesService" (default)

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -575,11 +575,6 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener {
         return topicPolicyListener;
     }
 
-    protected void registerTopicPolicyListener() {
-        brokerService.getPulsar().getTopicPoliciesService()
-                .registerListenerAsync(TopicName.getPartitionedTopicName(topic), getTopicPolicyListener());
-    }
-
     protected void unregisterTopicPolicyListener() {
         brokerService.getPulsar().getTopicPoliciesService()
                 .unregisterListener(TopicName.getPartitionedTopicName(topic), getTopicPolicyListener());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -50,6 +50,7 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Function;
 import java.util.function.ToLongFunction;
 import lombok.Getter;
 import lombok.Setter;
@@ -60,6 +61,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.loadbalance.extensions.ExtensibleLoadManagerImpl;
 import org.apache.pulsar.broker.resourcegroup.ResourceGroup;
 import org.apache.pulsar.broker.resourcegroup.ResourceGroupPublishLimiter;
 import org.apache.pulsar.broker.resources.NamespaceResources;
@@ -118,6 +120,10 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener {
     protected final ConcurrentHashMap<String, Producer> producers;
 
     protected final BrokerService brokerService;
+
+    // Wraps this topic as a TopicPolicyListener so topic-policy updates received while the initial policy is still
+    // loading are buffered and applied in order once initTopicPolicy() completes initialization.
+    protected final TopicPolicyListenerWrapper topicPolicyListener = new TopicPolicyListenerWrapper(this);
 
     // Prefix for replication cursors
     protected final String replicatorPrefix;
@@ -566,7 +572,7 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener {
     }
 
     protected TopicPolicyListener getTopicPolicyListener() {
-        return this;
+        return topicPolicyListener;
     }
 
     protected void registerTopicPolicyListener() {
@@ -577,6 +583,57 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener {
     protected void unregisterTopicPolicyListener() {
         brokerService.getPulsar().getTopicPoliciesService()
                 .unregisterListener(TopicName.getPartitionedTopicName(topic), getTopicPolicyListener());
+    }
+
+    /**
+     * Registers the topic-policy listener and applies the topic's initial policies (global and local) to this topic.
+     * Shared by {@link org.apache.pulsar.broker.service.persistent.PersistentTopic} and
+     * {@link org.apache.pulsar.broker.service.nonpersistent.NonPersistentTopic} so both load their own policies on
+     * topic load, which removes the need to broadcast every topic's policy when a namespace's policy cache finishes
+     * loading (see {@code topicPolicyListenerReplayEnabled}).
+     */
+    protected CompletableFuture<Void> initTopicPolicy() {
+        final var topicPoliciesService = brokerService.getPulsar().getTopicPoliciesService();
+        final var partitionedTopicName = TopicName.getPartitionedTopicName(topic);
+
+        return topicPoliciesService.registerListenerAsync(partitionedTopicName, topicPolicyListener)
+                .thenCompose(registered -> {
+                    if (!registered) {
+                        return CompletableFuture.completedFuture(null);
+                    }
+                    if (ExtensibleLoadManagerImpl.isInternalTopic(topic)) {
+                        // Internal topics don't load topic-level policies, but the listener wrapper must
+                        // still be initialized so any buffered/future updates are forwarded to the topic
+                        // instead of being silently dropped.
+                        return CompletableFuture.runAsync(
+                                () -> topicPolicyListener.completeInitialization(null, null),
+                                getPoliciesNotifyThread());
+                    }
+                    // future for fetching global topic policies
+                    CompletableFuture<Optional<TopicPolicies>> globalPoliciesFuture =
+                            topicPoliciesService.getTopicPoliciesAsync(partitionedTopicName,
+                                    TopicPoliciesService.GetType.GLOBAL_ONLY);
+                    // future for fetching local topic policies
+                    CompletableFuture<Optional<TopicPolicies>> localPoliciesFuture =
+                            topicPoliciesService.getTopicPoliciesAsync(partitionedTopicName,
+                                    TopicPoliciesService.GetType.LOCAL_ONLY);
+                    CompletableFuture<Void> initialPoliciesFuture =
+                            globalPoliciesFuture.thenCombine(localPoliciesFuture, (global, local) -> {
+                                // finally update the topic policies with the latest value or loaded value
+                                return CompletableFuture.runAsync(() ->
+                                        topicPolicyListener.completeInitialization(global.orElse(null),
+                                                local.orElse(null)),
+                                        getPoliciesNotifyThread());
+                            }).thenCompose(Function.identity());
+                    return initialPoliciesFuture.exceptionallyCompose(ex ->
+                            // The topic load path logs and continues when initial policy loading fails. Make sure the
+                            // already-registered wrapper is not left buffering future live updates forever.
+                            CompletableFuture.runAsync(
+                                    () -> topicPolicyListener.completeInitialization(null, null),
+                                    getPoliciesNotifyThread())
+                                    .thenCompose(__ -> FutureUtil.failedFuture(
+                                            FutureUtil.unwrapCompletionException(ex))));
+                });
     }
 
     protected boolean isSameAddressProducersExceeded(Producer producer) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
@@ -892,16 +892,41 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
                         .attr("topic", reader.getSystemTopic().getTopicName())
                         .log("Reach the end of the system topic.");
 
-                // replay policy message
-                List<CompletableFuture<Void>> notifyFutures = new ArrayList<>();
-                for (Map.Entry<TopicName, TopicPolicies> entry : policiesCache.entrySet()) {
-                    TopicName topicName = entry.getKey();
-                    TopicPolicies policies = entry.getValue();
-                    notifyFutures.add(notifyListenersForTopicAsync(topicName, policies));
+                // Optionally re-notify the topic-policy listeners for this namespace with the cached policies.
+                // Topics load their own policies on load (AbstractTopic#initTopicPolicy), so this replay is only
+                // needed for custom plugins that register TopicPolicyListeners and rely on the broadcast; it is
+                // off by default (topicPolicyListenerReplayEnabled).
+                if (pulsarService.getConfiguration().isTopicPolicyListenerReplayEnabled()) {
+                    NamespaceName namespaceObject = reader.getSystemTopic().getTopicName().getNamespaceObject();
+                    FutureUtil.completeAfter(future, replayTopicPolicyListeners(namespaceObject));
+                } else {
+                    future.complete(null);
                 }
-                FutureUtil.completeAfter(future, FutureUtil.waitForAll(notifyFutures));
             }
         });
+    }
+
+    /**
+     * Re-notifies the registered topic-policy listeners for every topic in {@code namespace} with the currently
+     * cached policies (both local and global). Topics apply their own policies on load, so this is only needed for
+     * custom plugins that register {@link TopicPolicyListener}s and rely on the broadcast when a namespace's policy
+     * cache finishes loading (see {@code topicPolicyListenerReplayEnabled}).
+     */
+    @VisibleForTesting
+    CompletableFuture<Void> replayTopicPolicyListeners(NamespaceName namespace) {
+        List<CompletableFuture<Void>> notifyFutures = new ArrayList<>();
+        addNamespacePolicyNotifications(policiesCache, namespace, notifyFutures);
+        addNamespacePolicyNotifications(globalPoliciesCache, namespace, notifyFutures);
+        return FutureUtil.waitForAll(notifyFutures);
+    }
+
+    private void addNamespacePolicyNotifications(Map<TopicName, TopicPolicies> cache, NamespaceName namespace,
+                                                 List<CompletableFuture<Void>> notifyFutures) {
+        for (Map.Entry<TopicName, TopicPolicies> entry : cache.entrySet()) {
+            if (Objects.equals(entry.getKey().getNamespaceObject(), namespace)) {
+                notifyFutures.add(notifyListenersForTopicAsync(entry.getKey(), entry.getValue()));
+            }
+        }
     }
 
     // Full teardown of a namespace's topic-policies state: removes and closes the reader, the message-handler

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/TopicPolicyListenerWrapper.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/TopicPolicyListenerWrapper.java
@@ -85,8 +85,18 @@ public class TopicPolicyListenerWrapper implements TopicPolicyListener {
         // The listener might have received a newer value (or a delete) than the loaded one while the loading
         // was happening; prefer the latest value received during initialization, falling back to the loaded
         // value only when nothing was received for that scope.
-        emitInitialPolicies(latestGlobalPolicies, loadedGlobalPolicies);
+        //
+        // Emit the local policy before the global policy. A local topic policy takes precedence over a global one,
+        // so applying the local value first means that by the time the global value is applied the local override is
+        // already in place and the merged (local-wins) result is what takes effect. Emitting the global value first
+        // would briefly apply it on its own and let a global-only setting act before the local policy overrides it --
+        // e.g. a compaction subscription being created for a global compaction policy even though the local policy
+        // disables compaction. This does not fully solve such ordering hazards, but it removes them whenever a local
+        // policy exists. When no local policy exists nothing is emitted for the local scope (see emitInitialPolicies),
+        // so this ordering does not change behavior for topics that only have a global policy.
         emitInitialPolicies(latestLocalPolicies, loadedLocalPolicies);
+        emitInitialPolicies(latestGlobalPolicies, loadedGlobalPolicies);
+
         latestGlobalPolicies = null;
         latestLocalPolicies = null;
         initialized = true;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
@@ -67,7 +67,6 @@ import org.apache.pulsar.broker.service.SubscriptionOption;
 import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.broker.service.TopicAttributes;
 import org.apache.pulsar.broker.service.TopicPolicyListener;
-import org.apache.pulsar.broker.service.TopicPolicyListenerWrapper;
 import org.apache.pulsar.broker.service.TransportCnx;
 import org.apache.pulsar.broker.service.schema.exceptions.IncompatibleSchemaException;
 import org.apache.pulsar.broker.service.schema.exceptions.NotExistSchemaException;
@@ -131,9 +130,6 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
             TOPIC_ATTRIBUTES_FIELD_UPDATER = AtomicReferenceFieldUpdater.newUpdater(
                     NonPersistentTopic.class, TopicAttributes.class, "topicAttributes");
 
-    // prevents race conditions in topic policy initialization
-    private final TopicPolicyListenerWrapper topicPolicyListener = new TopicPolicyListenerWrapper(this);
-
     private static class TopicStats {
         public double averageMsgSize;
         public double aggMsgRateIn;
@@ -161,7 +157,6 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
         super(topic, brokerService);
         this.log = LOG.with().ctx(super.log).build();
         this.isFenced = false;
-        registerTopicPolicyListener();
     }
 
     private CompletableFuture<Void> updateClusterMigrated() {
@@ -190,13 +185,17 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
                     updateResourceGroupLimiter(policies);
                     return updateClusterMigrated();
                 }, getPoliciesNotifyThread())
-                // Complete the topic-policy listener wrapper so buffered and future topic-level policy
-                // updates are forwarded to this topic. Without this the wrapper stays uninitialized forever
-                // and all topic-level policy updates are silently dropped. Unlike PersistentTopic,
-                // non-persistent topics don't load initial topic policies (matching the previous behavior),
-                // so the loaded values are passed as null.
-                .thenRunAsync(() -> topicPolicyListener.completeInitialization(null, null),
-                        getPoliciesNotifyThread());
+                // Load the topic's initial policies (global and local) and register the policy listener, so a
+                // non-persistent topic applies its own policies on load, the same as a persistent topic does.
+                .thenCompose(ignore -> initTopicPolicy())
+                // Mirror PersistentTopic: a failure to load the initial topic policies (for example a stuck or
+                // timed-out __change_events policy-cache init, issue #25294) must not fail topic loading.
+                // initTopicPolicy completes the listener wrapper before propagating the error, so the topic can
+                // continue and still pick up policies from later live updates.
+                .exceptionally(ex -> {
+                    log.warn().exception(ex).log("Error loading initial topic policies during initialization");
+                    return null;
+                });
     }
 
     @Override
@@ -1348,8 +1347,4 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
                 old -> old != null ? old : new TopicAttributes(TopicName.get(topic)));
     }
 
-    @Override
-    public TopicPolicyListener getTopicPolicyListener() {
-        return topicPolicyListener;
-    }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -59,7 +59,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
-import java.util.function.Function;
 import lombok.Getter;
 import lombok.Value;
 import org.apache.bookkeeper.client.BKException.BKNoSuchLedgerExistsException;
@@ -136,8 +135,6 @@ import org.apache.pulsar.broker.service.Subscription;
 import org.apache.pulsar.broker.service.SubscriptionOption;
 import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.broker.service.TopicPoliciesService;
-import org.apache.pulsar.broker.service.TopicPolicyListener;
-import org.apache.pulsar.broker.service.TopicPolicyListenerWrapper;
 import org.apache.pulsar.broker.service.TransportCnx;
 import org.apache.pulsar.broker.service.schema.BookkeeperSchemaStorage;
 import org.apache.pulsar.broker.service.schema.exceptions.IncompatibleSchemaException;
@@ -299,9 +296,6 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
     // Record the last time max read position is moved forward, unless it's a marker message.
     @Getter
     private volatile long lastMaxReadPositionMovedForwardTimestamp = 0;
-
-    // prevents race conditions in topic policy initialization
-    private final TopicPolicyListenerWrapper topicPolicyListener = new TopicPolicyListenerWrapper(this);
 
     @Getter
     private final ExecutorService orderedExecutor;
@@ -4878,50 +4872,6 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         });
     }
 
-    protected CompletableFuture<Void> initTopicPolicy() {
-        final var topicPoliciesService = brokerService.pulsar().getTopicPoliciesService();
-        final var partitionedTopicName = TopicName.getPartitionedTopicName(topic);
-
-        return topicPoliciesService.registerListenerAsync(partitionedTopicName, topicPolicyListener)
-                .thenCompose(registered -> {
-                    if (!registered) {
-                        return CompletableFuture.completedFuture(null);
-                    }
-                    if (ExtensibleLoadManagerImpl.isInternalTopic(topic)) {
-                        // Internal topics don't load topic-level policies, but the listener wrapper must
-                        // still be initialized so any buffered/future updates are forwarded to the topic
-                        // instead of being silently dropped.
-                        return CompletableFuture.runAsync(
-                                () -> topicPolicyListener.completeInitialization(null, null),
-                                getPoliciesNotifyThread());
-                    }
-                    // future for fetching global topic policies
-                    CompletableFuture<Optional<TopicPolicies>> globalPoliciesFuture =
-                            topicPoliciesService.getTopicPoliciesAsync(partitionedTopicName,
-                                    TopicPoliciesService.GetType.GLOBAL_ONLY);
-                    // future for fetching local topic policies
-                    CompletableFuture<Optional<TopicPolicies>> localPoliciesFuture =
-                            topicPoliciesService.getTopicPoliciesAsync(partitionedTopicName,
-                                    TopicPoliciesService.GetType.LOCAL_ONLY);
-                    CompletableFuture<Void> initialPoliciesFuture =
-                            globalPoliciesFuture.thenCombine(localPoliciesFuture, (global, local) -> {
-                                // finally update the topic policies with the latest value or loaded value
-                                return CompletableFuture.runAsync(() ->
-                                        topicPolicyListener.completeInitialization(global.orElse(null),
-                                                local.orElse(null)),
-                                        getPoliciesNotifyThread());
-                            }).thenCompose(Function.identity());
-                    return initialPoliciesFuture.exceptionallyCompose(ex ->
-                            // The topic load path logs and continues when initial policy loading fails. Make sure the
-                            // already-registered wrapper is not left buffering future live updates forever.
-                            CompletableFuture.runAsync(
-                                    () -> topicPolicyListener.completeInitialization(null, null),
-                                    getPoliciesNotifyThread())
-                                    .thenCompose(__ -> FutureUtil.failedFuture(
-                                            FutureUtil.unwrapCompletionException(ex))));
-                });
-    }
-
     @VisibleForTesting
     public MessageDeduplication getMessageDeduplication() {
         return messageDeduplication;
@@ -5097,8 +5047,4 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         return future;
     }
 
-    @Override
-    public TopicPolicyListener getTopicPolicyListener() {
-        return topicPolicyListener;
-    }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/MetadataStoreTopicPoliciesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/MetadataStoreTopicPoliciesTest.java
@@ -46,6 +46,14 @@ public class MetadataStoreTopicPoliciesTest extends TopicPoliciesTest {
 
     @Test(enabled = false)
     @Override
+    public void testNonPersistentTopicAppliesTopicPolicyOnLoad() throws Exception {
+        // This test is specific to SystemTopicBasedTopicPoliciesService (casts the service and uses
+        // getPoliciesCacheInit). The non-persistent load-path behavior itself is backend-agnostic and is
+        // covered against the default SystemTopicBasedTopicPoliciesService in TopicPoliciesTest.
+    }
+
+    @Test(enabled = false)
+    @Override
     public void testSystemTopicShouldBeCompacted() throws Exception {
         // Relies on __change_events system topic, which does not exist with MetadataStoreTopicPoliciesService.
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicPoliciesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicPoliciesTest.java
@@ -251,6 +251,48 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         assertEquals(topic1.getHierarchyTopicPolicies().getMaxSubscriptionsPerTopic().get(), Integer.valueOf(10));
     }
 
+    @Test
+    public void testNonPersistentTopicAppliesTopicPolicyOnLoad() throws Exception {
+        // Non-persistent topics now load and apply their own topic policies on load (like persistent topics), so a
+        // freshly loaded non-persistent topic must already reflect its topic-level policy without waiting for a
+        // namespace-wide broadcast. Before this change a non-persistent topic never applied its policies on load.
+        TopicName topicName = TopicName.get(
+                TopicDomain.non_persistent.value(),
+                NamespaceName.get(myNamespace),
+                "test-np-" + UUID.randomUUID()
+        );
+        String topic = topicName.toString();
+
+        SystemTopicBasedTopicPoliciesService policyService =
+                (SystemTopicBasedTopicPoliciesService) pulsar.getTopicPoliciesService();
+
+        admin.topics().createNonPartitionedTopic(topic);
+        admin.topicPolicies().setMaxSubscriptionsPerTopicAsync(topic, 10).get();
+
+        //wait until topic loaded with right policy value.
+        Awaitility.await().untilAsserted(() -> {
+            AbstractTopic loaded = (AbstractTopic) pulsar.getBrokerService().getTopic(topic, true).get().get();
+            assertEquals(loaded.getHierarchyTopicPolicies().getMaxSubscriptionsPerTopic().get(), Integer.valueOf(10));
+        });
+
+        //unload the topic
+        pulsar.getNamespaceService().unloadNamespaceBundle(pulsar.getNamespaceService().getBundle(topicName)).get();
+        assertFalse(pulsar.getBrokerService().getTopics().containsKey(topic));
+
+        //re-own the namespace bundle without loading the topic
+        log.info().attr("lookup", admin.lookups().lookupTopic(topic)).log("lookup");
+        assertTrue(pulsar.getBrokerService().isTopicNsOwnedByBrokerAsync(topicName).join());
+        assertFalse(pulsar.getBrokerService().getTopics().containsKey(topic));
+        //make sure namespace policy reader is fully started.
+        Awaitility.await().untilAsserted(() ->
+                assertTrue(policyService.getPoliciesCacheInit(topicName.getNamespaceObject()).isDone()));
+
+        //load the topic: it must already reflect the topic policy, proving it was applied on load, not via a
+        //later broadcast.
+        AbstractTopic loaded = (AbstractTopic) pulsar.getBrokerService().getTopic(topic, true).get().get();
+        assertEquals(loaded.getHierarchyTopicPolicies().getMaxSubscriptionsPerTopic().get(), Integer.valueOf(10));
+    }
+
 
     @Test
     public void testSetSizeBasedBacklogQuota() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesServiceTest.java
@@ -37,6 +37,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -45,6 +46,7 @@ import java.util.concurrent.TimeoutException;
 import lombok.Cleanup;
 import lombok.CustomLog;
 import org.apache.commons.lang3.reflect.FieldUtils;
+import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
 import org.apache.pulsar.broker.systopic.SystemTopicClient;
 import org.apache.pulsar.client.admin.PulsarAdminException;
@@ -835,5 +837,42 @@ public class SystemTopicBasedTopicPoliciesServiceTest extends MockedPulsarServic
                 spyService.getReaderCaches().get(namespace));
         assertSame(reloadInitFuture, spyService.getPoliciesCacheInit(namespace));
         Mockito.verify(reloadReader, Mockito.never()).closeAsync();
+    }
+
+    @Test
+    public void testReplayTopicPolicyListenersNotifiesOnlyNamespaceScopedLocalAndGlobalPolicies() throws Exception {
+        SystemTopicBasedTopicPoliciesService service =
+                (SystemTopicBasedTopicPoliciesService) pulsar.getTopicPoliciesService();
+        final NamespaceName namespaceA = NamespaceName.get(NAMESPACE1);
+        final NamespaceName namespaceB = NamespaceName.get(NAMESPACE2);
+        final TopicName localTopicA = TopicName.get("persistent", namespaceA, "replay-local-a");
+        final TopicName globalTopicA = TopicName.get("persistent", namespaceA, "replay-global-a");
+        final TopicName topicB = TopicName.get("persistent", namespaceB, "replay-b");
+
+        // Seed the caches: namespace A has one topic with a cached local policy and another with a cached global
+        // policy; namespace B has a topic with a cached local policy that must not be replayed for namespace A.
+        service.policiesCache.put(localTopicA, TopicPolicies.builder().isGlobal(false).build());
+        service.globalPoliciesCache.put(globalTopicA, TopicPolicies.builder().isGlobal(true).build());
+        service.policiesCache.put(topicB, TopicPolicies.builder().isGlobal(false).build());
+
+        final Map<TopicName, List<TopicPolicies>> received = new ConcurrentHashMap<>();
+        for (TopicName topicName : List.of(localTopicA, globalTopicA, topicB)) {
+            final List<TopicPolicies> updates = new CopyOnWriteArrayList<>();
+            received.put(topicName, updates);
+            service.registerListenerAsync(topicName, updates::add).get();
+        }
+
+        service.replayTopicPolicyListeners(namespaceA).get(30, TimeUnit.SECONDS);
+
+        // Only namespace A's topics are notified, once each, and both the local and the global cache are replayed.
+        Assertions.assertThat(received.get(localTopicA)).hasSize(1);
+        Assertions.assertThat(received.get(globalTopicA)).hasSize(1);
+        // Namespace B is left untouched. The pre-fix code iterated the whole cache and replayed every namespace.
+        Assertions.assertThat(received.get(topicB)).isEmpty();
+    }
+
+    @Test
+    public void testTopicPolicyListenerReplayDisabledByDefault() {
+        Assertions.assertThat(new ServiceConfiguration().isTopicPolicyListenerReplayEnabled()).isFalse();
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TopicPolicyListenerWrapperTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TopicPolicyListenerWrapperTest.java
@@ -56,15 +56,15 @@ public class TopicPolicyListenerWrapperTest {
         assertThat(real.updates).isEmpty();
 
         // On completion, the buffered local value wins over the loaded local value; the loaded global value
-        // is applied since none was buffered.
+        // is applied since none was buffered. The local policy is emitted before the global one.
         TopicPolicies loadedGlobal = globalPolicies();
         wrapper.completeInitialization(loadedGlobal, localPolicies());
-        assertThat(real.updates).containsExactly(loadedGlobal, bufferedLocal);
+        assertThat(real.updates).containsExactly(bufferedLocal, loadedGlobal);
 
         // After initialization, updates are forwarded immediately.
         TopicPolicies liveUpdate = localPolicies();
         wrapper.onUpdate(liveUpdate);
-        assertThat(real.updates).containsExactly(loadedGlobal, bufferedLocal, liveUpdate);
+        assertThat(real.updates).containsExactly(bufferedLocal, loadedGlobal, liveUpdate);
     }
 
     @Test
@@ -78,7 +78,7 @@ public class TopicPolicyListenerWrapperTest {
         wrapper.onUpdate(bufferedLocal);
 
         wrapper.completeInitialization(globalPolicies(), localPolicies());
-        assertThat(real.updates).containsExactly(bufferedGlobal, bufferedLocal);
+        assertThat(real.updates).containsExactly(bufferedLocal, bufferedGlobal);
     }
 
     @Test
@@ -86,10 +86,12 @@ public class TopicPolicyListenerWrapperTest {
         RecordingListener real = new RecordingListener();
         TopicPolicyListenerWrapper wrapper = new TopicPolicyListenerWrapper(real);
 
+        // The local policy is emitted before the global policy, so a local topic policy takes precedence over a
+        // global one once both have been applied.
         TopicPolicies loadedGlobal = globalPolicies();
         TopicPolicies loadedLocal = localPolicies();
         wrapper.completeInitialization(loadedGlobal, loadedLocal);
-        assertThat(real.updates).containsExactly(loadedGlobal, loadedLocal);
+        assertThat(real.updates).containsExactly(loadedLocal, loadedGlobal);
     }
 
     @Test
@@ -118,7 +120,19 @@ public class TopicPolicyListenerWrapperTest {
         wrapper.onUpdate(newerGlobal);
 
         wrapper.completeInitialization(globalPolicies(), localPolicies());
-        // Global: the newer update wins; Local: the delete (null) wins over the loaded local value.
-        assertThat(real.updates).containsExactly(newerGlobal, null);
+        // Local (emitted first): the delete (null) wins over the loaded local value; Global: the newer update wins.
+        assertThat(real.updates).containsExactly(null, newerGlobal);
+    }
+
+    @Test
+    public void shouldNotEmitLocalScopeWhenNoLocalPolicyExists() {
+        RecordingListener real = new RecordingListener();
+        TopicPolicyListenerWrapper wrapper = new TopicPolicyListenerWrapper(real);
+
+        // With no local policy, only the global policy is emitted; no local onUpdate happens, so the
+        // local-before-global ordering leaves behavior unchanged for topics that only have a global policy.
+        TopicPolicies loadedGlobal = globalPolicies();
+        wrapper.completeInitialization(loadedGlobal, null);
+        assertThat(real.updates).containsExactly(loadedGlobal);
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicTest.java
@@ -876,6 +876,13 @@ public class PersistentTopicTest extends BrokerTestBase {
             public void onUpdate(TopicPolicies policies) {
                 receivedUpdates.add(policies);
             }
+
+            // initTopicPolicy() moved to AbstractTopic (a different package), so widen it to public here to keep
+            // this same-package test able to invoke it directly.
+            @Override
+            public CompletableFuture<Void> initTopicPolicy() {
+                return super.initTopicPolicy();
+            }
         }
 
         final String topic = "persistent://prop/ns-abc/testTopicPolicyInitFailure-" + UUID.randomUUID();


### PR DESCRIPTION
### Motivation

Topic policies are applied to a topic when it loads via `AbstractTopic#initTopicPolicy` (added for
persistent topics in #16144), but non-persistent topics never did this: `NonPersistentTopic.initialize()`
completed its policy-listener wrapper with `null` policies and relied on a namespace-wide broadcast to
receive its policies. That broadcast — the end-of-topic "replay" in
`SystemTopicBasedTopicPoliciesService.initPolicesCache` — also had two bugs: it iterated the entire
`policiesCache` (every namespace, not just the one being loaded), and it ignored `globalPoliciesCache`
entirely. So on any namespace load it re-notified every topic's listener across all namespaces and never
replayed global policies.

### Modifications

- Move `initTopicPolicy()` and the `topicPolicyListener` wrapper up from `PersistentTopic` to
  `AbstractTopic`, and call it from `NonPersistentTopic.initialize()` (guarded by an `exceptionally` like
  `PersistentTopic`, so a policy-cache load failure/timeout doesn't fail topic creation). Non-persistent
  topics now load and apply their own global/local policies on load. Removed the now-unused
  `AbstractTopic.registerTopicPolicyListener()`.
- Because each topic now loads its own policies on load, the namespace-wide replay is redundant. Extract
  `replayTopicPolicyListeners(namespace)` that replays only the loaded namespace's topics and includes both
  local and global cached policies, and gate it behind a new `ServiceConfiguration` flag
  `topicPolicyListenerReplayEnabled` (disabled by default). The replay is only needed for custom plugins
  that register `TopicPolicyListener`s and depend on the broadcast; such deployments can enable the flag for
  backwards compatibility.
- Since policies are now applied immediately on load, `TopicPolicyListenerWrapper.completeInitialization`
  emits the local policy before the global one, so a local topic policy takes precedence at apply time (for
  example, it avoids creating a compaction subscription for a global compaction policy when the local policy
  disables compaction). When no local policy exists, nothing is emitted for the local scope, so global-only
  topics are unaffected.

### Verifying this change

This change added tests and can be verified as follows:

- `TopicPoliciesTest.testNonPersistentTopicAppliesTopicPolicyOnLoad`: sets a topic policy, unloads, then
  loads a non-persistent topic fresh and asserts the policy is applied on load (fails on the previous
  behavior).
- `SystemTopicBasedTopicPoliciesServiceTest.testReplayTopicPolicyListenersNotifiesOnlyNamespaceScopedLocalAndGlobalPolicies`
  and `testTopicPolicyListenerReplayDisabledByDefault`: assert the replay is namespace-scoped, includes both
  local and global policies, and is off by default.
- `TopicPolicyListenerWrapperTest`: updated to assert the local-before-global emit order, plus a case that
  no local scope is emitted when there is no local policy.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [x] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

Adds a new broker configuration `topicPolicyListenerReplayEnabled` (default `false`).
