### PR TITLE
[improve][pip] PIP-478: Asynchronous v5 client authentication + TLS material provider SPIs (design)

### DIFF
--- a/pip/pip-478.md
+++ b/pip/pip-478.md
@@ -1,0 +1,1200 @@
+# PIP-478: Asynchronous v5 client authentication plugin interfaces and TLS material provider plugin interface
+
+# Background knowledge
+
+Apache Pulsar's Java client lets applications plug in custom authentication through `org.apache.pulsar.client.api.Authentication` and `org.apache.pulsar.client.api.AuthenticationDataProvider`. The same pair has been in place since the first 2.x releases and is the basis of every client-side auth mechanism Pulsar ships (token, mTLS, KeyStore TLS, Basic, OAuth2, Athenz, SASL).
+
+**PIP-97** (*Asynchronous Authentication Provider*, accepted for 2.10/2.12) made the **broker-side** authentication framework asynchronous so that providers can do non-blocking I/O during authentication — for example, the OAuth2 / OIDC verifier needs to call out to an identity provider. PIP-97 deliberately scoped itself to the broker side and explicitly deferred the client side: deprecated methods on `Authentication` were left behind for later cleanup. Three years on, that cleanup never happened, and the deprecated methods (`getAuthData()` no-arg, `configure(Map)`) are still part of the v4 surface.
+
+**PIP-337** (*SSL Factory Plugin*, Pulsar 3.x) introduced a pluggable `PulsarSslFactory` so operators can replace Pulsar's default file-based TLS material loading with custom logic (e.g., using a Key Management System (KMS) API). The factory takes a `PulsarSslConfiguration` value object that includes — among the TLS file paths — a direct field `AuthenticationDataProvider authData`. This forced the SSL layer in `pulsar-common` to depend on the v4 `AuthenticationDataProvider` interface, even though the SSL factory ought to be a transport concern independent of who supplies the credentials. The PIP-337 classes live in `org.apache.pulsar.common.util`, alongside dozens of unrelated utility helpers, which is the wrong package for what is now a public SPI.
+
+**PIP-466** (*New Java Client API V5*, accepted for Pulsar 5.0) created two new modules — `pulsar-client-api-v5` and `pulsar-client-v5` — to host a modernised Java client API. PIP-466 is explicitly *additive*: the existing v4 modules (`pulsar-client-api`, `pulsar-client`) remain unchanged. PIP-466 sketched a sync `Authentication` stub in `pulsar-client-api-v5` and a basic adapter in `pulsar-client-v5`; this PIP replaces both with the async, capability-segregated SPI and the bridges described below. PIP-466 punted on auth design and explicitly invited a follow-up proposal to fill it in. This PIP is that follow-up.
+
+## How Pulsar client authentication works
+
+Pulsar clients authenticate to the broker over **two transports**, each with their own protocol semantics. A plugin typically supports both, because applications commonly produce / consume on the binary protocol AND administer the cluster through the HTTP REST API with the same credentials.
+
+### Transport A — Pulsar binary protocol
+
+The Pulsar binary protocol is a length-prefixed Protocol Buffers framing used for produce, consume, lookup, and admin RPCs over TCP (typically port 6650; 6651 for TLS). Authentication is conveyed in dedicated `Command*` messages:
+
+1. Client opens a TCP (or TLS) connection.
+2. Client sends `org.apache.pulsar.common.api.proto.CommandConnect` carrying:
+   - `auth_method_name` — stable string identifying the plugin (e.g., `"token"`, `"basic"`, `"sasl"`).
+   - `auth_data` — opaque byte payload (the credential bytes — a JWT token, a SASL initial frame, etc.).
+3. Broker either:
+   - **Succeeds immediately** (single-pass authentication): broker sends `CommandConnected`. The connection is ready.
+   - **Sends a challenge** (multi-round authentication): broker sends `CommandAuthChallenge` carrying a `challenge` payload. Client replies with `CommandAuthResponse` carrying response bytes. This repeats until the broker accepts (then sends `CommandConnected`) or rejects.
+   - **Fails**: broker sends `ServerError` with `AuthenticationError`. The connection is closed.
+
+The binary protocol also reuses `CommandAuthChallenge` for **broker-pushed credential refresh**: a magic payload `AuthData.REFRESH_AUTH_DATA_BYTES = "PulsarAuthRefresh"` signals "your short-lived credential is about to expire (or has already expired) — produce a fresh one and respond with `CommandAuthResponse`." This is how OAuth2 / Athenz / other short-lived-credential schemes stay valid across long-lived connections.
+
+### Transport B — HTTP/HTTPS REST API (admin client, HTTP topic lookup)
+
+The Pulsar admin client and HTTP-mode topic lookup speak HTTP/1.1 (typically port 8080; 8443 for TLS). Authentication rides in standard HTTP headers:
+
+1. Client constructs an HTTP request.
+2. Client attaches authentication headers. For single-pass credentials, typically `Authorization: <scheme> <credential>` — e.g., JWT auth sends `Authorization: Bearer <jwt>`; Basic auth sends `Authorization: Basic <base64(user:pass)>`; Athenz sends a custom `Athenz-Role-Auth: <role_token>` header.
+3. Server either:
+   - **Succeeds**: handles the request normally (2xx response).
+   - **Sends a challenge** (multi-round): replies with `401 Unauthorized` carrying the challenge in Pulsar-specific SASL headers — `SASL-Token` (the base64 token bytes), `State`, and `SASL-Server-ID` (to correlate the multi-round session) — **not** the standard `WWW-Authenticate` header. The client resubmits the request with updated `SASL-Token` / `State` / `SASL-Server-ID` headers. This repeats until the server accepts, at which point it responds `200 OK` carrying the final `SaslAuthRoleToken`. SASL (Kerberos) over HTTP follows this pattern, driven server-side by `AuthenticationProviderSasl` and client-side by `AuthenticationSasl`.
+   - **Fails**: the request is rejected (`401`/`403`) and not retried.
+
+Today this multi-round HTTP loop is **not** driven by a generic framework component — the SASL plugin implements it itself. `AuthenticationSasl.authenticationStage(...)` recursively resubmits the request on each `401` until the server returns `200`, and both the admin client and the HTTP-lookup client simply call the plugin's `authenticationStage(...)` / `newRequestHeader(...)` hooks. Two quirks follow from this: the SASL stage always re-issues the exchange as a `GET` to the original URI (even when the original request was a `POST`), and the admin client and HTTP-lookup client reach the same plugin through two different HTTP client APIs — JAX-RS (Jersey) for the admin client, raw AsyncHttpClient for HTTP lookup — even though both run over the same AsyncHttpClient transport (Jersey is wired through Pulsar's own `AsyncHttpConnector`). The v5 design relocates this loop into a framework-side **driver** — one shared loop implementation behind a thin adapter per client API — leaving the plugin to compute only each round's response; see [the capability-segregated SPI](#capability-segregated-authentication-spi).
+
+### Authentication styles
+
+Independent of transport, every Pulsar authentication method follows one of two styles:
+
+- **Single-pass credential exchange.** The client presents a credential (a token, a username/password pair, a signed assertion) and the broker accepts or rejects in a single round trip. Long-lived credentials need no refresh at all — a static JWT (`Token`) or a `Basic` username/password is presented as-is on every connection. Short-lived credentials *do* expire, and refreshing them is an **internal concern of the authentication plugin**: the plugin produces a fresh credential when next asked (and may proactively renew in the background, or react to the broker's refresh sentinel — see Transport A). The framework does not manage refresh; it simply re-invokes the plugin's async credential method. Examples: `Token`/JWT and `Basic` (long-lived, no refresh); OAuth2 (short-lived access token the plugin renews against the IdP) and Athenz (short-lived role tokens the plugin renews against ZTS).
+
+- **Multi-round challenge/response.** The client and broker exchange multiple frames before the broker grants access. The exchanged bytes are opaque to the framework; only the implementation knows how to interpret a challenge and compose a response. Example: SASL (Kerberos).
+
+### A note on mTLS
+
+Mutual TLS (mTLS) is sometimes called an "authentication method", but the TLS material and handshake are a **transport-layer concern** rather than a credential-carrying authentication plugin (in v5 the mTLS case is handled by the built-in `TlsAuthentication` plugin — see below). The client's certificate and private key are configured at the `PulsarClient` builder level and attached to both transports' `SSLContext`s. The broker authenticates the client by inspecting the certificate chain presented during the TLS handshake (its server-side `AuthenticationProviderTls` reads `SSLContext.getSession()`). No `auth_data` payload is exchanged at the Pulsar protocol layer.
+
+The v4 client conflated this by exposing `AuthenticationTls` as an `Authentication` plugin whose main purpose was to point the SSL layer at certificate files. **In v5, the TLS key and certificate for mTLS are configured directly at the `PulsarClient` builder**, not in an authentication plugin. mTLS authentication is then represented by the built-in `TlsAuthentication` plugin, which carries no TLS material — it only makes the binary protocol set `auth_method_name=tls` on `CommandConnect` (the broker reads the client certificate from the TLS handshake). The compatibility layer maps legacy v4 `AuthenticationTls` configuration onto this builder-level TLS material **plus** the built-in `TlsAuthentication` plugin, and the same implementation backs both the v4 and v5 client APIs in Pulsar 5.0.
+
+### Concrete examples
+
+| Method | Style | Binary `auth_data` | HTTP encoding | Notes                                                                               |
+|---|---|---|---|-------------------------------------------------------------------------------------|
+| Token / JWT | single-pass | `utf8(jwt)` | `Authorization: Bearer <jwt>` | Most common deployment                                                              |
+| Basic | single-pass | `utf8(user:pass)` | `Authorization: Basic <base64(user:pass)>` |                                                                                     |
+| OAuth2 | single-pass | `utf8(access_token)` | `Authorization: Bearer <access_token>` | Token-exchange step uses HTTP to the IdP                                            |
+| Athenz | single-pass | `utf8(role_token)` | custom `Athenz-Role-Auth: <role_token>` header | ZTS exchange uses Athenz SDK                                                        |
+| SASL | multi-round | `sasl_initial_bytes`, then `CommandAuthResponse` rounds | custom `SASL-Token` / `State` / `SASL-Server-ID` headers, multi-round via repeated `401` (no `WWW-Authenticate`) |                                                                 |
+| mTLS | transport-layer | empty (`auth_method_name=tls`) | n/a (cert presented at TLS handshake) | TLS material configured at the builder; the built-in `TlsAuthentication` plugin sets `auth_method_name=tls` on the binary protocol |
+
+### Key concepts used in this proposal
+
+- *Capability segregation* — an interface describes one cross-cutting concern; an implementation that needs to expose several concerns implements several interfaces. The opposite is the *kitchen-sink* shape, where a single interface declares every concern and implementations leave most methods returning `null`.
+
+- *Async authentication* — completing authentication-related work via `CompletableFuture` so the calling thread (typically a Netty I/O thread on the connection path) is not blocked while the auth provider performs other I/O (e.g., calling a remote token endpoint).
+
+- *Single-pass vs challenge-response* — the two authentication styles described above. Reflected in the v5 interfaces.
+
+- *Configuration vs initialization* — in v5 these are separate concerns. **Configuration** is supplying the plugin its `authParams` (the path to the token file, the OAuth2 issuer URL, etc.) — static, plugin-specific data, independent of when/where the plugin runs. **Initialization** is when the plugin is given runtime services (a `PulsarHttpClient` factory, a scheduler, an OpenTelemetry handle) and may do I/O to prepare itself. The v4 interface conflated these with `configure(Map)` + `start()`; v5 splits them cleanly so the same plugin instance can be constructed and configured at one time and initialized later when a `PulsarClient` is built.
+
+# Motivation
+
+The v4 client authentication surface has five concrete, observable problems that are not addressed by any in-flight work.
+
+### 1. The Netty event loop blocks under token refresh.
+
+`ClientCnx.handleAuthChallenge()` is invoked when the broker pushes `CommandAuthChallenge`. The broker also uses this command, with payload `AuthData.REFRESH_AUTH_DATA_BYTES`, to signal "your short-lived credential is about to expire or has expired — fetch a new one and reply." `ClientCnx` services this push synchronously: it calls `authentication.getAuthData(remoteHostName)` and then `authenticationDataProvider.authenticate(challenge)` on whatever thread delivered the channel-read event — namely, the Netty I/O loop. For `AuthenticationToken` and `AuthenticationTls` this is fast, but for `AuthenticationOAuth2` it can stall the loop while a token endpoint is hit, and for `AuthenticationAthenz` while ZTS is queried. A single slow refresh therefore halts every I/O multiplexed onto that loop — producers, consumers, lookups — across every connection.
+
+### 2. `AuthenticationDataProvider` is a kitchen sink.
+
+A single interface declares 13 methods covering three unrelated concerns: TLS material (cert chain, private key, file paths, keystore params, truststore stream — 7 methods), HTTP request authentication (auth-type, headers — 3 methods), and binary-protocol authentication (command data, plus SASL `authenticate(AuthData)` for challenge-response — 3 methods). Every built-in implementation returns `null` or `false` from the methods it does not care about. Implementers cannot tell at compile time which transports an `Authentication` actually supports — the answer is "whichever combination of getters happen to return non-null at runtime." There is no compile-time guarantee that an impl claiming `hasDataForTls()` will return non-null from `getTlsCertificates()`, and no clean way to write a composite implementation (say, mTLS *and* OAuth) without re-hashing this implicit contract.
+
+### 3. Authentication plugins such as the plugin for OAuth2 cannot share resources with the rest of the runtime.
+
+`AuthenticationOAuth2` needs HTTP to talk to its identity provider. Today the OAuth2 implementation creates *three separate* `DefaultAsyncHttpClient` instances (in `FlowBase`, `TokenClient`, and `DefaultMetadataResolver`) because the API surface gives it nowhere to ask "the client" for an HTTP client. `FlowBase` even constructs a private `PulsarSslFactory` instance to configure those clients. Apache Pulsar issue [#24795](https://github.com/apache/pulsar/issues/24795) is exactly this complaint — operators want to control the HTTP client (proxies, retry policy, observability) without forking — and PR [#24944](https://github.com/apache/pulsar/pull/24944) is a workaround patch for one specific case. The root cause is that the `Authentication` SPI gives implementations no hook to acquire shared client services. Beyond a plain HTTP client, plugins also need to share the Netty DNS-resolution configuration and DNS cache.
+
+### 4. The PIP-337 SSL Factory interface is a kitchen sink that exposes implementation details and prevents a clean separation of concerns.
+
+`PulsarSslConfiguration` — the value object that `PulsarSslFactory` implementations consume — carries a field `AuthenticationDataProvider authData`, which forces the SSL layer in `pulsar-common` to depend on the entire v4 auth SPI even though it only needs TLS material. This coupling exists because v4 `AuthenticationTls` could override the client's TLS configuration, and that override was wired through `PulsarSslConfiguration` instead of a clean integration point.
+
+The interface itself is also a kitchen sink: `initialize(PulsarSslConfiguration)`, `needsUpdate()`, `update()`, `createInternalSslContext()`, `getInternalSslContext()`, and `getInternalNettySslContext()` expose implementation details — the order in which a default file-based implementation rebuilds its state on rotation — as public methods. A custom plugin should not have to deal with any of this; it should answer with a fully configured TLS object for the use case it supports (for example "TLS for the Pulsar binary protocol client", "TLS for the admin HTTP client", or "TLS for OAuth2 token-endpoint calls") and deliver a rebuilt object through a reload callback when its material changes — keeping rebuild orchestration internal to the plugin instead of spread across every consumer. The SPI is also synchronous, so loading TLS material can block the Netty I/O loop — the same hazard as Motivation #1. Finally, PIP-337's API already traffics in Netty types (`getInternalNettySslContext()`), yet the consequences for custom factories used with the **shaded** Pulsar client — where Netty is relocated — are undocumented and unresolved; this PIP documents the packaging requirement explicitly.
+
+The decoupling matters operationally, not just structurally. Many organizations operate under security policies that forbid storing TLS private keys in files at all — keys must stay inside an HSM or KMS, or be delivered in-memory by a workload-identity system (e.g. SPIFFE/SPIRE). A TLS SPI that asks the plugin only for a working TLS object — and confines rotation to a reload callback — is what makes such integrations practical. PIP-337 nominally allows a custom factory, but its surface forces the implementer to re-own context construction and rotation and couples them to the v4 auth SPI, so in practice those deployments fork the SSL layer instead. Replacing PIP-337 with an SPI decoupled from the implementation closes this gap.
+
+### 5. Challenge-response authentication is a maintenance burden because its handling is scattered across the stack.
+
+Multi-round (challenge/response) authentication has no single integration point, so its logic is duplicated and entangled with unrelated concerns. On the binary protocol, `ClientCnx.handleAuthChallenge()` interleaves the initial connect, broker-pushed credential refresh, and SASL challenge rounds on one synchronous path. On HTTP there is no generic multi-round driver at all: the SASL plugin implements the `401`→resubmit→`200` loop itself (`AuthenticationSasl.authenticationStage(...)`), and the admin (JAX-RS) client and the HTTP-lookup client each drive it separately, so the loop is effectively re-implemented per HTTP client API — even though both APIs run over the same AsyncHttpClient transport. The SASL plugin even takes over request construction, re-issuing the exchange as a `GET` to the original URI regardless of the original method. The result is costly to maintain and hard to extend: supporting another challenge-response scheme (such as HTTP digest) would mean changing the plugin, both HTTP client integrations, and the binary connect path instead of implementing one well-defined capability.
+
+# Goals
+
+## In Scope
+
+This PIP introduces new API and implementation across the existing `pulsar-client-api-v5` and `pulsar-client-v5` modules created by PIP-466, plus a new small, dependency-light `pulsar-common-api` module that hosts the TLS and HTTP SPIs so the sibling broker-side PIP can depend on them without importing a client artifact (see [Resolved design decisions](#resolved-design-decisions)):
+
+1. **Asynchronous, capability-segregated v5 authentication SPI** in `org.apache.pulsar.client.api.v5.auth`
+2. **Two configuration paths** matching the existing v4 idioms:
+   - **Programmatic**: user constructs an `Authentication` instance (typically via a constructor or builder) and passes it to `PulsarClient.builder().authentication(myAuth)`. `configure(...)` is NOT called by the framework in this path (the instance is assumed already configured by the caller).
+   - **String-based**: user supplies `authPluginClassName` + `authParams` (JSON map or existing `key:val,key:val` String format). The framework reflectively instantiates the class via its no-arg constructor, calls `configure(parsedAuthParams)` once, then `initializeAsync(ctx)` once. Matches the existing `AuthenticationUtil.create(...)` semantics.
+
+3. **`PulsarHttpClient` SPI** in `org.apache.pulsar.client.api.v5.http`, with **framework-managed lifecycle**. The framework owns Netty event loops, timers, DNS caches, and TLS material refresh integration; plugins describe what kind of HTTP client they need via a `PulsarHttpClientConfig` (timeouts, proxy, a `TlsPurpose` selecting dedicated TLS material) and obtain an instance via `AuthenticationInitContext.httpClientFactory().newHttpClient(config)`. The framework MAY issue multiple `PulsarHttpClient` instances per `PulsarClient` for different uses — OAuth2's mTLS exchange to the IdP and a third-party plugin's own HTTP endpoint may each target a different trust domain and so need a different TLS configuration, but they share the underlying event loop / timer / DNS resources. The implementation is framework-owned and backed by AsyncHttpClient; the HTTP *backend* is deliberately not pluggable (see the Detailed Design).
+
+4. **Redesigned PIP-337 SSL provider** — purpose-driven, no kitchen-sink config. The existing `PulsarSslFactory` / `PulsarSslConfiguration` surface is completely removed and replaced in Pulsar 5.0 and in v5 client's TLS configuration and integration points. This change also impacts the broker side.
+
+5. **v5 client builder TLS configuration**, including mTLS, at the client configuration level (mTLS may also be used for TLS auth). This subsumes the experimental PIP-466-era `org.apache.pulsar.client.api.v5.config.TlsPolicy` sketch in `pulsar-client-api-v5` (see the [Detailed Design](#detailed-design)).
+
+6. **Compatibility bridge** in `pulsar-client-v5`, in both directions:
+   - `LegacyV4AuthenticationAdapter` — wraps a v4 `Authentication` instance as a v5 `Authentication` declaring the right capability for its style. v4 calls are always off-loaded to a separate, dedicated executor (`ctx.blockingExecutor()`); the Netty event loop never runs the v4 plugin's I/O.
+   - `V5ToV4AuthenticationAdapter` — exposes a v5 `Authentication` through the v4 `Authentication` interface that `ClientCnx` already drives, so the v5 SPI can back the v4 client API and built-in v4 shims.
+
+7. **Pulsar 5.0 client's internal implementation migration to use the v5 Authentication SPI and TLS SPI**. This applies also to the v4 client API usage in Pulsar 5.0 client since it provides both v4 and v5 client APIs.
+
+## Out of Scope
+
+- **Broker-side authentication.** Pulsar's broker-side `AuthenticationProvider` / `AuthenticationState` interfaces have their own set of design problems (PIP-97 only covered the async basics). They are out of scope; a sibling PIP will address them with the same design principles.
+
+- **Removal of the v4 `Authentication` interface or its deprecated methods.** The v4 surface — including the deprecated `getAuthData()` no-arg and `configure(Map)` methods — is retained indefinitely for source compatibility. Their bodies are re-implemented on top of the v5 SPI as part of in-scope item #7, but the method signatures stay.
+
+- **Non-Java client SDKs.** Each non-Java SDK (Python, Go, C++, Node.js) follows its own auth model and will be addressed by per-SDK PIPs.
+
+- **Off-loading the proxy's own broker-client credential I/O (known gap).** Motivation #1's event-loop-safety guarantee is delivered for `PulsarClient` / `PulsarAdmin` (and the broker's outbound clients, which are genuine clients that bind the framework's `ClientAuthenticationServices`). The **proxy's** connection to the broker is not a `PulsarClientImpl`: its lookup path uses a bare `ConnectionPool` and its data path a hand-rolled Netty `DirectProxyHandler`, and neither binds the client auth services (bounded blocking executor, framework HTTP client factory). A proxy configured with a blocking-credential broker-client plugin (e.g. OAuth2) therefore still runs that credential fetch inline on the proxy's Netty loop — **the same behavior as v4, not a regression introduced by this PIP**. Closing it requires reordering proxy startup (the broker-client `Authentication` is created and started before the proxy's event loop, DNS resolver, and TLS factory exist) plus an async rework of `DirectProxyHandler`'s inline `getAuthData()`; it is deferred to a follow-up rather than bundled into this change.
+
+# High Level Design
+
+This proposal centers on a small core `Authentication` interface plus four narrow, opt-in **capability interfaces**, a framework-managed `PulsarHttpClient` SPI, and a purpose-driven `PulsarTlsFactory` SPI that replaces PIP-337. This section describes the shape and the reasoning; the full type listings live in the [Detailed Design](#detailed-design).
+
+## Design principles
+
+Four principles run through everything below; they are also the yardsticks the [Resolved design decisions](#resolved-design-decisions) at the end of this document are argued against.
+
+1. **Simple things stay simple.** The overwhelmingly common deployment — TLS material in PEM or keystore files, a single trust domain, one of the built-in auth methods — keeps file-path-level ergonomics and never sees a provider, purpose, or capability type. The new SPIs are opt-in layers *underneath* that configuration, not a new prerequisite for it. (See the [three usage tiers](#the-pulsartlsfactory-spi-pip-337-replacement) of the TLS surface.)
+2. **Plugins exist for what files cannot cover.** Many organizations have security policies that TLS private keys must never be stored in files — keys live in an HSM/KMS or are delivered in-memory by a workload-identity system. Because the PIP-337 replacement asks a factory only for ready-built TLS objects — material sourcing and key handling stay entirely inside the factory, and key material never crosses a Pulsar API — those deployments become first-class instead of requiring a fork of the SSL layer.
+3. **One concern per interface, asynchronous by construction.** A plugin declares exactly the transports and styles it supports as capability interfaces (the 2×2 matrix below); every credential-producing method returns a `CompletableFuture`, so the Netty event loop is never blocked.
+4. **The framework owns shared runtime resources.** HTTP clients, event loops, DNS caches, and schedulers are framework-managed and handed to plugins through contexts; a plugin never builds parallel infrastructure.
+
+## Capability-segregated authentication SPI
+
+Every plugin implements the core `Authentication` interface, which carries only lifecycle: a `configure(Map<String,String>)` hook (called for the string-based path only), an `initializeAsync(AuthenticationInitContext)` hook that may do I/O, a `capability(Class<T>)` lookup for delegating wrappers, and `close()`.
+
+The actual credential work lives on **four capability interfaces** — one per cell of a 2×2 matrix whose axes are the two transports and the two authentication styles described in the [Background](#how-pulsar-client-authentication-works). This matrix *is* the conceptual model: an authentication plugin is the core lifecycle interface plus whichever cells it supports, and nothing else.
+
+|                        | Pulsar binary protocol           | HTTP / REST                                    |
+|------------------------|----------------------------------|------------------------------------------------|
+| **Single-pass**        | `BinaryAuthDataProvider` | `HttpAuthHeadersProvider`                      |
+| **Challenge/response** | `BinaryAuthChallengeHandler`       | `HttpAuthChallengeHandler` (SASL style) |
+
+- `BinaryAuthDataProvider` — single-pass credential for the binary protocol.
+- `HttpAuthHeadersProvider` — single-pass credential for HTTP.
+- `BinaryAuthChallengeHandler` — multi-round challenge/response for the binary protocol.
+- `HttpAuthChallengeHandler` — multi-round challenge/response for HTTP in the **SASL style** (repeated `401` carrying Pulsar's custom SASL headers, as used by the existing SASL-over-HTTP mechanism).
+
+Placing the built-ins on the matrix: Token, Basic, OAuth2, and Athenz occupy the **single-pass row** (both cells); SASL occupies **all four cells** (an initial frame plus challenge rounds, on each transport); the built-in `TlsAuthentication` plugin occupies only the binary single-pass cell, with empty credential bytes (see below). The four names deliberately read directly off the matrix — the transport prefix names the row's transport, and the suffix names the style (`…Provider` = single-pass, `…Handler` = challenge/response); see [Resolved design decisions](#resolved-design-decisions).
+
+These four are the integration points today's protocols need; the model is open-ended. Additional capability interfaces can be introduced later if a future mechanism needs to plug into the binary or HTTP authentication flow in a way these four don't capture, without disturbing existing plugins. HTTP multi-round auth is the first place this is expected: the SASL style above is custom to Pulsar, whereas standard `WWW-Authenticate`-based schemes (e.g. HTTP digest) follow a different exchange. The design therefore anticipates a **second, standard-style** HTTP challenge-response interface alongside `HttpAuthChallengeHandler`, with the framework's HTTP auth **driver** (below) selecting the handling by which interface a plugin implements. Only the SASL-style interface ships in this PIP — a deliberate decision; see [Resolved design decisions](#resolved-design-decisions).
+
+**HTTP auth drivers.** Unlike the binary protocol — where `ClientCnx` is the single place that runs the `CommandAuthChallenge`/`CommandAuthResponse` loop — HTTP is reached through two client APIs: JAX-RS (Jersey) for the admin client and raw AsyncHttpClient for HTTP topic lookup, both running over the same AsyncHttpClient transport (see [Transport B](#transport-b--httphttps-rest-api-admin-client-http-topic-lookup)). In v4 the multi-round loop lives inside the SASL plugin itself, which also re-issues the exchange as a `GET` to the original URI. v5 instead puts the loop in a framework-side **driver** — a single `401`→resubmit→`200` state machine behind a thin request/response adapter per client API — that calls the plugin only to compute each round's response. For backward compatibility the SASL driver preserves the existing behaviour (custom headers, the `GET`-to-original-URI takeover); a future standard-style driver will handle `WWW-Authenticate`/digest. The driver is internal to the framework and is not part of the plugin SPI.
+
+For convenience, one **composite interface** bundles the overwhelmingly common combination so an implementation can declare a single interface:
+
+- `SinglePassAuthentication extends Authentication, BinaryAuthDataProvider, HttpAuthHeadersProvider` — a single-pass credential served over both transports.
+
+The composite is purely a convenience; an implementation is free to implement the individual capability interfaces directly and combine only the ones it needs. (A four-capability `ChallengeResponseAuthentication` composite was considered and left out — its only plausible implementor is the built-in SASL plugin, which simply lists its interfaces.) For the typical plugin author — a custom single-pass credential served over both transports — the entire task is: implement `SinglePassAuthentication` and return the credential from its two async methods. The full matrix only becomes visible when a mechanism genuinely spans it (today, only SASL does).
+
+**Built-in `TlsAuthentication` plugin (mTLS).** mTLS is not a capability that other plugins mix in — it is a small, self-contained `Authentication` implementation. The built-in `TlsAuthentication` class implements `Authentication` and `BinaryAuthDataProvider`, reporting `authMethodName() == "tls"` (overridable via its constructor) with empty `auth_data` so the binary protocol authenticates via the TLS handshake. It carries **no** TLS material — certificates and keys are configured at the `PulsarClient` builder (see [A note on mTLS](#a-note-on-mtls)) — and exists only so a client that wants mTLS auth can select it and have the binary protocol send `auth_method_name=tls` on `CommandConnect`.
+
+These interfaces replace v4's kitchen-sink `AuthenticationDataProvider`: capabilities make a plugin's supported transports and styles visible at compile time, and composing concerns (e.g., binary + HTTP single-pass) is a matter of implementing two interfaces rather than re-hashing an implicit contract. The core `Authentication` acts as an explicit **capability factory**: the framework discovers what a plugin supports *only* through `capability(Class<T>)` — never via `instanceof` on the plugin instance — so an implementation is free to serve a capability from a separate internal class (or forward a wrapped delegate's) instead of implementing it on the plugin type itself. The default implementation returns `this` when the plugin implements the requested interface directly, so the common case needs no override; there is no registry. Making the lookup the single mechanism removes a standing trap: if discovery were split between `instanceof` and the lookup, a wrapper forwarding its delegate's capabilities would silently break every `instanceof` call site. All capability methods are asynchronous (`CompletableFuture`), so credential acquisition never blocks the Netty event loop.
+
+Cross-round runtime state (a SASL conversation, a multi-stage HTTP handshake) lives on the per-call context's **state slot**, not on method parameters (see [per-call contexts](#authenticationcallcontext--httpauthcallcontext)).
+
+## Two configuration paths
+
+Both v4 idioms are preserved (see In-Scope item #2): the **programmatic** path, where the user constructs and configures the `Authentication` instance and `configure(...)` is not called by the framework; and the **string-based** path, where `authPluginClassName` + `authParams` drive reflective construction followed by one `configure(...)` and one `initializeAsync(...)`.
+
+## Initialization and per-call contexts
+
+`AuthenticationInitContext` is passed once to `initializeAsync(...)` and exposes the framework's shared runtime services: a `PulsarHttpClientFactory`, a `ScheduledExecutorService` for scheduled work, a separate `Executor` for potentially-blocking work, a `Clock`, an `OpenTelemetry` handle, the client instance id, and a convenience copy of the configured `params`. The framework owns and closes these shared services; the plugin may retain references for its lifetime and releases its own resources in `close()`.
+
+`AuthenticationCallContext` (binary) and `HttpAuthCallContext` (HTTP) are cheap per-call objects that carry transport-specific routing (broker host/port, or request URI) and expose a per-exchange **state slot** (`getStateObject`/`setStateObject`, keyed by class) so an implementation can retain conversation state across challenge-response rounds. The slot's lifetime equals one authentication exchange; concurrent authentications to different brokers each get their own context, so in-flight handshakes don't collide. (This general state slot subsumes what a transport-specific `previousResponseHeaders` parameter would otherwise carry.)
+
+## The `PulsarHttpClient` SPI
+
+Auth plugins that need HTTP (OAuth2's token endpoint and well-known metadata; a JWKS endpoint) obtain a client from the framework rather than constructing their own — fixing the v4 problem where `AuthenticationOAuth2` spins up three private `DefaultAsyncHttpClient` instances (Motivation #3). Athenz is the exception: its ZTS role-token exchange runs on the Athenz SDK's own HTTP transport, which the SDK owns and this PIP does not reroute through the framework (consistent with the Athenz row in [Concrete examples](#concrete-examples)). The **framework manages HTTP client lifecycle** (Netty event loop, timer, DNS cache, TLS material refresh) for the plugins it does serve; such a plugin describes what it needs via a `PulsarHttpClientConfig` and receives an instance from `AuthenticationInitContext.httpClientFactory()`.
+
+The framework may hand out **multiple** `PulsarHttpClient` instances per `PulsarClient`: OAuth2's mTLS exchange to the IdP and a third-party plugin's own HTTP endpoint can each target a different trust domain and so need a different TLS configuration, while sharing the underlying event-loop / timer / DNS resources. This need is not hypothetical. When the application terminates mTLS itself — rather than delegating the secure channel to a service mesh (e.g. Istio) — each outbound trust domain (the Pulsar cluster, the identity provider, a JWKS endpoint) presents its own client certificate and trust anchors. Workload-identity frameworks make this concrete: under [SPIFFE](https://spiffe.io/)/SPIRE a workload receives a distinct X.509-SVID and trust bundle per trust domain it talks to, so a single process legitimately holds several non-interchangeable key materials at once. Binding TLS configuration to a *purpose* rather than to one process-wide default is what lets the framework route each `PulsarHttpClient` to the right material.
+
+The `PulsarHttpClient` model — a small request/response SPI with framework-owned resources and purpose-driven TLS — is deliberately not auth-specific. The same model can later serve other HTTP needs inside Pulsar (for example JWKS fetching in the broker-side OIDC provider, which today embeds its own HTTP client) under the sibling broker-side PIP; to enable that reuse the SPI lives in the small neutral `pulsar-common-api` module (see [Resolved design decisions](#resolved-design-decisions)).
+
+## The `PulsarTlsFactory` SPI (PIP-337 replacement)
+
+PIP-337's `PulsarSslFactory` / `PulsarSslConfiguration` are removed entirely (Motivation #4) and replaced by a deliberately small, purpose-driven **instance factory**. A **`TlsPurpose`** is a simple named key that identifies *why* TLS is requested and in what role: a role (client or server), a well-known name (`CLIENT_DEFAULT`, `CLIENT_OAUTH2`, `BROKER_CLIENT`; `BROKER`, `PROXY`, `WEB`), and an optional **single-level fallback** naming the purpose to consult when this one has no material configured (empty fallback means the system default on the client side, a configuration error on the server side). Client-side consumers may additionally pass the **destination endpoint** (host and port) as a per-request hint, so a factory that serves per-destination material (multi-cluster deployments, per-target workload identities) can specialize; factories are free to ignore it. The factory answers `createInstance(purpose, instanceClass)` with a **fully configured TLS object** of the requested class — `io.netty.handler.ssl.SslContext`, Jetty's `SslContextFactory.Server`, or `javax.net.ssl.SSLContext` (the fallback baseline) — or `Optional.empty()` when it does not support that combination, in which case the framework synthesizes the richer object from the JDK `SSLContext` the factory does provide. A factory therefore need only implement whichever classes it can build directly; as long as it supplies at least the `SSLContext` for a purpose, the framework can derive the Netty and Jetty objects from it. A second overload additionally subscribes a reload callback (`Consumer<T> onLoadOrReload`) that receives the instance on first load and a rebuilt instance whenever the underlying material changes. *How* the factory sources key material and builds the objects — files, a KMS API, an HSM-backed `KeyManagerFactory` — is entirely factory-internal; nothing material-shaped appears in the SPI, and key material never crosses a Pulsar API. The SPI deliberately omits PIP-337's consumer-driven rebuild choreography (`needsUpdate()` / `update()` / `createInternalSslContext()` call-ordering) and its kitchen-sink `PulsarSslConfiguration`.
+
+Rotation is push-based: the reload callback delivers the rebuilt instance directly. Server-side consumers subscribe — the broker/proxy binary listeners swap the `SslContext` they use for new connections, and the Jetty web service either receives a self-reloading `SslContextFactory.Server` from the factory or has the framework drive Jetty's documented `SslContextFactory.reload(...)` API from an `SSLContext` subscription (see the [Detailed Design](#detailed-design)). Most client-side consumers don't subscribe: they request the instance per new connection, picking up rotated material naturally. (Synchronous client integration points — an HTTP library's engine factory, or the proxy's broker-facing data path — instead hold the subscribing overload's current instance; see the [Detailed Design](#detailed-design).) The default `FileBasedTlsFactory` loads PEM and keystore files and reloads on rotation; it is **immutable after construction** — the v5 builder composes the final purpose→policy map (including material contributed by the v4 `AuthenticationTls` bridge) before creating it. A custom factory can integrate a Key Management System (KMS) and may differ between client and broker sides.
+
+Because the well-known classes include Netty (and Jetty) types, a custom factory must be packaged to match the relocation of the artifact it plugs into. The concern is confined to the **shaded v4 client distributions** — `pulsar-client-shaded`, `pulsar-client-admin-shaded`, and the `pulsar-client-all` fat jar — which relocate Netty (`io.netty` → `org.apache.pulsar.shade.io.netty`). A factory used with those must be published as a **relocated** plugin artifact whose Netty/Jetty references are rewritten to the shaded names (without bundling the relocated classes); the plain, unrelocated artifact serves `pulsar-client-original` / `pulsar-client-admin-original` and all server-side components, which are not shaded. The **v5 client** (`pulsar-client-v5` / `pulsar-client-api-v5`, PIP-466) is published **unshaded** and therefore has no such problem — a single plain plugin artifact works. Applications on the v5 client that nonetheless need shading to resolve a dependency conflict perform that relocation themselves, in their own build, and relocate the plugin along with everything else as part of it. PIP-337 has the same constraint on the shaded v4 client today, undocumented; this PIP makes it explicit (see the shading note in the [Detailed Design](#detailed-design)).
+
+**Three usage tiers.** The TLS surface is layered so that complexity is proportional to need:
+
+1. **File paths (almost everyone).** TLS material in PEM or keystore files, configured essentially as today — broker/proxy via the existing `ServiceConfiguration` properties, the v5 client via a simple builder-level TLS configuration object. The default `FileBasedTlsFactory` is wired automatically; the user never names a factory, a purpose, or an instance class.
+2. **Per-purpose policies (multi-trust-domain deployments).** Deployments where, say, the OAuth2 IdP needs different trust anchors or a different client certificate than the brokers configure an additional `TlsPolicy` for that specific purpose (`CLIENT_OAUTH2`). Still no custom code.
+3. **Custom factory (keys never touch a file).** Organizations whose policy forbids on-disk private keys implement `PulsarTlsFactory` against their KMS / HSM / workload-identity system. The mandatory part is small: build a JDK `SSLContext` — typically from the provider's `KeyManagerFactory`/`TrustManagerFactory`, so keys stay non-extractable behind the JCA provider (PKCS#11, KMS JCA provider; signing happens inside the HSM/KMS) — and deliver rebuilt instances through the reload callbacks on rotation. Engine-level policy (protocol/cipher restrictions, client-auth mode, endpoint identification) can optionally accompany the context as a `javax.net.ssl.SSLParameters` — still zero non-JDK dependencies (see the well-known-class table). Richer per-stack objects (a native OpenSSL-based Netty context, even a BoringSSL "keyless" one; a keystore-backed Jetty factory with SNI support) are optional extras the factory may choose to supply. Key material never crosses a Pulsar API at all.
+
+## Compatibility bridge for v4 plugins
+
+`LegacyV4AuthenticationAdapter` wraps an arbitrary v4 `Authentication` as a v5 `Authentication`, declaring the capability interfaces that match the v4 plugin's style. All v4 calls are off-loaded to a separate, dedicated executor (`ctx.blockingExecutor()`, kept distinct from the scheduler) so the Netty event loop never runs v4 plugin I/O. v4 plugins that supply TLS material (`hasDataForTls() == true`, e.g., `AuthenticationTls`) have that material registered with the client's `PulsarTlsFactory` and are represented by the built-in `TlsAuthentication` plugin.
+
+## `ClientCnx` async-driver carve-out
+
+The only change to the otherwise-untouched v4 client is a marker interface `AsyncAuthenticationDriver` (in `pulsar-client-api`, `.internal` subpackage). `ClientCnx` detects it and routes connect / refresh / challenge handling through the async API; plain v4 instances keep the existing synchronous path verbatim. This is generic across all challenge types.
+
+## Error model
+
+All async failures complete the returned future exceptionally with a v5 `org.apache.pulsar.client.api.v5.PulsarClientException` — `AuthenticationException` (terminal), `GettingAuthenticationDataException` (transient/retryable), or `UnsupportedAuthenticationException` (capability not supported by a wrapped v4 impl). Details and the v4-exception translation are in the Detailed Design.
+
+# Detailed Design
+
+## Design & Implementation Details
+
+### The `Authentication` core and capability interfaces
+
+The new core `Authentication` interface lives in `pulsar-client-api-v5`:
+
+```java
+package org.apache.pulsar.client.api.v5.auth;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+public interface Authentication extends AutoCloseable {
+    /**
+     * Configuration step. Called once by the framework AFTER no-arg construction
+     * when the plugin was loaded reflectively from authPluginClassName +
+     * authParams. NOT called when the plugin was constructed programmatically
+     * by the user — that path presumes the instance is already configured.
+     * Default: no-op. Implementations override to read their parameters.
+     *
+     * <p>Configuration is intentionally separate from {@link #initializeAsync}:
+     * configuration is static plugin-level data (file paths, URLs, scopes);
+     * initialization gives the plugin runtime services and may do I/O.
+     */
+    default void configure(Map<String, String> authParams) {}
+
+    /**
+     * Initialization step. Called once by the framework with runtime services
+     * after configuration. May do I/O; the returned future completes when the
+     * implementation is ready to serve credentials.
+     */
+    CompletableFuture<Void> initializeAsync(AuthenticationInitContext ctx);
+
+    /**
+     * Capability factory — the framework's ONLY discovery mechanism. The
+     * framework never uses {@code instanceof} on a plugin instance; it asks this
+     * method for each capability it may drive. An implementation may therefore
+     * serve a capability from a separate internal class, or forward a wrapped
+     * delegate's capability, rather than implementing it on this type. The
+     * default implementation returns {@code this} when the plugin implements the
+     * requested interface directly, covering the common case with no override.
+     *
+     * <p>Contract: results are STABLE once {@link #initializeAsync} has completed —
+     * the framework may look a capability up once and cache it for the client's
+     * lifetime. One object may serve several capabilities. Capability objects are
+     * owned by this plugin and released by {@link #close()}; the framework never
+     * closes them individually. All capability methods must tolerate concurrent
+     * invocation (multiple connections authenticate in parallel); only the rounds
+     * of a single exchange are serialized by the framework.
+     */
+    default <T> Optional<T> capability(Class<T> kind) {
+        return kind.isInstance(this) ? Optional.of(kind.cast(this)) : Optional.empty();
+    }
+
+    @Override default void close() throws Exception {}
+}
+```
+
+The four capability interfaces, each in its own file in the same package — segregated by transport (binary vs HTTP) and style (single-pass vs challenge-response). An implementation declares the ones that match what it supports (e.g., a one-pass plugin that serves both transports implements both `BinaryAuthDataProvider` and `HttpAuthHeadersProvider`):
+
+```java
+package org.apache.pulsar.client.api.v5.auth;
+
+import java.util.concurrent.CompletableFuture;
+
+/** Single-pass credential exchange for Pulsar binary protocol. */
+public interface BinaryAuthDataProvider {
+    /** Stable identifier sent in CommandConnect.auth_method_name */
+    String authMethodName();
+
+    /**
+     * Produce a credential for the binary protocol connection. The returned
+     * {@link BinaryAuthData} carries the {@code auth_data} bytes for
+     * {@code CommandConnect}; the framework pairs them with {@link #authMethodName()}.
+     */
+    CompletableFuture<BinaryAuthData> getAuthDataAsync(AuthenticationCallContext ctx);
+}
+
+/** Single-pass credential exchange for Pulsar HTTP transport. */
+public interface HttpAuthHeadersProvider {
+    /**
+     * Produce the authentication headers for an outgoing HTTP request (e.g.
+     * {@code Authorization: Bearer <jwt>}, or a custom header such as
+     * {@code Athenz-Role-Auth}). The returned {@link HttpAuthHeaders} are attached
+     * to the request; most implementations produce the same credential for every
+     * call. Completes exceptionally on failure (see the error model).
+     */
+    CompletableFuture<HttpAuthHeaders> getHttpHeadersAsync(HttpAuthCallContext ctx);
+}
+
+/** Multi-round challenge/response (SASL-style and custom protocols) for Pulsar binary protocol. */
+public interface BinaryAuthChallengeHandler {
+    /**
+     * Respond to a binary-protocol {@code CommandAuthChallenge}. The framework places
+     * the returned bytes in {@code CommandAuthResponse}. Completion is decided by the
+     * broker (it replies with {@code CommandConnected} when satisfied), so the handler
+     * does not signal it; cross-round conversation state is kept in the context's
+     * state slot.
+     */
+    CompletableFuture<ChallengeResponse> respondToChallengeAsync(AuthenticationCallContext ctx,
+                                                                 AuthChallenge authChallenge);
+}
+
+/**
+ * SASL-style multi-round challenge/response over HTTP. Handles the existing Pulsar
+ * SASL-over-HTTP mechanism, where the server returns HTTP {@code 401} carrying the
+ * challenge in Pulsar's custom SASL headers (e.g. {@code SASL-Token} / {@code State} /
+ * {@code SASL-Server-ID}) rather than the standard {@code WWW-Authenticate} header.
+ * Standard {@code WWW-Authenticate}-based schemes (e.g. HTTP digest) will be served by a
+ * separate interface; the framework's HTTP auth driver dispatches to whichever a plugin
+ * implements.
+ */
+public interface HttpAuthChallengeHandler {
+    /**
+     * Compute the headers for the next round. The server's challenge headers from the
+     * prior {@code 401} are available via {@link HttpAuthCallContext#serverChallengeHeaders()};
+     * the returned {@link HttpAuthHeaders} are attached to the resubmitted request.
+     * Cross-round conversation state is kept in the context's state slot.
+     */
+    CompletableFuture<HttpAuthHeaders> respondToHttpChallengeAsync(HttpAuthCallContext ctx);
+}
+```
+
+**Binary challenge routing (normative).** The binary transport's driver (`ClientCnx`) routes exactly as follows, for every plugin:
+
+1. **Initial connect** → `capability(BinaryAuthDataProvider.class).getAuthDataAsync(ctx)`; the capability is required for any plugin used on the binary transport — absent, client construction fails with `UnsupportedAuthenticationException`.
+2. **`CommandAuthChallenge` carrying the refresh sentinel** (`AuthData.REFRESH_AUTH_DATA_BYTES`, `"PulsarAuthRefresh"`) → `ClientCnx` **terminates the current exchange and starts a fresh one**, producing the new credential via that fresh exchange's `getAuthDataAsync(ctx)` — a new call context and a new state slot — and sends it as `CommandAuthResponse`. **Conversation state does NOT survive a REFRESH**: refresh is by definition "produce your current credential again", a fresh single-pass exchange, not a continuation of the prior conversation. The sentinel never reaches the challenge handler.
+3. **Any other `CommandAuthChallenge`** → `capability(BinaryAuthChallengeHandler.class).respondToChallengeAsync(ctx, challenge)`; if the plugin does not expose the capability, the connection fails with `AuthenticationException` (matching v4, where a plugin without `authenticate(AuthData)` cannot answer a challenge).
+
+A mechanism spanning both cells (SASL) therefore sees: initial frame via rule 1, conversation rounds via rule 3, and — should the broker ever push the sentinel mid-conversation — a fresh exchange via rule 2 that restarts authentication from a new initial frame (the prior conversation's state does not carry over; a REFRESH begins a clean single-pass exchange).
+
+One optional **composite interface** bundles the overwhelmingly common combination. It adds no methods — an implementation may declare it instead of listing the individual capabilities, or implement the capability interfaces directly:
+
+```java
+package org.apache.pulsar.client.api.v5.auth;
+
+/** Convenience: a single-pass credential served over both transports. */
+public interface SinglePassAuthentication
+        extends Authentication, BinaryAuthDataProvider, HttpAuthHeadersProvider {}
+```
+
+The built-in **`TlsAuthentication`** plugin handles mTLS. It is an ordinary `Authentication` implementation, **not** a capability interface: it implements `BinaryAuthDataProvider` with `authMethodName()` defaulting to `"tls"` and empty `auth_data`, carries no TLS material (that is configured at the builder), and exists only to drive `auth_method_name=tls` on the binary protocol so the broker authenticates from the TLS-handshake certificate:
+
+```java
+package org.apache.pulsar.client.impl.v5.auth;
+
+import java.util.concurrent.CompletableFuture;
+import org.apache.pulsar.client.api.v5.auth.*;
+
+/**
+ * Built-in mTLS plugin. The certificate and private key are configured at the
+ * {@code PulsarClient} builder (see "A note on mTLS"), not here. This plugin only
+ * reports {@code authMethodName()} (default {@code "tls"}) with empty {@code auth_data},
+ * so the binary protocol sends {@code auth_method_name=tls} on {@code CommandConnect}
+ * and the broker authenticates from the certificate presented during the TLS handshake.
+ */
+public class TlsAuthentication implements Authentication, BinaryAuthDataProvider {
+    private final String authMethodName;
+
+    public TlsAuthentication() { this("tls"); }
+    public TlsAuthentication(String authMethodName) { this.authMethodName = authMethodName; }
+
+    @Override public String authMethodName() { return authMethodName; }
+
+    @Override public CompletableFuture<Void> initializeAsync(AuthenticationInitContext ctx) {
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override public CompletableFuture<BinaryAuthData> getAuthDataAsync(AuthenticationCallContext ctx) {
+        return CompletableFuture.completedFuture(new BinaryAuthData(new byte[0]));
+    }
+}
+```
+
+### Value types
+
+The credential/challenge value types in `org.apache.pulsar.client.api.v5.auth`. `BinaryAuthData` carries the binary-protocol credential; `HttpAuthHeaders` carries the HTTP headers; `AuthChallenge` / `ChallengeResponse` carry the multi-round binary exchange.
+
+```java
+/**
+ * Binary-protocol credential: the auth_data bytes for CommandConnect. The
+ * auth-method name is deliberately NOT part of this value — it comes from
+ * exactly one place, {@link BinaryAuthDataProvider#authMethodName()},
+ * so a plugin cannot contradict itself (carrying the name on both the provider
+ * and the data value would leave "which one wins?" to the
+ * javadoc). Kept as a record rather than a bare byte[] so fields can be added
+ * later without an API break.
+ */
+public record BinaryAuthData(byte[] bytes) {}
+```
+
+```java
+/**
+ * HTTP authentication headers an implementation produces for an outgoing request
+ * (and, for challenge-response, the headers carrying a server's challenge). Header
+ * names are canonicalised on construction (RFC 7230 §3.2); {@link #get} is
+ * case-insensitive; {@link #asMap} returns the canonical-cased view.
+ */
+public final class HttpAuthHeaders {
+    static HttpAuthHeaders empty();
+    static HttpAuthHeaders of(String name, String value);
+    static HttpAuthHeaders of(Map<String, String> headers);
+    Optional<String> get(String name);   // case-insensitive
+    Map<String, String> asMap();
+    // ...
+}
+```
+
+```java
+/** A binary-protocol CommandAuthChallenge payload handed to a BinaryAuthChallengeHandler. */
+public record AuthChallenge(byte[] bytes) {}
+
+/**
+ * Reply from respondToChallengeAsync — just the bytes for the next
+ * CommandAuthResponse. There is no completion flag: the broker decides when the
+ * handshake is finished (it sends CommandConnected); the implementation tracks any
+ * cross-round state of its own in the call context's state slot. Kept as a record
+ * rather than a bare byte[] so fields can be added later without an API break.
+ */
+public record ChallengeResponse(byte[] bytes) {}
+```
+
+### `AuthenticationInitContext`
+
+```java
+public interface AuthenticationInitContext {
+    /**
+     * Factory for {@link PulsarHttpClient} instances. The framework manages
+     * lifecycle (event loop, timer, DNS cache, TLS material refresh integration);
+     * plugins describe what they need via {@link PulsarHttpClientConfig} and
+     * receive a configured instance owned by the framework. Multiple instances
+     * with different TLS / timeouts / proxy may be obtained for different uses
+     * (e.g., OAuth2's mTLS exchange to the IdP vs a third-party plugin's own
+     * HTTP endpoint).
+     *
+     * <p>A plugin that needs framework-managed HTTP MUST obtain it here rather
+     * than constructing its own — a private client defeats the framework's
+     * shared event-loop / DNS / refresh integration.
+     */
+    PulsarHttpClientFactory httpClientFactory();
+
+    /** Scheduler for delayed / periodic authentication work (e.g. proactive
+     *  credential renewal). Never the Netty event loop. Reserved for scheduled
+     *  tasks — potentially-blocking work belongs on {@link #blockingExecutor()}. */
+    ScheduledExecutorService scheduler();
+
+    /**
+     * Dedicated executor for off-loading potentially-blocking authentication
+     * work, kept separate from {@link #scheduler()} so that blocking calls
+     * cannot starve the scheduler's threads or delay scheduled tasks. The
+     * {@link LegacyV4AuthenticationAdapter} offloads every synchronous v4
+     * plugin call here. Never the Netty event loop. Framework-owned and shared
+     * per PulsarClient: a small bounded cached pool (max 16 threads, created on
+     * demand and reaped after 60s idle) — a fixed framework default, not a
+     * client-builder knob.
+     */
+    Executor blockingExecutor();
+
+    /** Used by implementations that schedule against wall-clock. */
+    Clock clock();
+
+    /** Telemetry root; framework defaults to OpenTelemetry.noop() if unset. */
+    OpenTelemetry openTelemetry();
+
+    /** Stable id of the owning PulsarClient for logging correlation. */
+    String clientInstanceId();
+
+    /**
+     * Convenience copy of the parsed authParams previously passed to
+     * {@link Authentication#configure}. Mostly useful for plugins constructed
+     * reflectively that want their params at init time too.
+     */
+    Map<String, String> params();
+}
+```
+
+The lifecycle is: the framework constructs a single `AuthenticationInitContext` per `PulsarClient`, calls `initializeAsync(ctx)` once when the client is built, and the implementation may retain references for the lifetime of the client. `Authentication.close()` releases any resources the implementation acquired; the framework owns and closes the shared services (HTTP clients, scheduler, blocking executor). Per-call `AuthenticationCallContext` instances are cheap to allocate.
+
+### `AuthenticationCallContext` / `HttpAuthCallContext`
+
+A per-call context carries any transport-specific routing details, and exposes a **per-exchange state slot** for the implementation to retain conversation state across calls (challenge-response rounds, multi-stage HTTP auth, etc.):
+
+```java
+public interface AuthenticationCallContext {
+    String brokerHost();
+    int brokerPort();
+
+    /**
+     * Retrieve an implementation-controlled state object previously stored
+     * with {@link #setStateObject}. The slot is keyed by class so the pieces
+     * of one plugin — which, under the capability-factory model, may be
+     * separate internal classes participating in the same exchange (e.g. the
+     * initial-data provider and the challenge handler on one binary connect) —
+     * can each keep state without collision; impls typically store one object
+     * of their own type (e.g., their SASL conversation state).
+     *
+     * <p>The slot's lifetime equals the authentication exchange: for binary
+     * protocol, the lifetime of one {@code ClientCnx} setup (including all
+     * {@code CommandAuthChallenge}/{@code CommandAuthResponse} rounds);
+     * for HTTP, one request's retry sequence. Concurrent authentications
+     * to different brokers get their own context with their own slots,
+     * so multiple in-flight handshakes don't collide.
+     */
+    <T> Optional<T> getStateObject(Class<T> clazz);
+
+    /** Store a state object keyed by its (or any) class; a {@code null} value
+     *  removes the entry. Implementations should key with a private class of
+     *  their own (e.g. their conversation record) to avoid collisions. Rounds
+     *  of one exchange are serialized by the framework, so slot access within
+     *  an exchange needs no synchronization. */
+    <T> void setStateObject(Class<T> clazz, T value);
+}
+```
+
+```java
+public interface HttpAuthCallContext {
+    URI requestUri();
+
+    /**
+     * For SASL-style HTTP challenge/response: the challenge headers from the server's
+     * prior {@code 401} response (e.g. {@code SASL-Token} / {@code State} /
+     * {@code SASL-Server-ID}). Empty on the first request, before any challenge.
+     */
+    Optional<HttpAuthHeaders> serverChallengeHeaders();
+
+    // Per-exchange state slot — same contract as on AuthenticationCallContext
+    <T> Optional<T> getStateObject(Class<T> clazz);
+    <T> void setStateObject(Class<T> clazz, T value);
+}
+```
+
+(The state slot is defined on each of the two contexts rather than hoisted into a shared `StatefulCallContext` supertype — nothing is generic over both contexts, so the extra public type would buy nothing.)
+
+Most implementations don't need to inspect any of the routing fields — they produce the same credential for every call. Implementations of `BinaryAuthChallengeHandler` typically use the state slot to track their conversation across rounds (the server's challenge bytes arrive as the `AuthChallenge` parameter; cross-call state lives in `getStateObject(...)`). For HTTP, `HttpAuthChallengeHandler` reads the server's challenge from `HttpAuthCallContext.serverChallengeHeaders()` and keeps its own conversation state in the same state slot.
+
+### The `PulsarHttpClient` SPI
+
+The pluggable HTTP client lives in `org.apache.pulsar.client.api.v5.http`. The **framework manages HTTP client lifecycle**, including the Netty event loop, timer, DNS cache, and `PulsarTlsFactory` integration. Plugins describe what kind of HTTP client they need; the framework constructs, pools, and closes instances:
+
+```java
+package org.apache.pulsar.client.api.v5.http;
+
+public interface PulsarHttpClient extends AutoCloseable {
+    CompletableFuture<HttpResponse> execute(HttpRequest request);
+
+    /** Release this instance. Idempotent. Instances are framework-owned: a plugin
+     *  MAY close an instance it no longer needs, and the framework closes every
+     *  remaining instance when the owning PulsarClient closes — so calling this
+     *  is optional for plugins. */
+    @Override void close();
+}
+
+/**
+ * Framework-owned factory. A plugin that needs framework-managed HTTP
+ * MUST obtain a client via {@link AuthenticationInitContext#httpClientFactory()}
+ * rather than constructing its own. Multiple instances per PulsarClient
+ * are supported — e.g., OAuth2's mTLS exchange to the IdP uses a different
+ * TlsPurpose-driven TLS configuration than a third-party plugin's own HTTP
+ * endpoint, but they share the underlying event loop / timer / DNS resources.
+ */
+public interface PulsarHttpClientFactory {
+    PulsarHttpClient newHttpClient(PulsarHttpClientConfig config);
+}
+```
+
+`HttpRequest` is an immutable value type with method, URI, headers, optional body (sealed `Body = Bytes | Form`), and optional timeout override. `HttpResponse` exposes status, headers, and the body bytes (buffered-only in v1; 16 MiB default cap configurable via `PulsarHttpClientConfig.maxResponseBodyBytes()`). `PulsarHttpClientConfig` carries per-instance concerns: a `TlsPurpose` (the framework consults the configured `PulsarTlsFactory` for the TLS material bound to that purpose), default timeouts, proxy settings, the Pulsar user-agent string, and default headers; tracing and metrics ride on the OpenTelemetry handle from `AuthenticationInitContext`, not on a bespoke hooks type. The configuration deliberately does NOT carry the cert/key/trust material directly — that lives in the `PulsarTlsFactory` and is looked up by purpose. For a plugin that needs its own trust domain (the OAuth2 IdP being the canonical case), the plugin selects a distinct purpose — `TlsPurpose.CLIENT_OAUTH2`, or a minted variant such as `TlsPurpose.client("oauth2.myPlugin", CLIENT_OAUTH2)` — and the operator configures a `TlsPolicy` for that purpose; the plugin never handles raw material. This purpose-key indirection is how a plugin gets its own trust domain — expressed as an ordinary `TlsPurpose` rather than a separate addressing type.
+
+**Why multiple HTTP clients?** When the binary connection uses mTLS, the OAuth2 client may need a DIFFERENT mTLS configuration to talk to the identity provider — the IdP and the broker are different trust domains. Sharing one HTTP client instance across both is wrong. But the *resources* — event loop threads, DNS resolver cache, refresh scheduler — should be shared. The framework owns the shared resources and hands out distinct `PulsarHttpClient` instances per `PulsarHttpClientConfig`.
+
+**Design decision — the backend is framework-owned, not pluggable.** Every `PulsarHttpClient` is built by the framework on AsyncHttpClient (in `pulsar-client-v5`), with TLS wired through the purpose-driven `PulsarTlsFactory` lookup. A pluggable backend was considered — a `ServiceLoader`-discovered `PulsarHttpClientProvider` SPI with name/priority resolution, a `builder.httpClientProvider(name)` selector, an opt-in JDK-`HttpClient` provider module, and a caller-supplied `builder.httpClient(instance)` escape hatch — and deliberately rejected. What plugins need (Motivation #3) is to *obtain* a framework-managed client, not to choose its transport; `PulsarHttpClientConfig` already covers the things operators actually asked for in [#24795](https://github.com/apache/pulsar/issues/24795) (timeouts, proxy, observability). The `PulsarHttpClient` interface boundary by itself keeps the framework free to change its internal backend later, whereas a public discovery contract would have to be documented, tested, and maintained forever — with third-party backends of varying fidelity (a JDK backend, for instance, lacks SOCKS5 and custom DNS resolution and would need a client rebuild on TLS rotation). Backend pluggability can be reintroduced additively if a concrete need ever emerges.
+
+**TLS rotation behind `PulsarHttpClient`.** AsyncHttpClient fixes its TLS configuration at instance build, so the framework does not hand it a static context: it installs its own `SslEngineFactory` and subscribes to the Netty `SslContext` for the instance's `TlsPurpose` (`createInstance(purpose, SslContext.class, onLoadOrReload)`); each new engine — i.e. each new connection — is created from the most recently delivered context, so rotated material takes effect for new connections. Established pooled connections do not renegotiate: on reload delivery the framework evicts **idle** pooled connections, and pooled-connection TTL (AsyncHttpClient's connection-TTL setting, bounded by default) caps how long an active connection can keep using pre-rotation material — rotation is therefore effective within the TTL bound, not merely "eventually". Plugins see none of this — rotation is invisible behind `PulsarHttpClient`.
+
+Consumers of `PulsarHttpClient`:
+
+- The built-in OAuth2 plugin, for token-endpoint and well-known-metadata fetches. The OAuth2 credential flow (`Flow`/`FlowBase`) that makes these calls stays on the v4 `AuthenticationOAuth2` class rather than being reimplemented v5-native — see the layering note under [the v4 internal migration](#class-name-compatibility-and-the-v4-internal-migration).
+- Any third-party plugin that needs HTTP.
+
+The HTTP topic-lookup client (`HttpClient`) and the admin client's `AsyncHttpConnector` are deliberately **not** `PulsarHttpClient` consumers: each still constructs its own `DefaultAsyncHttpClient`. They do, however, adopt the same two framework mechanisms this PIP introduces — the rotating `SslEngineFactory` backed by a `PulsarTlsFactory` subscription to the `CLIENT_DEFAULT` `SslContext` (so rotated TLS material takes effect for new connections, with idle pooled connections evicted on reload), and the shared `HttpAuthenticationDriver` for the SASL `401`→resubmit→`200` loop — so they gain the TLS-rotation and multi-round-auth behaviour without moving onto the `PulsarHttpClient` SPI itself.
+
+Athenz is deliberately **not** in this list: its ZTS role-token exchange runs on the Athenz SDK's own HTTP transport (the SDK owns that connection), so `AuthenticationAthenz` does not obtain a framework `PulsarHttpClient` — only OAuth2 among the built-ins does.
+
+**Standalone plugin usage.** The v4 `Authentication` contract allows a plugin to be created and started outside any `PulsarClient`/`PulsarAdmin` (`AuthenticationFactory.create(...).start()` — the proxy's own broker-client authentication and CLI tools do exactly this). Such a plugin has no framework services bound, so OAuth2's HTTP needs are served by a self-contained standalone fallback factory: a framework-owned HTTP client on its own minimal resources, honoring the plugin's IdP TLS parameters (with rotation) when present and platform-default trust otherwise, closed with the plugin. Bound usage always prefers the client's shared resources; the standalone form exists solely to preserve the v4 contract.
+
+### Redesigned PIP-337 SSL provider: `PulsarTlsFactory`
+
+A small set of new types replaces the existing `PulsarSslFactory` / `PulsarSslConfiguration` surface as the v5 client's (and Pulsar 5.0's) TLS integration point. The SPI is a typed **instance factory**: consumers request fully configured TLS objects per purpose; how the factory sources material and builds them is factory-internal.
+
+- **`PulsarTlsFactory`** (interface, in `org.apache.pulsar.common.tls`) — the v5 TLS SPI. The framework requests an instance of a well-known class for a `TlsPurpose` (described next); the factory returns a configured instance when it supports the combination, or `Optional.empty()` when it does not:
+
+  ```java
+  public interface PulsarTlsFactory extends AutoCloseable {
+      CompletableFuture<Void> initialize(TlsFactoryInitContext context);
+
+      /**
+       * A fully configured instance of {@code instanceClass} for the purpose, or
+       * {@code Optional.empty()} when this factory does not support the
+       * (purpose, class) combination. Failure to build a SUPPORTED combination
+       * completes the future exceptionally instead.
+       */
+      <T> CompletableFuture<Optional<TlsHandle<T>>> createInstance(
+              TlsPurpose purpose, Class<T> instanceClass);
+
+      /**
+       * One-shot variant carrying the destination endpoint as a per-request HINT.
+       * Client-side consumers pass the target host/port when they know it (one
+       * connection, one instance); a factory that serves per-destination material
+       * (multi-cluster deployments, per-target workload identities) may key on it.
+       * The default implementation ignores the endpoint and delegates to
+       * {@link #createInstance(TlsPurpose, Class)} — most factories, including the
+       * default file-based one, never look at it. The endpoint does NOT replace
+       * hostname verification or SNI: those are applied at engine creation from
+       * the same peer address (see the usage notes below).
+       */
+      default <T> CompletableFuture<Optional<TlsHandle<T>>> createInstance(
+              TlsPurpose purpose, TlsEndpoint endpoint, Class<T> instanceClass) {
+          return createInstance(purpose, instanceClass);
+      }
+
+      /**
+       * Like the one-shot form, but additionally subscribes to reloads:
+       * {@code onLoadOrReload} receives the instance on initial load and a REBUILT
+       * instance whenever the underlying material changes. The returned future
+       * completes after the first delivery. Subscriptions are purpose-scoped and
+       * carry no endpoint — they serve server-side listeners, which have no
+       * destination.
+       */
+      <T> CompletableFuture<Optional<TlsHandle<T>>> createInstance(
+              TlsPurpose purpose, Class<T> instanceClass, Consumer<T> onLoadOrReload);
+
+      @Override
+      void close();
+  }
+
+  /** Destination of an outbound connection, passed to the factory as a hint. */
+  public record TlsEndpoint(String host, int port) {}
+
+  /**
+   * Handle for a built instance — returned by every {@code createInstance} form.
+   * For a one-shot request, {@link #get()} returns the built instance; for a
+   * subscribing request, it returns the value most recently delivered to
+   * {@code onLoadOrReload} (the initial load, or the latest rebuild), so a
+   * consumer can read the live instance on demand without caching callback
+   * deliveries. A single handle type is used rather than separate
+   * ({@code TlsInstance} / {@code TlsSubscription}) types, which would be
+   * byte-identical — differing only in prose.
+   */
+  public interface TlsHandle<T> {
+      T get();
+      /** Unregister the reload callback (if any) and release the factory-side
+       *  resources backing this handle (background refresh, caches). */
+      void dispose();
+  }
+  ```
+
+  How a factory is *selected* is component-specific configuration (see [Configuration](#configuration)); at initialization every factory receives a **`TlsFactoryInitContext`** carrying its parameters and the framework's runtime services (the default `FileBasedTlsFactory` additionally receives its purpose→policy map through its constructor, composed by the owning component — see the build-time composition note below):
+
+  ```java
+  public interface TlsFactoryInitContext {
+      /** Factory-specific parameters from the owning component's configuration
+       *  (the tlsFactoryConfig key on the server side; builder-supplied on the client). */
+      Map<String, String> params();
+
+      /** Scheduler for file-watch polling and rotation work. Framework-owned. */
+      ScheduledExecutorService scheduler();
+
+      /** Executor for potentially-blocking material loading. Never a consumer event loop. */
+      Executor blockingExecutor();
+
+      Clock clock();
+      OpenTelemetry openTelemetry();
+  }
+  ```
+
+  The context is constructed by whichever component owns the factory — the v5 client builder on the client side; the broker / proxy / websocket / functions-worker service on the server side — and `initialize(...)` completes before the first `createInstance` call. A failure during `initialize` is fatal to the owning component's startup.
+
+  The **well-known instance classes** and their support contract:
+
+  | Requested class | Consumer | Contract |
+  |---|---|---|
+  | `io.netty.handler.ssl.SslContext` | binary protocol; AsyncHttpClient-based HTTP | optional — on `empty()` the framework wraps the JDK `SSLContext` fallback with Netty's `JdkSslContext` adapter (the default file-based factory supports it natively, keeping OpenSSL-based contexts available) |
+  | `org.eclipse.jetty.util.ssl.SslContextFactory.Server` | broker / proxy / function-worker web server | optional — on `empty()` the framework synthesizes it from an `SSLContext` subscription and Jetty's `reload(...)` (see the Jetty section below) |
+  | `javax.net.ssl.SSLContext` | fallback source for the classes above; non-Netty consumers | **required only as a fallback** — a factory must support it for a purpose *unless* it natively supplies every richer (Netty / Jetty) class that purpose consumes; the framework builds the Netty `SslContext` / Jetty `SslContextFactory.Server` from it whenever the factory returns `empty()` for them |
+  | `javax.net.ssl.SSLParameters` | optional companion to the `SSLContext` fallback | **optional** — consulted by the framework *only* when it synthesizes from the `SSLContext` fallback; carries the factory's engine-level baseline policy (enabled protocols and cipher suites, client-auth mode, endpoint identification, algorithm constraints) that a bare `SSLContext` cannot express — the JDK API has no setter for a context's default parameters. `empty()` means the consumer's own configuration applies, as before |
+
+  `javax.net.ssl.SSLContext` is deliberately listed **last**: it is not an end in itself but the **universal fallback** the framework synthesizes the richer objects from. For each purpose the framework first asks the factory for the object a consumer actually needs — the Netty `SslContext`, or Jetty's `SslContextFactory.Server`. Only when the factory returns `Optional.empty()` for that richer class does the framework fall back to requesting `SSLContext` for the same purpose and build the richer object itself (wrapping it with `JdkSslContext` for Netty, or configuring and driving `reload(...)` for Jetty). The consequence: a factory that natively supplies every richer object a purpose consumes is never asked for `SSLContext` for that purpose and need not implement it at all; a factory that supplies neither Netty nor Jetty objects must implement `SSLContext` so the framework can synthesize both from it.
+
+  On that synthesis path the framework additionally asks the factory for `createInstance(purpose, SSLParameters.class)` — the optional engine-policy companion. Merge order is deterministic: (1) the factory's `SSLParameters` (non-null members only) form the engine baseline; (2) `endpointIdentificationAlgorithm` — the factory's value wins when set, otherwise the consumer's hostname-verification configuration applies `"HTTPS"` on client purposes; (3) SNI server names are always set per connection from the target endpoint, overriding any factory baseline (a factory should not pin SNI); (4) on server purposes, a factory-supplied `SSLParameters` is authoritative for `needClientAuth`/`wantClientAuth`, otherwise the consumer's client-auth flag maps as usual. On subscriptions, the parameters are re-requested with each `SSLContext` delivery, so engine policy may rotate with material. The synthesized *Jetty* factories consult the protocols, cipher suites, and client-auth members only (Jetty's `SslContextFactory` exposes no setters for the finer members; endpoint identification is a client-engine concern the Jetty server path never needs) — the full member set applies on the Netty synthesis path. Rationale: without this companion, an `SSLContext`-only factory could not restrict protocols or ciphers, or state its own verification and client-auth policy — those are engine-level parameters, and `SSLContext` offers `getDefaultSSLParameters()` but no setter. With it, the tier-3 story is complete at **zero non-JDK dependencies**.
+
+  Jetty's `SslContextFactory.Client` is deliberately **not** in the well-known set. Its one in-tree consumer — the proxy's `AdminProxyHandler`, whose Jetty `HttpClient` forwards admin requests to brokers over TLS (today via a `SslContextFactory.Client` subclass wired to the PIP-337 factory) — is served by a framework-synthesized instance: a plain `SslContextFactory.Client` configured via `setSslContext(...)` from the same `SSLContext` fallback. Factories never build Jetty client factories.
+
+  The contract is enforced **fail-fast**: at startup the framework probes every (purpose, class) pair it needs; a purpose for which the framework can obtain *neither* the richer class *nor* its `SSLContext` fallback is a boot-time configuration error rather than a failure at first connection. Contract violations discovered later (e.g. a subscription that never delivers) surface as runtime exceptions. Probing mechanics: the probe uses the one-shot, endpoint-less `createInstance` form, and the returned handle is **retained as the initial cached instance** rather than disposed — the probe is the first load, not a throwaway. Statically known purposes are probed when the owning component starts (`PulsarClient` build on the client side, service start on the server side); plugin-minted purposes are probed when the plugin first requests them during `initializeAsync`. TLS material therefore loads **eagerly at build time** — a deliberate behavior change from the v4 client's lazy load at first connection, accepted because surfacing misconfiguration at build is the point of the fail-fast contract.
+
+  Usage patterns per consumer: server-side consumers use the **subscribing** overload — the broker/proxy binary listeners swap the `SslContext` they use to build `SslHandler`s for new connections; Jetty instances are requested with the **one-shot** overload since a factory-supplied `SslContextFactory.Server` handles reloading internally (obligations below). Client-side consumers use the one-shot overload per new connection, passing the destination as a `TlsEndpoint` hint when they know it; the factory returns its cached instance until material changes (per-destination factories may cache per endpoint), and `dispose()` releases the consumer's interest (disposal on connection close also balances any Netty reference count). The one-shot form presumes an *asynchronous* connection path — the instance future composes into the connect chain before the transport connects, never blocking an event loop; Pulsar's binary connect already has this shape. A client-side consumer whose integration point is synchronous (an HTTP library's engine factory that must produce an `SSLEngine` on demand) instead holds the **subscribing** overload's current instance; the proxy's broker-facing data path, whose channel initializer is synchronous, does the same. Both are first-class client patterns. Per-instance settings — protocols, ciphers, server client-auth mode, insecure trust-all modes, and **client-side hostname verification** — are baked into the built objects by the factory from the configuration it was initialized with. Hostname verification cannot be left to the consumer to toggle per connection: Netty's OpenSSL-based `SslContext` fixes the endpoint-identification algorithm at build time (it is a `final` field on `ReferenceCountedOpenSslContext`, settable only via `SslContextBuilder.endpointIdentificationAlgorithm(...)`), and a per-`SSLEngine` `setSSLParameters` override is asymmetric on that backend — it can force verification on but does not relax it off. The factory therefore sets the algorithm when it builds the client context for a purpose, driven by the client/builder configuration. (The JDK backend would permit a clean per-`SSLEngine` override either way, but the SPI treats hostname verification as a per-context setting for backend independence.) Reload callbacks are serial per subscription, never concurrent, never invoked on a consumer event loop, and the first delivery happens-before the returned future completes.
+
+  **Reload failure semantics.** A failed rebuild on rotation (e.g. a half-written or invalid rotated file — the canonical incident) must not tear down a working subscription: the factory keeps serving the **last-good** instance, logs the failure at WARN, records it in the reload-failure metric (see [Metrics](#metrics)), and retries on the next observed material change. A consumer callback that throws is caught and logged; the subscription stays live and later deliveries proceed. `initialize()` failing at boot fails the owning component's startup, per the fail-fast contract above.
+
+  **Ownership and disposal.** The component that creates a factory owns and closes it: the default factory, and any custom factory instantiated from configuration, are closed by the framework when the owning client or service closes. A factory *instance* supplied programmatically to the v5 builder is **adopted** — the client closes it on `PulsarClient.close()`, matching the v4 precedent for builder-supplied `Authentication` instances. Handles follow their consumer: server-side subscriptions are disposed when the listener or web service stops; a client connection disposes its one-shot handle when the connection closes. A leaked (undisposed) handle costs at most a factory-side cache/refresh registration — the default factory shares one `TlsMaterialSource` per purpose, so a leak never duplicates file watchers and is bounded.
+
+  A factory that natively supplies `SslContextFactory.Server` takes on three obligations: the instance must be handed over **unstarted** (Jetty starts it with the connector lifecycle), repeated requests for the same purpose must return the **same instance** (it is a stateful lifecycle bean, not a value), and the factory must drive `reload(...)` on it internally when material rotates. The framework-synthesized fallback carries these obligations instead, which is why most factories should simply return `empty()` for the Jetty class. The native-supply path is retained (rather than making Jetty integration framework-only) because it is the only way a factory can control Jetty-level engine settings — protocol/cipher selection, SNI keystores — that a bare `SSLContext` cannot carry.
+
+  `Optional.empty()` from `createInstance` means exactly one thing: the factory does not support the requested (purpose, class) combination. It is **not** a purpose-resolution signal — how a factory maps a purpose to configured material is factory-internal. The default `FileBasedTlsFactory` resolves the requested purpose first, then its single-level fallback (see `TlsPurpose`); when nothing is configured along that path, a client-role purpose resolves to the system default (OS trust store, no client certificate) and a server-role purpose fails the request. Two guardrails keep custom factories from misusing the signal: a factory that has resolved a purpose to material (or to the system default) and *supports the requested class* must **never** return `empty()` for it — a resolved-but-unbuildable request completes exceptionally, so a real configuration error can't be masked by the framework quietly falling back to `SSLContext` synthesis; and the framework's default factory honors `TlsPurpose.fallback()` exactly as specified above (resolve the purpose, then its single fallback, then the role's empty-fallback rule), so its resolution is objectively testable. A custom factory owns its own purpose→material resolution, but MUST document any divergence from that default so operators can reason about it. Example: `createInstance(CLIENT_OAUTH2, SslContext.class)` on the default factory with no OAuth2 policy configured returns a system-default-trust context (client role, empty fallback → system default) — not `empty()`, and not an error. Like every future-returning method in this PIP, `createInstance` reports all failures through the returned future and never throws synchronously.
+
+  **Instance ownership.** Built TLS objects are **factory-owned snapshots**: consumers never close, release, or mutate them — in particular they must not `release()` a Netty reference-counted OpenSSL context. `TlsHandle.dispose()` only signals that this consumer is done; the factory releases a superseded or fully-disposed instance's native resources itself, once the last handle referencing it is gone. A factory that builds reference-counted Netty contexts therefore manages their refcounts internally; consumers treat every returned object as an immutable borrow.
+
+  **Shading and plugin packaging.** The well-known classes include Netty and Jetty types, and `pulsar-client-shaded` / `pulsar-client-admin-shaded` relocate Netty (`io.netty` → `org.apache.pulsar.shade.io.netty`). A custom `PulsarTlsFactory` intended for the shaded artifacts must therefore be **relocated the same way** — its bytecode references rewritten to the shaded class names (e.g. with the Gradle Shadow or Maven Shade plugin), *without bundling the relocated classes themselves*. The plain, unrelocated plugin artifact serves `pulsar-client-original` / `pulsar-client-admin-original` and all server-side components, which are not shaded. Plugins targeting both client flavors should publish both artifacts (e.g. a `-shaded` classifier). PIP-337 has exactly the same constraint through `getInternalNettySslContext()`, but leaves it undocumented and unresolved; this PIP makes the requirement explicit.
+
+  A support class (**`TlsContexts`**) ships with the SPI so factories compose instead of reimplement: build a JDK `SSLContext` or Netty `SslContext` from PEM/keystore inputs or from a `KeyManagerFactory`/`TrustManagerFactory`, and wrap JDK→Netty via `JdkSslContext`. Its exact method surface is an implementation detail to be settled in code review — it is a convenience helper, not part of this PIP's SPI contract.
+
+- **`TlsPurpose`** (a value type, in `org.apache.pulsar.common.tls`) — identifies *why* TLS is requested and in what role. It is a **simple named key**, not a type hierarchy: a role (client or server), an open name, and an optional single-level fallback fixed at construction. Well-known purposes are exposed as constants; a factory serves distinct material per purpose. Instances are used as map keys, so identity matters: `equals`/`hashCode` are defined over `(role, name)` **only** — the `fallback()` is resolution metadata and is deliberately excluded, so `client("x")` and `client("x", CLIENT_DEFAULT)` address the same purpose→policy slot (including the fallback in identity would split one config key into two and cause silent lookup misses). This deliberately avoids a sealed `Client`/`Server` split, a `UsageIdentifier(Class<?>, String)` addressing dimension, a structured `host()` (SNI cert-*selection* is unused — Pulsar sets `setSniRequired(false)`), a multi-hop enum fallback *chain*, and a second `qualifier()` addressing dimension — an open name with an explicit fallback covers the same need with one dimension instead of two.
+
+  ```java
+  package org.apache.pulsar.common.tls;
+
+  public final class TlsPurpose {
+      public enum Role { CLIENT, SERVER }
+
+      public Role role();
+      /** Well-known or plugin-minted name, e.g. "default", "oauth2", "broker-client", "broker". */
+      public String name();
+      /** Purpose consulted when none is configured for this one (single level, fixed at
+       *  construction). Empty means: CLIENT role — the system default (OS trust store,
+       *  no client certificate); SERVER role — a configuration error. */
+      public Optional<TlsPurpose> fallback();
+
+      /** Mint purposes, e.g. TlsPurpose.client("oauth2.myPlugin", CLIENT_OAUTH2). */
+      public static TlsPurpose client(String name);
+      public static TlsPurpose client(String name, TlsPurpose fallback);
+      public static TlsPurpose server(String name);
+      public static TlsPurpose server(String name, TlsPurpose fallback);
+
+      // equals/hashCode are defined over (role, name) only; fallback() is excluded.
+
+      // Well-known CLIENT purposes
+      public static final TlsPurpose CLIENT_DEFAULT;  // Pulsar-cluster traffic: binary, HTTP lookup, admin
+      public static final TlsPurpose CLIENT_OAUTH2;   // OAuth2 / IdP calls — must NOT reuse cluster material
+      public static final TlsPurpose BROKER_CLIENT;   // a server component's own outbound Pulsar-client traffic:
+                                                      // replication, proxy→broker, websocket→broker, worker→broker
+      // Well-known SERVER purposes
+      public static final TlsPurpose BROKER;
+      public static final TlsPurpose PROXY;
+      public static final TlsPurpose WEB;
+  }
+  ```
+
+  Users configuring the client only ever reference client purposes, and in practice only two buckets matter: `CLIENT_DEFAULT` (all Pulsar-cluster traffic — binary protocol, HTTP topic lookup, and the admin client all resolve here) and `CLIENT_OAUTH2` for OAuth2/IdP calls, whose empty fallback resolves to the **system default** (OS trust store, no client certificate) rather than to the cluster material, since the IdP is a different trust domain. The framework may internally request finer client purposes (a dedicated binary/lookup/admin purpose), but they carry `fallback = CLIENT_DEFAULT` and so resolve there unless a deployment explicitly configures one differently. A plugin that needs its own trust domain **mints** an open-named purpose with an explicit fallback — `TlsPurpose.client("oauth2.myPlugin", CLIENT_OAUTH2)` — giving it a dedicated config key while inheriting sensible resolution.
+
+  On the server side, `BROKER` / `PROXY` / `WEB` cover the binary listeners and the web server, and `BROKER_CLIENT` covers a server component's *own outbound* Pulsar-client connections — geo-replication, proxy→broker, websocket→broker, and functions-worker→broker traffic, which today is configured through the dedicated `brokerClient*` keys (including `brokerClientSslFactoryPlugin`), a distinct trust domain from both the server listeners and any application client. Unconfigured server purposes fall back to the component's configured default server material. `BROKER_CLIENT` resolution additionally **folds the component's broker-client `Authentication` TLS material** when the plugin supplies any (`brokerClientAuthenticationPlugin=AuthenticationTls`): the plugin's in-memory cert/key override the configured `brokerClient*` file paths — the server-side mirror of the client TLS override hook, preserving the PIP-337 behavior that `PulsarSslConfiguration.authData` carried. Without the fold, a proxy would present the wrong identity to the broker and break forwarded-principal authorization. Per-advertised-listener material is deferred to the separate listener-aware broker PIP; when it lands, dotted minted names (e.g. `server("broker.internal")` with `fallback = BROKER`) are the natural additive extension — no new addressing dimension is required.
+
+  **Design decision — destination endpoint as a hint, not part of the purpose.** Three options were considered for letting TLS material vary by destination: (a) no destination in the SPI at all (the first draft's stance: material lookup never needs it); (b) *(chosen)* keep `TlsPurpose` a static key and pass the destination as an optional per-request `TlsEndpoint` hint on the one-shot `createInstance`, which factories may ignore (the default file-based factory does); (c) fold the destination into the purpose value itself. Rationale: (a) forecloses per-destination material — multi-cluster deployments and workload-identity systems that mint per-target credentials have no way to see the target — and retrofitting the parameter later would ripple through every factory; (c) would make the purpose a dynamic value, destroying its role as a stable configuration key (purpose names map to config entries — see the config-file note below). Option (b) costs one default method that simple factories never notice, and keeps the two concerns cleanly separated: the *purpose* says which trust domain, the *endpoint* says which peer within it. Hostname verification and SNI are unaffected either way — they are applied at engine creation from the same peer address by whichever component builds the `SSLEngine`, never by the factory. **Scope note:** per-endpoint material selection is a feature of the *one-shot, binary-transport* path only. Subscriptions are purpose-scoped (no endpoint overload), and `PulsarHttpClient` instances select TLS material **by purpose only** — an HTTP client instance talks to one logical service, so its trust domain is fixed at instance creation; if per-destination HTTP material is ever needed, the framework's `SslEngineFactory` already sees the peer address per engine and an endpoint-aware lookup can be added there without SPI changes.
+
+**Jetty web server integration (replacing the `getSslContext()` override).** Pulsar's current `JettySslContextFactory` subclasses Jetty's `SslContextFactory.Server` and overrides `getSslContext()` to return the rotating context on every call. That pattern is unsound: Jetty selects protocols and cipher suites at `load()` time *from the context it loads*, so with the override the selection runs against a throwaway context, handshakes use a different one, and rotation never re-runs selection — it works today only by accident (see [Appendix A: Jetty getSslContext override analysis](#appendix-a-jetty-getsslcontext-override-analysis)). v5 abandons the override entirely.
+
+The correct, documented mechanism — the same one Jetty's own `KeyStoreScanner` hot-reload module uses — is `SslContextFactory.reload(Consumer<SslContextFactory>)`: the consumer mutates the configuration under the factory's lock, then Jetty unloads and re-runs `load()`, atomically swapping the internal state and re-selecting protocols/ciphers from the new context. Under the v5 SPI there are two paths. A factory that **natively supplies** `SslContextFactory.Server` owns this itself (the obligations listed above: unstarted hand-over, same instance per purpose, internal `reload(...)` on rotation). When the factory returns `Optional.empty()` for the Jetty class — the recommended default — the **framework synthesizes** the integration: it subscribes to `javax.net.ssl.SSLContext` for the purpose via `createInstance(purpose, SSLContext.class, onLoadOrReload)`, configures a plain (non-subclassed) `SslContextFactory.Server` with `setSslContext(initialContext)` before start, and on each callback delivery runs:
+
+```java
+sslContextFactory.reload(f -> f.setSslContext(newContext));
+```
+
+Existing connections keep their negotiated sessions; new connections use the new context. One caveat: with a directly-set `SSLContext`, Jetty cannot wrap `KeyManager`s for SNI-based certificate selection — Pulsar does not use that feature (it sets `setSniRequired(false)` today), and a factory that needs it can supply a keystore-backed `SslContextFactory.Server` natively.
+
+**Default file-based factory.** `FileBasedTlsFactory` implements `PulsarTlsFactory`, natively supplying the Netty `SslContext` (on the configured engine — JDK, or OpenSSL-based where available) and the JDK `SSLContext`; it returns `empty()` for the Jetty class, which the framework synthesizes — the recommended default for every factory (see the Jetty section). It lives in **`pulsar-common`** (package `org.apache.pulsar.common.tls.impl`), not in the SPI module: `pulsar-common` already carries `netty-handler` and the `netty-tcnative` OpenSSL binding the native contexts need, while the SPI module stays dependency-light; the distinct `.impl` package keeps the SPI package single-owner. It is configured with a `TlsPolicy` per `TlsPurpose` (see below), and internally turns each policy into a **`TlsMaterialSource`** — a package-internal object that owns the runtime behavior: it polls its backing files/keystore for changes, caches the loaded material while the source is unchanged (value-equality on the loaded material suppresses spurious rebuilds when files are touched but unchanged), and notifies subscribers on change. The factory itself owns the purpose→source registry, the purpose matching and single-level fallback, and the reload fan-out to subscribers; `TlsMaterialSource` owns only the load/watch/cache of one material set. This is a clean split — `TlsPolicy` is the declarative *what* (user-facing), `TlsMaterialSource` is the runtime *how* (internal).
+
+**Immutable after construction — policies compose at build time.** `FileBasedTlsFactory` is constructed with its complete purpose→`TlsPolicy` map and never mutates it afterwards: no public reconfiguration API, no concurrency contract between reconfiguration and in-flight `createInstance` calls. The one case that must *merge* TLS configuration from two places — the v4 compatibility path, where some TLS settings come from the client builder and some from a legacy `AuthenticationTls` / `AuthenticationKeyStoreTls` plugin — is resolved by the v5 client **builder before the factory exists**: the builder extracts the plugin's material paths (see the [TLS override hook](#legacyv4authenticationadapter-v4--v5)), merges them with any builder-configured policy (plugin-supplied key/cert combines with builder-supplied trust; on a per-field conflict the plugin value wins, preserving v4's "`AuthenticationTls` overrides TLS" semantics), and constructs the factory with the final map. Mutation methods (`setPolicy`/`addPolicy`) on the factory were considered for this and rejected: their overlap-merge semantics could not be stated crisply as a public contract, and nothing needs to reconfigure TLS after the client is built — file *rotation* is not reconfiguration, it is handled inside `TlsMaterialSource`. A user who installs a fully custom `PulsarTlsFactory` configures its material directly, and the v4 bridge then has nothing to contribute.
+
+The broker's default `DefaultBrokerTlsFactory` is a thin `FileBasedTlsFactory` wrapper whose constructor takes the purpose→policy map composed from the existing `ServiceConfiguration` properties; it lives in **`pulsar-broker-common`** (which owns the Jetty integration today), keeping both the SPI module and `pulsar-common` free of broker configuration knowledge.
+
+**Client configuration: the `TlsPolicy` value.** The default client-side `PulsarTlsFactory` is wired from the client builder, and **`TlsPolicy` is the single TLS type a user ever touches** — a flat, immutable value describing *what* material to use and the policy flags. It subsumes the experimental PIP-466 `TlsPolicy` (which was PEM-only and lived in `org.apache.pulsar.client.api.v5.config`) and the internal material-source machinery; the type lives in `org.apache.pulsar.common.tls` in the neutral SPI module so the client builder and the server components consume the same value. The builder turns each `TlsPolicy` into an internal `TlsMaterialSource` and configures the `FileBasedTlsFactory` for the relevant purpose(s).
+
+To keep it friendly to a future configuration file (see below), `TlsPolicy` is a **flat value with a `format` discriminator** rather than a polymorphic hierarchy — one type covering PEM and keystore/truststore, plus the common flags, with static factories for the common shapes:
+
+```java
+package org.apache.pulsar.common.tls;
+
+public final class TlsPolicy {
+    public enum Format { PEM, KEYSTORE }
+
+    public Format format();
+    // format == PEM
+    public String trustCertsFilePath();
+    public String certificateFilePath();
+    public String keyFilePath();
+    // format == KEYSTORE
+    public String trustStorePath();
+    public String trustStorePassword();
+    public String keyStorePath();
+    public String keyStorePassword();
+    public String keyStoreType();       // JKS / PKCS12 (blank -> JDK default)
+    public String trustStoreType();     // JKS / PKCS12 (blank -> JDK default)
+    // common flags (both formats)
+    public boolean allowInsecureConnection();
+    public boolean enableHostnameVerification();
+    public List<String> protocols();    // optional
+    public List<String> ciphers();      // optional
+
+    public static TlsPolicy pem(String trustCerts, String cert, String key);
+    // keyStore(...) sets a single storeType on BOTH stores (the common case); for a mixed setup
+    // (e.g. a PKCS12 keystore with a JKS truststore) use builder().keyStoreType(..).trustStoreType(..).
+    public static TlsPolicy keyStore(String trustStore, String trustStorePw,
+                                     String keyStore, String keyStorePw, String storeType);
+    public static TlsPolicy insecure();
+    public static Builder builder();
+}
+```
+
+The tier-1 case is one expression — `builder.tlsPolicy(TlsPolicy.pem(trust, cert, key))` — applied to all client purposes. The tier-2 case binds a policy to a specific purpose — `builder.tlsPolicy(TlsPurpose.CLIENT_OAUTH2, idpPolicy)` — and unconfigured purposes fall back to `CLIENT_DEFAULT` (or, for `CLIENT_OAUTH2`, to the system default). `TlsPolicy` describes material *locations*, not the loaded material, so it stays a small serializable value; the loading, caching, and rotation are the internal `TlsMaterialSource`'s job.
+
+**Config-file (de)serialization (out of scope, but accommodated).** Some deployments keep client configuration in a properties or JSON file rather than building it programmatically. Wiring a config-file loader for the v5 client is out of scope for this PIP, but it shapes one decision here: keeping `TlsPolicy` a flat, discriminated value (and `TlsPurpose` a plain named key usable as a config key) means it can later map cleanly to flat keys (e.g. `tls.default.trustCertsFilePath=…`, `tls.oauth2.trustStorePath=…`) without polymorphic type-tag handling.
+
+**Custom factories** implement `PulsarTlsFactory` directly and may externalize the entire TLS configuration (e.g. to a KMS). A custom factory that still uses files can reuse the internal file-watching `TlsMaterialSource` for load/cache/rotation, and the `TlsContexts` helper for building the well-known instance classes. The same implementation can serve both client and broker sides, or differ between them (a server-side KMS integration often differs from the client-side one).
+
+**Removal.** The existing v4 `org.apache.pulsar.common.util.PulsarSslFactory` and `PulsarSslConfiguration` are removed completely — an intentional breaking change. Because the SPI now answers ready-built TLS objects per purpose (rotation is factory-internal, surfaced through the reload callbacks), the `org.apache.pulsar.common.util.keystoretls.KeyStoreSSLContext` class is no longer needed either; the default file-based factory reads keystores (PKCS12/JKS) directly for the private key, key-cert chain, and trust certificates. PIP-337 is not broadly used, so it is removed rather than retained alongside the new SPI.
+
+The internal TLS utility layer is decomposed at the same time, applying this PIP's own anti-kitchen-sink philosophy to the helpers: the generic `org.apache.pulsar.common.util.SecurityUtility` grab-bag is **removed**, its surviving primitives split into cohesive single-concern containers under `org.apache.pulsar.common.util.tls` — `PemReader` (PEM certificate/key parsing), `JcaProviders` (Bouncy Castle / Conscrypt provider resolution), and `JdkSslContexts` (JDK `SSLContext` assembly). The delegate-swap rotation helpers `org.apache.pulsar.common.util.TrustManagerProxy` / `KeyManagerProxy` — and `SecurityUtility.createAutoRefreshSslContextForClient`, their only caller — are **removed as obsolete**: the rebuild-the-context rotation model described next is precisely why they are no longer needed (see [Appendix B](#appendix-b-delegate-swap-rotation-and-netty-openssl)). Also removed with `SecurityUtility` are its unused Netty context-builder helpers (`createNettySslContextForClient` / `createNettySslContextForServer`), the per-connection `configureSSLHandler` (hostname verification is now baked into the built context, not re-applied per connection), and — superseding the earlier decision to leave it in place — the unused `org.apache.pulsar.common.util.keystoretls.SSLContextValidatorEngine`. This layer carries no `@InterfaceStability` annotation and has no client-API importer, so its decomposition and removal are internal-only and not a public-API break.
+
+**Rotation model: rebuild the context, don't mutate behind a stable one.** The reload callback hands consumers a freshly built `SslContext` / `SSLContext` on each rotation, rather than keeping one context alive and swapping new material in behind mutable delegates — the approach of `org.apache.pulsar.common.util.TrustManagerProxy` / `KeyManagerProxy`. The delegate-swap pattern interacts badly with Netty's **OpenSSL** provider in three verified ways: a custom `KeyManager` forfeits the native/caching key-manager factories and requires an *extractable* private key, ruling out HSM/PKCS#11 keys — the very case this PIP targets; a mid-handshake delegate swap can race alias selection against material fetch; and a server's advertised client-CA list (the TLS *CertificateRequest*) is written into the native context once at build and never follows the swap. Rebuilding the whole context avoids all three, and its cost — one build per rotation rather than per connection — is negligible. The detailed analysis is in [Appendix B: delegate-swap rotation and Netty OpenSSL](#appendix-b-delegate-swap-rotation-and-netty-openssl).
+
+### `LegacyV4AuthenticationAdapter` (v4 → v5)
+
+Wraps an arbitrary v4 `Authentication` instance as a v5 `Authentication`. Selects the plugin's style by its advertised **auth-method name** — `"tls"` → `LegacyV4TlsAdapter`, `"sasl"` → `LegacyV4ChallengeResponseAdapter`, anything else → `LegacyV4CredentialAdapter` — and declares the matching v5 capability. Routing is deliberately by name, not by probing `has*()`: probing would run v4 credential I/O on the caller thread, breaking the PIP-478 offload discipline. The `has*()` methods are consulted only *post-start*, on the blocking executor, to decide which single-pass capabilities the credential adapter actually advertises:
+
+```java
+package org.apache.pulsar.client.impl.v5.auth;
+
+public abstract class LegacyV4AuthenticationAdapter implements Authentication {
+
+    protected final org.apache.pulsar.client.api.Authentication v4;
+    protected AuthenticationInitContext ctx;
+
+    /**
+     * Wraps {@code v4} and returns an instance that declares the right
+     * capability interfaces for its style — typically
+     * {@link BinaryAuthDataProvider} (+ {@link HttpAuthHeadersProvider})
+     * for one-pass plugins (Token, Basic, OAuth2, Athenz) or
+     * {@link BinaryAuthChallengeHandler} for SASL.
+     * Plugins reporting {@code hasDataForTls() == true} have their TLS material
+     * registered with the client's {@link PulsarTlsFactory} by the bridge
+     * and are represented by the built-in {@link TlsAuthentication} plugin (see "TLS
+     * override hook" below).
+     */
+    public static Authentication wrap(org.apache.pulsar.client.api.Authentication v4);
+
+    @Override public void configure(Map<String,String> p) { v4.configure(p); }
+    @Override public CompletableFuture<Void> initializeAsync(AuthenticationInitContext c);
+    @Override public void close() throws Exception;
+}
+```
+
+Internally, the concrete subclasses cover the cases:
+
+- `LegacyV4CredentialAdapter implements BinaryAuthDataProvider, HttpAuthHeadersProvider` — the default for any plugin whose method name is neither `"tls"` nor `"sasl"` (e.g. `AuthenticationToken`). *Post-start*, on the blocking executor, it probes the started plugin's `hasDataFromCommand()` / `hasDataForHttp()` and advertises (via `capability(...)`) only the single-pass capabilities the plugin actually supports; it renders the credential into binary bytes (`v4.getAuthData(host).getCommandData()`) and/or HTTP headers (`getHttpHeaders()`).
+- `LegacyV4ChallengeResponseAdapter implements BinaryAuthDataProvider, BinaryAuthChallengeHandler` — selected for the method name `"sasl"`. It produces the initial frame via `getAuthDataAsync(...)` and routes binary challenges through `respondToChallengeAsync(...)`, driving the v4 `authenticate(AuthData)` method across rounds (the per-exchange v4 provider is kept in the call-context state slot). **Consequence of name-based routing:** a third-party challenge-response plugin whose method name is *not* `"sasl"` is routed to the credential adapter instead, so its multi-round `authenticate(AuthData)` flow is not driven — a known limitation of bridging arbitrary v4 challenge-response plugins.
+
+The v4 `Authentication.authenticationStage(...)` HTTP multi-round hook is **not** carried through the bridge. The built-in SASL plugin never needs it there — it becomes v5-native under the internal migration (in-scope item #7) and implements `HttpAuthChallengeHandler` directly. A *third-party* v4 plugin that drives HTTP challenge/response through `authenticationStage(...)` is explicitly unsupported on the v5 path (it keeps working unchanged on the v4 client API); bridging it would mean reproducing the v4 plugin-driven resubmit loop inside the v5 driver, and no such third-party plugin is known to exist.
+- `LegacyV4TlsAdapter extends TlsAuthentication` — selected for the method name `"tls"` (the built-in `AuthenticationTls` / `AuthenticationKeyStoreTls`). It reuses the built-in `TlsAuthentication` plugin (so the binary protocol sends `auth_method_name=tls`), and the builder folds the plugin's TLS material into the client's TLS configuration — see the TLS override hook below.
+
+Three invariants apply across all adapters:
+
+1. **Always offload to a separate executor (`ctx.blockingExecutor()`).** Even calls to "fast" v4 implementations like `AuthenticationToken.getAuthData()` go through this dedicated executor rather than the scheduler, so a slow or blocking v4 plugin cannot tie up the scheduler's threads or the Netty event loop. The cost is a thread hop, but the simplicity is worth it: the adapter has no class-name allow-list, no per-impl heuristics, and no production hazard from a misclassified plugin.
+2. **Translate v4 exceptions.** Any `org.apache.pulsar.client.api.PulsarClientException` thrown by the v4 call is wrapped in the v5 `org.apache.pulsar.client.api.v5.PulsarClientException` and used to complete the returned future exceptionally.
+3. **Refresh is the plugin's concern.** The framework has no built-in refresh; proactive renewal and token reuse are internal to the authentication implementation. A short-lived-credential plugin (e.g. `AuthenticationOAuth2`, `AuthenticationAthenz`) renews its credential internally and returns the current one whenever the framework next calls its async credential method — and the broker's `CommandAuthChallenge` refresh sentinel simply triggers that same call. The legacy adapter therefore just re-invokes the wrapped v4 plugin per request; no refresh metadata crosses the capability surface.
+
+**TLS override hook.** When the v5 client builder is asked to use a v4 plugin that reports `hasDataForTls() == true` (notably the v4 `AuthenticationTls` and `AuthenticationKeyStoreTls` classes, or any third-party equivalent), the bridge does two things during client construction: (1) it **contributes** the plugin's TLS material to the client's TLS configuration — the builder merges it into the purpose→policy map for the relevant client purposes *before* constructing the default `FileBasedTlsFactory` (see the build-time composition note in [`PulsarTlsFactory`](#redesigned-pip-337-ssl-provider-pulsartlsfactory)), rather than mutating or replacing a factory the user may have configured — and (2) it represents the connection's authentication with the built-in `TlsAuthentication` plugin so the binary protocol sends `auth_method_name=tls`. There is no material-extraction hook on the adapter: `LegacyV4AuthenticationAdapter.unwrapV4(...)` recovers the wrapped v4 plugin, and the v5 client builder itself does the inspection — it reads the built-in `AuthenticationTls` / `AuthenticationKeyStoreTls` fields directly, and probes an arbitrary third-party plugin via `hasDataForTls()` — then merges the **file-based** PEM paths or keystore into the purpose→policy map, logging a `WARN` when the plugin's material is only in-memory and so cannot be represented as a file-based `TlsPolicy`.
+
+This preserves v4's "`AuthenticationTls` is an `Authentication` that overrides TLS" semantics for source compatibility, now expressed cleanly as builder-level TLS material **plus** the built-in `TlsAuthentication` plugin.
+
+### `ClientCnx` async-driver carve-out (generic, not SASL-specific)
+
+The v5 client wraps the v4 transport (per PIP-466), so the practical change is twofold:
+
+1. `V5ToV4AuthenticationAdapter` exposes the v4 `Authentication` interface that `ClientCnx` already drives.
+2. A new public interface `org.apache.pulsar.client.api.internal.AsyncAuthenticationDriver` (in `pulsar-client-api`) lets `ClientCnx` detect when the wrapped authentication supports an async path. It is **exchange-scoped**: the driver hands `ClientCnx` an `AuthenticationExchange` for one connection attempt, and every round of that connect is driven through the single exchange object:
+
+```java
+package org.apache.pulsar.client.api.internal;
+
+public interface AsyncAuthenticationDriver {
+    // One exchange per connection attempt; ClientCnx drives every round through it.
+    AuthenticationExchange newAuthenticationExchange(String brokerHostName);
+
+    interface AuthenticationExchange {
+        CompletableFuture<AuthData> getAuthDataAsync();                       // initial connect
+        CompletableFuture<AuthData> authenticateAsync(AuthData challenge);           // ordinary challenge round; the REFRESH sentinel never reaches the exchange
+    }
+}
+```
+
+The `.internal.` subpackage signals "stable internal — application code should not implement this." `ClientCnx` calls `newAuthenticationExchange(brokerHostName)` once per connection attempt and drives that connect through the returned exchange — the initial credential via `getAuthDataAsync()` and every ordinary `CommandAuthChallenge` round via `authenticateAsync(...)`. The broker's REFRESH sentinel is **not** driven through the current exchange: `ClientCnx` terminates it and opens a **fresh** exchange whose `getAuthDataAsync()` re-produces the credential (binary routing rule 2), so conversation state does not survive a REFRESH. **Exchange scoping matches the state slot's lifetime.** An authentication's per-connection conversation state — for the v4↔v5 bridge, one `AuthenticationCallContext` and its state slot — lives exactly one *exchange*, so the driver hands `ClientCnx` an object that *owns* that state for the duration of the exchange, rather than re-deriving it from a host argument on each call. (This supersedes an earlier two-method, host-keyed listing — `getAuthDataAsync(String)` / `authenticateAsync(AuthData, String)` — under which the bridge allocated a fresh call context per call and so lost challenge-response state across rounds.) `ClientCnx.newConnectCommand()` and `ClientCnx.handleAuthChallenge(...)` check `authentication instanceof AsyncAuthenticationDriver async` and route through the exchange when present; a fresh exchange is created per connection attempt (and when `ClientCnx` restarts authentication on the REFRESH sentinel), so concurrent handshakes never share state. **Generic across all challenge types** — connect, REFRESH, SASL multi-round, custom challenge-response. The marker is the only carve-out from the otherwise-untouched v4 client.
+
+The async and sync handling are **one state machine, not two parallel paths**: credential resolution produces a `CompletableFuture<AuthData>` (already-completed for a sync plugin, computed inline; pending for an async driver), feeding a single continuation that performs every side effect the sync path performs today — assigning the connection's `authenticationDataProvider` (on connect *and* on the REFRESH sentinel), building the command, transitioning connection state, writing, and completing the connection future. The continuation runs inline when the future is already done (preserving today's sync behaviour verbatim) and hops to the channel's event executor only when it was pending. This single-assignment-site structure is a hard requirement: splitting into a *duplicated* async path risks silently dropping the `authenticationDataProvider` assignment. Two invariants are acceptance criteria, enforced by pre-existing tests on master: the connection's `authenticationDataProvider` observable (`getCommandData()`) must reflect the refreshed credential, and a broker-pushed refresh must not disconnect (`getLastDisconnectedTimestamp()` unchanged — see `TokenOauth2AuthenticatedProducerConsumerTest.testOAuth2TokenRefreshedWithoutReconnect`). Failures from the async path are unwrapped (`CompletionException` never leaks) to the matching v4 `PulsarClientException` subtype before failing the connection future.
+
+When `authentication` is a plain v4 instance (not `AsyncAuthenticationDriver`), `ClientCnx` preserves the existing sync path verbatim — no behavioral change for v4-only callers.
+
+After the v4 internal migration (in-scope item #7) completes, the **credential-fetching** built-in v4 classes (Token, Basic, OAuth2, Athenz, SASL) keep their v4 synchronous surface verbatim and **additively** expose `AsyncAuthenticationDriver`; each hands `ClientCnx` an exchange that drives a v5-native body through `V5BinaryAuthenticationDriver` (in `pulsar-client`, `org.apache.pulsar.client.impl.auth.v5`), so even users of v4 `PulsarClient` get the async path automatically for the plugins where it matters — the ones that perform credential I/O (Motivation #1). The **no-credential-I/O** built-ins (`AuthenticationDisabled`, `AuthenticationTls`, `AuthenticationKeyStoreTls`) intentionally stay on the verbatim sync path: async buys them nothing, and keeping the default no-auth hot path synchronous avoids routing every connect through the executor machinery. `V5BinaryAuthenticationDriver` shares the same `BinaryAuthenticationExchange` as the v5-builder-path `V5ToV4AuthenticationAdapter` (`pulsar-client-v5`), so on this v4-facing path v5 auth exceptions are mapped **back** to the corresponding v4 `org.apache.pulsar.client.api.PulsarClientException` subtypes — v4 exception types are part of the public API and must be preserved for v4 callers (see the Error model).
+
+### HTTP multi-round auth drivers
+
+The binary protocol runs its multi-round loop in one place (`ClientCnx`, above). HTTP is reached through two client APIs — the JAX-RS (Jersey) admin client and the raw-AsyncHttpClient HTTP-lookup client, both over the same AsyncHttpClient transport — so the `401`→resubmit→`200` loop is implemented as one framework-side **driver** (a single shared state machine behind a thin request/response adapter per client API) rather than inside the plugin (the v4 hazard the [Transport B](#transport-b--httphttps-rest-api-admin-client-http-topic-lookup) note describes). The driver detects the challenge style by asking the plugin for the corresponding capability — today only `capability(HttpAuthChallengeHandler.class)` — surfaces each server challenge through `HttpAuthCallContext.serverChallengeHeaders()`, and attaches the plugin's computed headers to the resubmitted request. The SASL driver reproduces v4 behaviour exactly, including re-issuing the exchange as a `GET` to the original URI.
+
+**Bounded exchange (normative).** The driver enforces limits so a misbehaving server or plugin cannot loop or hang: at most a fixed number of challenge rounds per request (`HttpAuthenticationDriver.MAX_CHALLENGE_ROUNDS`, a `public static final int` = 10), and the *original request's* timeout budget covers the whole exchange — challenge rounds do not reset it. A plugin failure (the handler's future completing exceptionally) fails the request with that error; the driver never retries plugin failures — any retry is the caller's ordinary request-retry policy applied to the whole request. Request replay: the SASL style sidesteps body replay entirely because the exchange is re-issued as a bodiless `GET` to the original URI (the v4 takeover, preserved); a future standard-style driver must define non-replayable-body behaviour before it ships. The standard `WWW-Authenticate` style is a documented future extension, not shipped API — see [Resolved design decisions](#resolved-design-decisions).
+
+### Class-name compatibility and the v4 internal migration
+
+`authPluginClassName` strings in `ClientConfigurationData` continue to work without modification:
+
+- The existing v4 class names (`org.apache.pulsar.client.impl.auth.AuthenticationToken`, `AuthenticationTls`, `AuthenticationOAuth2`, `AuthenticationAthenz`, `AuthenticationBasic`, `AuthenticationSasl`, `AuthenticationDisabled`, plus the v4 `AuthenticationKeyStoreTls`) are retained.
+- **After the v4 internal migration (in-scope item #7)**, each of those classes keeps its v4 synchronous surface **verbatim** and *additively* implements the async binary driver; it does **not** route its existing sync methods through a v5 delegate. The v5-native body is constructed only when the async path is entered. The migrated `AuthenticationToken` illustrates the shape:
+  ```java
+  public class AuthenticationToken
+          implements org.apache.pulsar.client.api.Authentication,
+                     AsyncAuthenticationDriver, ClientAuthenticationServicesAware {
+      // v4 sync surface — unchanged from before this PIP:
+      @Override public String getAuthMethodName() { return "token"; }
+      @Override public void configure(String params)          { /* parse the token locally, as before */ }
+      @Override public void configure(Map<String,String> p)   { /* no-op, as before */ }
+      @Override public void start()                           { /* no-op — no eager I/O */ }
+      @Override public AuthenticationDataProvider getAuthData() {
+          return new AuthenticationDataToken(tokenSupplier);   // built directly — verbatim v4
+      }
+      // PIP-478, additive: bind the framework's late-bound services, then drive the async binary path.
+      @Override public void bindClientAuthenticationServices(ClientAuthenticationServices s) { this.authServices = s; }
+      @Override public AuthenticationExchange newAuthenticationExchange(String brokerHostName) {
+          // The v5-native body is constructed HERE, only for the async binary path.
+          return new V5BinaryAuthenticationDriver(new TokenAuthenticationV5(tokenSupplier), authServices)
+                  .newAuthenticationExchange(brokerHostName);
+      }
+  }
+  ```
+  So the v5-native body (`TokenAuthenticationV5`) drives **only** the non-blocking binary path — via `V5BinaryAuthenticationDriver`, whose `ensureInitialized()` calls the body's `initializeAsync(...)` lazily on first use — while the v4 sync methods that predate this PIP are untouched. For the HTTP-capable built-ins (SASL over HTTP), the v5-native body additionally drives the framework's HTTP multi-round loop through the `AsyncHttpAuthenticationProvider` seam and the shared `HttpAuthenticationDriver`, rather than a per-class `authenticationStage(...)` hook.
+- The v4 `AuthenticationTls` / `AuthenticationKeyStoreTls` are also shims, but rather than wrapping a v5 auth they surface their configured paths/keystore to the client builder, which merges them into the `FileBasedTlsFactory`'s purpose→policy map at client construction (the build-time composition above), and use the built-in `TlsAuthentication` plugin so the binary protocol sends `auth_method_name=tls`.
+- **OAuth2 and Athenz invert the body direction — deliberately.** For the two credential-acquisition-heavy plugins the additive-driver shape above is reversed: rather than the v5-native body owning credential acquisition (as `TokenAuthenticationV5` does for the token above), the battle-tested provider-integration machinery is *not* reimplemented on the v5 side. `AuthenticationOAuth2` keeps its OAuth2 flow, early-refresh scheduling, and token cache (`Flow`/`FlowBase`); `AuthenticationAthenz` keeps its ZTS client (on the Athenz SDK transport) and role-token cache. The matching v5 bodies (`OAuth2AuthenticationV5`, `AthenzAuthenticationV5`) are thin *readers* that simply return the current credential the v4 layer supplies through an access-token / role-token `Supplier`. This is a reuse-not-duplicate choice: it exposes the v5 async capability surface — so both v4- and v5-`PulsarClient` users get off-loaded, non-event-loop-blocking credential I/O (Motivation #1) — without forking hard-won provider logic. It is why this PIP speaks of these plugins gaining the *async path*, not of a self-sufficient v5-native reimplementation of OAuth2/ZTS.
+- Third-party class names (or v4 classes without a v5-native equivalent) go through `LegacyV4AuthenticationAdapter` unchanged.
+- `AuthenticationFactory.create(authPluginClassName, authParamsString)` and `AuthenticationFactory.create(authPluginClassName, Map<String,String>)` continue to instantiate via `AuthenticationUtil.create()`, unchanged.
+
+The two configuration paths (programmatic vs string-based) both work for the v4 surface:
+
+- **Programmatic**: `new AuthenticationToken(jwt)` — the constructor stores the JWT exactly as before, and `getAuthData()` still serves it synchronously. The v5-native `TokenAuthenticationV5` is created lazily, only when `ClientCnx` first opens an async exchange; `start()` remains a no-op (no eager I/O).
+- **String-based**: `AuthenticationUtil.create("...AuthenticationToken", "{...}")` — reflection invokes the no-arg constructor, then `configure(params)` runs the class's own (verbatim v4) parsing. `start()` remains a no-op; the async body is initialized on first use inside `V5BinaryAuthenticationDriver`, not from `start()`.
+
+### Error model
+
+A blanket contract applies to **every** future-returning method introduced by this PIP (`Authentication`, the capability interfaces, `PulsarTlsFactory`, `PulsarHttpClient`): failures — including argument validation and build errors — are reported by completing the returned future exceptionally; the method itself never throws synchronously (Pulsar's async convention; a synchronous throw on a Netty event loop is exactly the class of bug this PIP exists to remove).
+
+All async failures complete the returned `CompletableFuture` exceptionally with a v5 `org.apache.pulsar.client.api.v5.PulsarClientException`. The relevant subclasses for auth are:
+
+- `AuthenticationException` — terminal authentication failure (rejected credential, untrusted certificate). Connection is failed.
+- `GettingAuthenticationDataException` — transient failure during credential acquisition (token endpoint timeout, ZTS unavailable). The caller may retry; the v5 connection layer treats this the same way it treats network errors.
+- `UnsupportedAuthenticationException` — the requested capability is not supported by the wrapped impl (used by `LegacyV4AuthenticationAdapter` when a v4 provider returns null/false from the corresponding `hasData*` method).
+
+Translation runs in **both** directions, since v4 and v5 exception types are both public API:
+
+- **v4 → v5** — `LegacyV4AuthenticationAdapter` wraps any v4 `org.apache.pulsar.client.api.PulsarClientException` thrown by a wrapped v4 plugin onto the v5 subclasses above.
+- **v5 → v4** — on the v4-facing path (`V5ToV4AuthenticationAdapter` and the built-in v4 shims), v5 auth exceptions are mapped back to the matching v4 `PulsarClientException` subtypes so v4 callers see the exceptions they always have. This is a straightforward one-to-one mapping (v5 `AuthenticationException` → v4 `AuthenticationException`, and so on) that introduces no behavioural change; the acceptance criterion is that the existing v4 authentication tests pass unmodified after the migration.
+
+## Public-facing Changes
+
+### Public API
+
+New public types introduced by this PIP:
+
+- `org.apache.pulsar.client.api.v5.auth` — `Authentication` (replacing the PIP-466 sync stub); capability interfaces `BinaryAuthDataProvider`, `HttpAuthHeadersProvider`, `BinaryAuthChallengeHandler`, `HttpAuthChallengeHandler`; the convenience composite `SinglePassAuthentication`; the static `AuthenticationFactory` (token/tls/create entry points); contexts `AuthenticationInitContext`, `AuthenticationCallContext`, `HttpAuthCallContext`; value types `BinaryAuthData`, `HttpAuthHeaders`, `AuthChallenge`, `ChallengeResponse`; exceptions `AuthenticationException`, `GettingAuthenticationDataException`, `UnsupportedAuthenticationException`.
+- `org.apache.pulsar.client.api.v5.http` — `PulsarHttpClient`, `PulsarHttpClientFactory`, `PulsarHttpClientConfig`, `ProxyConfig` (the proxy value type returned by `PulsarHttpClientConfig.proxy()`), `HttpRequest`, `HttpResponse`. Hosted in the new neutral **`pulsar-common-api`** module (see [Resolved design decisions](#resolved-design-decisions)); `pulsar-client-api-v5` depends on it.
+- `org.apache.pulsar.common.tls` (in `pulsar-common-api`) — the SPI: `PulsarTlsFactory` with the `TlsHandle` handle and `TlsFactoryInitContext`; the `TlsPurpose` named-key value type and the `TlsEndpoint` destination hint; the flat `TlsPolicy` value (PEM and keystore, via a `format` discriminator — the single user-facing TLS type, consumed by the client builder and the server components alike). (The well-known instance classes are `io.netty.handler.ssl.SslContext`, Jetty's `SslContextFactory.Server`, and the JDK `javax.net.ssl.SSLContext` fallback plus its optional `javax.net.ssl.SSLParameters` engine-policy companion. The two non-JDK ones remain `compileOnly`-style optional references for factories; custom factories targeting the shaded client must publish a relocated artifact, see the shading note in the Detailed Design. The `SSLContext`/`SSLParameters` fallbacks carry no non-JDK dependency.)
+- `org.apache.pulsar.common.tls.impl` (in `pulsar-common`) — `FileBasedTlsFactory`, the `TlsContexts` build-support helper, and the internal `TlsMaterialSource`; `pulsar-common` already carries the Netty engine dependencies these need. `DefaultBrokerTlsFactory` lives in `pulsar-broker-common`.
+- `org.apache.pulsar.client.api.internal` — `AsyncAuthenticationDriver` (observed by `ClientCnx`; application code should not implement it).
+- `org.apache.pulsar.client.api.v5.internal` (in `pulsar-client-api-v5`) — `ClientAuthenticationServices` and `ClientAuthenticationServicesAware`, the "stable internal" seam through which the framework late-binds its runtime services (scheduler, bounded blocking executor, HTTP client factory, client instance id) into an authentication driver after the `PulsarClient` is constructed. The `.internal.` subpackage marks them framework-driven — application code neither implements nor consumes them.
+- `pulsar-client-v5` (`org.apache.pulsar.client.impl.v5.auth`) — the built-in `TlsAuthentication` mTLS plugin, and the compatibility adapters `LegacyV4AuthenticationAdapter` and `V5ToV4AuthenticationAdapter`.
+
+Dependency note: the v4 `pulsar-client` module gains an `api` dependency on `pulsar-client-api-v5`, because the migrated built-in v4 plugins delegate to v5-native bodies (in-scope item #7). The shaded v4 artifacts consequently bundle the v5 auth API classes — unrelocated, as they are Pulsar's own API packages.
+
+Removed: `org.apache.pulsar.common.util.PulsarSslFactory`, `PulsarSslConfiguration`, and `org.apache.pulsar.common.util.keystoretls.KeyStoreSSLContext` (intentional breaking change — see Backward & Forward Compatibility). Also removed, but **internal-only** (no `@InterfaceStability`, no client-API importer — not a compatibility break): the `org.apache.pulsar.common.util.SecurityUtility` grab-bag (decomposed into the cohesive `PemReader` / `JcaProviders` / `JdkSslContexts` containers), the obsolete `TrustManagerProxy` / `KeyManagerProxy` delegate-swap rotation helpers, and the unused `SSLContextValidatorEngine` — see *Removal* in the Detailed Design.
+
+### Binary protocol
+
+No new wire-protocol commands. The existing `CommandConnect`, `CommandAuthChallenge`, and `CommandAuthResponse` are used unchanged.
+
+### Configuration
+
+**Server-side (new keys, replacing the PIP-337 keys).** Each server component gains a pair of keys naming and parameterizing its `PulsarTlsFactory`:
+
+- Broker `ServiceConfiguration`: `tlsFactoryClassName` (default: blank — a blank value has the framework build the built-in `DefaultBrokerTlsFactory`) + `tlsFactoryConfig` for the listener/web purposes, and `brokerClientTlsFactoryClassName` + `brokerClientTlsFactoryConfig` for the broker's own outbound clients (the `BROKER_CLIENT` purpose).
+- Proxy `ProxyConfiguration`, the WebSocket service configuration, and the functions-worker `WorkerConfig`: the same pattern. (The websocket service and the functions worker hard-instantiate the PIP-337 default factory today; they gain factory pluggability for the first time.)
+
+These keys are the successors of PIP-337's `sslFactoryPlugin` / `sslFactoryPluginParams` / `brokerClientSslFactoryPlugin` / `brokerClientSslFactoryPluginParams`; the disposition of every removed key is inventoried under [PIP-337 removal impact](#pip-337-removal-impact).
+
+**v5 client builder.** Gains `tlsFactory(PulsarTlsFactory)` to supply a custom factory instance (adopted — closed with the client), and `tlsPolicy(TlsPolicy)` / `tlsPolicy(TlsPurpose, TlsPolicy)` to configure one or more `TlsPolicy` values — each covering cert/key/trust paths or a keystore, ciphers/protocols, and hostname-verification / insecure-connection flags — bound to a `TlsPurpose` (defaulting to all client purposes). The simple file-based case is a single builder-level value, subsuming the PIP-466-era experimental `TlsPolicy` (see the Detailed Design).
+
+**v4 configuration path.** The v4 string-config path (`ClientConfigurationData`, `PulsarAdminBuilder`) cannot select a custom v5 `PulsarTlsFactory` — custom factories are a v5-builder (and server-config) feature. v4 applications keep their existing `tls*` file/keystore settings, which the internal migration maps onto the default factory (see the v4 mapping under [PIP-337 removal impact](#pip-337-removal-impact)).
+
+### CLI
+
+No new CLI commands. The `pulsar-testclient` flags `--ssl-factory-plugin` / `--ssl-factory-plugin-params` are removed with PIP-337 (the perf tools follow the client).
+
+### Metrics
+
+New OpenTelemetry instruments:
+
+| Instrument | Type | Attributes | Description |
+|---|---|---|---|
+| `pulsar.tls.reload` | counter | `purpose`, `result` (`success`/`failure`) | TLS material load/reload attempts per purpose, client and server side |
+| `pulsar.tls.last_reload_success` | gauge (unix time) | `purpose` | Time of the last successful load/reload — lets alerts catch silently-failing rotation long before certificates expire |
+| `pulsar.client.auth.credential.duration` | histogram | `auth_method` | Latency of async credential acquisition (`getAuthDataAsync` / `getHttpHeadersAsync`) |
+| `pulsar.client.auth.failure` | counter | `auth_method`, `error` (`terminal`/`transient`) | Authentication failures by error class (matches the error model) |
+
+`PulsarHttpClient` request metrics ride on the OpenTelemetry handle already exposed through `AuthenticationInitContext.openTelemetry()`; no bespoke HTTP-metrics API is introduced.
+
+### PIP-337 removal impact
+
+`PulsarSslFactory`, `PulsarSslConfiguration`, `DefaultPulsarSslFactory`, and `KeyStoreSSLContext` are removed (see *Removal* in the Detailed Design). Be explicit about what this means operationally: deployment automation that sets the removed server config keys or testclient flags **will fail at startup, loudly and by design** — a 5.0 major-release break chosen over silently ignoring security-relevant settings, and over carrying a PIP-337 adapter for another release (rejected: the adapter would preserve exactly the maintenance burden and kitchen-sink surface this PIP removes, for a plugin population the project believes is near-zero). The public surface that exposes them today, and each item's disposition:
+
+| Existing surface | Where | Disposition in 5.0 |
+|---|---|---|
+| `sslFactoryPlugin`, `sslFactoryPluginParams` | broker `ServiceConfiguration` | Removed from operation; replaced by `tlsFactoryClassName` / `tlsFactoryConfig` (see Configuration). The fields themselves are retained as `@Deprecated` solely so a stale configuration is *detected*: startup fails with an actionable error when a key is set to a non-default value (deleting the fields would make stale configs silently ignored by the config loader — the opposite of the intent) |
+| `brokerClientSslFactoryPlugin`, `brokerClientSslFactoryPluginParams` | broker `ServiceConfiguration` | Same mechanism; replaced by `brokerClientTlsFactoryClassName` / `brokerClientTlsFactoryConfig` |
+| the same four keys | `ProxyConfiguration` | Same treatment as the broker |
+| hard-instantiated `DefaultPulsarSslFactory` | websocket `ProxyServer`, functions-worker `WorkerServer` | Replaced by the default factory wiring; both components gain the new factory keys |
+| `ClientBuilder.sslFactoryPlugin(String)` / `sslFactoryPluginParams(String)` | **v4 public client API** | **Retained, deprecated, non-functional**: setting a non-default value fails client build with an error pointing at the v5 migration. Removing the methods would break v4 source compatibility; silently ignoring a security-relevant setting is worse — failing loudly is the only safe disposition |
+| `PulsarAdminBuilder.sslFactoryPlugin(...)` / `sslFactoryPluginParams(...)` | v4 public admin API | Same treatment as `ClientBuilder` |
+| `ClientConfigurationData.sslFactoryPlugin` / `sslFactoryPluginParams` | v4 client config | Same; the field default no longer references the removed `DefaultPulsarSslFactory` class |
+| `ClusterData.brokerClientSslFactoryPlugin` / `...Params` | admin API + **serialized cluster metadata** | Fields **retained and deprecated** so cluster metadata written by 4.x still deserializes. A **custom** per-cluster factory value **fails loudly** at cluster-client / cluster-admin creation with a migration message — silently building file-based TLS would downgrade that cluster's broker-client identity/trust on upgrade — while a blank or the removed-default's FQCN is tolerated (it maps to the same file-based TLS the new path builds). Per-cluster TLS *material* (the existing `brokerClientTls*` fields on `ClusterData`) keeps working — each outbound replication client owns a factory built from its own configuration, which already carries that cluster's material, so no shared-factory purpose minting is needed; factory-class selection becomes broker-level |
+| `pulsar-admin clusters` `--tls-factory-plugin` / `--tls-factory-plugin-params` options | `CmdClusters` CLI | Retained and deprecated (they write the retained-but-ignored `ClusterData` fields above; removing the flags would break scripts for no gain); the option help states they have no effect since 5.0 |
+| `--ssl-factory-plugin`, `--ssl-factory-plugin-params` | `pulsar-testclient` CLI | Removed |
+
+**Component → purpose mapping.** Every current `PulsarSslFactory` consumer and the `TlsPurpose` its TLS resolves to after migration:
+
+| Component / connection | Purpose |
+|---|---|
+| Broker binary listener(s) | `BROKER` |
+| Broker web service (Jetty) | `WEB` |
+| Broker outbound: geo-replication clients, cluster-internal admin/lookup clients | `BROKER_CLIENT` (per-cluster material: `broker-client.<cluster>`) |
+| Proxy binary front-end | `PROXY` |
+| Proxy web service / `AdminProxyHandler` outbound Jetty client | `WEB` / `BROKER_CLIENT` |
+| Proxy → broker binary connections | `BROKER_CLIENT` |
+| WebSocket service listener / its internal Pulsar client | `WEB` / `BROKER_CLIENT` |
+| Functions-worker web server / its Pulsar + admin clients | `WEB` / `BROKER_CLIENT` |
+| Application client: binary protocol, HTTP lookup, admin | `CLIENT_DEFAULT` |
+| OAuth2 / IdP HTTP calls | `CLIENT_OAUTH2` |
+| `pulsar-perf` / testclient tools | `CLIENT_DEFAULT` |
+
+**v4 client `tls*` settings.** The ~15 `tls*` fields on `ClientConfigurationData` (`tlsKeyFilePath`, `tlsCertificateFilePath`, `tlsTrustCertsFilePath`, the `tlsKeyStore*` / `tlsTrustStore*` family, `tlsCiphers`, `tlsProtocols`, `tlsAllowInsecureConnection`, `tlsHostnameVerificationEnable`, `useKeyStoreTls`) all continue to work: the internal migration maps them onto a `TlsPolicy` bound to `CLIENT_DEFAULT`. The v4 `tlsKeyStoreType` and `tlsTrustStoreType` are mapped onto **separate** `TlsPolicy.keyStoreType()` / `trustStoreType()` fields (not collapsed into one), preserving v4 parity for a mixed setup such as a PKCS12 keystore with a JKS truststore; the same holds for the server-side `brokerClientTls{Key,Trust}StoreType` mapping. `sslProvider` (JDK vs OpenSSL engine selection) is deliberately **not** a `TlsPolicy` field — the engine is a factory concern, configured on the default `FileBasedTlsFactory` and mapped from the v4 field by the migration. That mapping recognizes only the `OPENSSL` / `OPENSSL_REFCNT` literals as selecting the native Netty engine; any other value — including a JCE *provider name* such as `Conscrypt` or `SunJSSE`, which the old code accepted — maps to the JDK engine. A v4 deployment that set `sslProvider` to a JCE provider name therefore silently gets the default JDK engine on the binary/client path after upgrade (the web/Jetty path still receives the string as its JCE provider). This is a niche behavior delta, not a security regression; if provider-name engine selection is ever needed it would return as a dedicated `jceProvider`-style setting on `FileBasedTlsFactorySettings`, not on `TlsPolicy`.
+
+**TLS-utility decomposition.** Beyond the SPI-level removals, the rebuild-not-mutate rotation model (Appendix B) and the new instance-factory SPI make several delegate-swap / kitchen-sink TLS helpers obsolete: the `KeyManagerProxy` / `TrustManagerProxy` auto-refresh delegates and the `keystoretls.SSLContextValidatorEngine` are deleted, and the grab-bag `org.apache.pulsar.common.util.SecurityUtility` is dissolved. Its still-needed primitives are re-homed into small single-concern containers under `org.apache.pulsar.common.util.tls` — `PemReader` (PEM cert/key loading), `JcaProviders` (BouncyCastle / Conscrypt provider resolution), and `JdkSslContexts` (JDK `SSLContext` assembly, consumed by `TlsContexts` in `org.apache.pulsar.common.tls.impl`). The obsolete auto-refresh Netty-context builders are dropped entirely (rotation is now the factory's concern). All of these are internal utilities (no `@InterfaceStability` contract, no client-API surface), so the decomposition is a source-internal cleanup, not a public-API break.
+
+# Monitoring
+
+- **Certificate rotation health.** Alert when `pulsar.tls.last_reload_success` for a purpose is older than the deployment's rotation interval, or on any increase of `pulsar.tls.reload{result=failure}`. This matters because the reload failure semantics deliberately keep serving last-good material after a failed rotation — the system stays up, so a rotation problem is visible only through these metrics until the certificate actually expires.
+- **Credential acquisition.** `pulsar.client.auth.credential.duration` exposes slow IdP/ZTS token endpoints that in v4 stalled the Netty event loop invisibly (Motivation #1); sustained latency growth indicates an unhealthy identity provider.
+- Existing connection/producer/consumer monitoring is unchanged.
+
+# Security Considerations
+
+- **TLS verification defaults.** Certificate verification is on by default everywhere, and the **v5 `TlsPolicy` defaults hostname verification ON** (`enableHostnameVerification()` defaults true; `allowInsecureConnection()` defaults false). The **legacy v4 and server-side flags keep their historical defaults** for compatibility — `tlsHostnameVerificationEnable` on `ClientConfigurationData` and the broker/proxy outbound equivalents default off, exactly as in 4.x, because flipping them would break existing deployments this PIP promises not to touch. Enabling any insecure setting is logged once at WARN level, on first use.
+- **Default enabled protocol set.** When no protocols are configured, the framework pins **`{TLSv1.3, TLSv1.2}`** on the built contexts — the native Netty, the JDK-synthesis, and the Jetty include-protocols paths alike — preserving the floor the removed `DefaultPulsarSslFactory` forced rather than silently deferring to the JVM/provider default on upgrade.
+- **Jetty web listener client-cert trust is scoped like Netty's.** With optional client auth (`tlsRequireTrustedClientCertOnConnect=false`), an *untrusted* client certificate is accepted at the web listener's handshake **only when `tlsAllowInsecureConnection=true`** — `wantClientAuth` no longer implies trust-all. This diverges from the pre-5.0 Jetty behavior (which trusted any presented client cert whenever client auth was optional) and is a deliberate security fix aligning the web listener with the binary listener's semantics.
+- **Private keys need never touch the filesystem — or any Pulsar API.** A custom `PulsarTlsFactory` keeps keys in its HSM/KMS or workload-identity system and returns ready-built TLS objects; key material never crosses a Pulsar interface and is never logged, serialized, or copied by the framework. For JCA-provider-backed keys (PKCS#11, KMS JCA providers) the key never leaves the HSM/KMS at all.
+
+# Backward & Forward Compatibility
+
+- The v5 client is published as a standalone artifact in 5.0.0-M1 (the existing `pulsar-client-v5` and `pulsar-client-api-v5` modules from PIP-466); folding the v5 client into `pulsar-client-shaded` is acknowledged as a follow-up gap and tracked separately.
+- PIP-337 is removed from Pulsar in Pulsar 5.0 since retaining it in the code base causes an additional maintenance burden and most users don't use it. Existing PIP-337 users will need to migrate to the new `PulsarTlsFactory` SPI — the affected public keys/methods and each one's disposition are inventoried in [PIP-337 removal impact](#pip-337-removal-impact), and a migration sketch is under Upgrade below.
+
+## Upgrade
+
+- Existing applications using `pulsar-client-api` (v4) require **no changes**, with one narrow exception: an application that configures a custom PIP-337 factory via `sslFactoryPlugin` (rare) must port that factory to `PulsarTlsFactory` — the deprecated v4 builder methods fail loudly rather than silently ignore a security-relevant setting (see [PIP-337 removal impact](#pip-337-removal-impact)). The rest of the v4 surface is untouched; the deprecated v4 methods (`getAuthData()` no-arg, `configure(Map)`) are retained per PIP-466's stability promise. The only v4 module addition is a new public interface `org.apache.pulsar.client.api.internal.AsyncAuthenticationDriver` (in a `.internal.` subpackage) — application code should not implement it; it is observed by `ClientCnx` to opt into the async path.
+- **PIP-337 → PIP-478 migration sketch.** A PIP-337 factory implements `initialize(PulsarSslConfiguration)` / `createInternalSslContext()` / `getInternalSslContext()` / `getInternalNettySslContext()` / `needsUpdate()` / `update()`, with consumers driving its rebuild choreography. The same integration under PIP-478 implements `PulsarTlsFactory`: read parameters in `initialize(TlsFactoryInitContext)`, answer `createInstance(purpose, SSLContext.class)` with a built context per supported purpose (the `TlsContexts` helper covers assembly), deliver rebuilt contexts through the subscribing overload's callback when material rotates, and return `Optional.empty()` for any richer class not built natively — the framework synthesizes the Netty/Jetty objects. Rotation timing, caching, and rebuild ordering move from the consumers into the factory; nothing else needs to be implemented.
+- Applications using `pulsar-client-api-v5` (v5) gain the new SPI. Existing `authPluginClassName` strings continue to work across both the v4 and v5 client APIs.
+- Mixed v4 + v5 Client API usage in the same JVM is supported.
+- The `Serializable` contract on the v4 `Authentication` interface remains, supporting Pulsar Functions and connector frameworks that serialize auth instances. The v5 `Authentication` interface deliberately does **not** extend `Serializable`; `V5ToV4AuthenticationAdapter.writeObject` throws `NotSerializableException` with an actionable message pointing to the `authPluginClassName` + `authParams` migration path. Connectors that serialize auth across class loaders must continue to use the v4 interface or the configuration-based approach. This is the stance for now; specific configuration-serialization needs for frameworks such as Apache Flink will be addressed when Flink support is added to Pulsar 5.0.
+
+## Downgrade / Rollback
+
+- Removing the v5 SPI types is a source-incompat break for any application that compiled against them, but the v4 surface is always a rollback target — applications can pin to the v4 `pulsar-client` and the new types are simply unused.
+
+## Pulsar Geo-Replication Upgrade & Downgrade/Rollback Considerations
+
+Authentication is a per-client concern: each cluster authenticates the replicator client independently using whichever auth plugin is configured, and no auth-related metadata changes. TLS *is* affected, because `ClusterData` carries per-cluster `brokerClientSslFactoryPlugin`/`...Params` fields today: those fields are retained for metadata compatibility, but a *custom* value now fails loudly at client creation rather than silently downgrading (see [PIP-337 removal impact](#pip-337-removal-impact)), while the per-cluster TLS *material* fields (`brokerClientTls*`) keep working, mapped to minted `broker-client.<cluster>` purposes. Because no `ClusterData` fields are removed, a mixed-version fleet (4.x and 5.0 brokers reading the same cluster metadata) deserializes cleanly in both directions.
+
+# Alternatives
+
+- **Pure additive `AuthenticationAsync` alongside v4.** Add async methods to a new sibling interface but keep the v4 surface as the data model. Rejected: it extends the kitchen-sink `AuthenticationDataProvider` problem rather than fixing it. Implementations would still mix TLS, HTTP, and command-data concerns in one type.
+
+- **Reusing AsyncHttpClient directly without an interface.** Skip `PulsarHttpClient` and just expose AsyncHttpClient on `AuthenticationInitContext`. Rejected: it ties Pulsar's public API to the AsyncHttpClient transitive dependency and freezes the framework's ability to ever change its internal backend. The `PulsarHttpClient` interface boundary provides that freedom by itself — which is also why the *opposite* extreme, a publicly pluggable backend SPI, was cut (see the design decision in the Detailed Design).
+
+- **Splitting the PIP-337 cleanup into a separate sibling PIP.** Rejected. Folding the relocation into this PIP keeps the auth-to-TLS decoupling in one document, avoids interleaved release ordering between two related PIPs, and gives reviewers a single place to evaluate the overall design.
+
+- **`@Deprecated` and remove the v4 `Authentication` interface outright.** Rejected: PIP-466 explicitly committed v4 to remain unchanged, and the v4 `Authentication` interface carries `@InterfaceStability.Stable`. Removing it would break v4 API usage and every third-party auth plugin in Pulsar 5.0.
+
+- **A material/configuration TLS SPI instead of the instance factory.** In this alternative, providers return raw *material* — a `TlsEndpointSpec` splitting key/cert-chain/trust-certs (or a JCA `KeyManagerFactory`/`TrustManagerFactory` pair) from optional behavioural configuration — with the framework owning all engine assembly. Its appeal was shading-neutrality: JDK/JCA types are never relocated, so one plugin artifact would serve the shaded and unshaded clients alike. Rejected because it is harder to implement on both sides: every stack the framework integrates must be expressible from the material model, the model must grow whenever a factory needs a capability it cannot express (engine-level options, BoringSSL keyless HSM signing, SNI keystores), and the framework re-owns exactly the build/cache/rotate machinery the factory shape keeps inside the plugin. The shading concern is handled by packaging instead — a relocated plugin artifact for the shaded client, the plain artifact for `pulsar-client-original` / `pulsar-client-admin-original` and the server side (see the shading note in the Detailed Design). PIP-337 silently has the same shading constraint today; documenting the packaging requirement is strictly better than contorting the SPI to avoid it.
+
+# Resolved design decisions
+
+Design questions considered during this proposal, now resolved. Each records the options considered, the tradeoffs, and the rationale for the choice, so reviewers can challenge the reasoning rather than re-derive it. **No unresolved decisions remain for this PIP** (follow-ups deliberately left out of scope are listed in [Out of Scope](#out-of-scope)).
+
+## 1. HTTP multi-round driver design and the SASL-vs-standard interface split
+
+**Decision.** Ship only the SASL-style `HttpAuthChallengeHandler`. The framework implements **one** `401`→resubmit→`200` state machine, shared behind a thin request/response adapter per HTTP client API (both APIs — JAX-RS/Jersey and raw AsyncHttpClient — run over the same AsyncHttpClient transport). The driver selects a plugin's challenge handling by capability lookup (`capability(HttpAuthChallengeHandler.class)`). A standard `WWW-Authenticate` (e.g. digest) interface is a documented future extension, added as a sibling capability when a real mechanism needs it.
+
+**Options and tradeoffs.** (a) *(chosen)* SASL-style only — no speculative API; the capability model makes the later addition non-breaking by construction. (b) Define both interfaces now — a complete surface from day one, but the second interface would ship unvalidated by any implementation, and speculative SPI tends to be wrong SPI. (c) One interface with a style discriminator — avoids the split but makes the capability non-self-describing at the type level.
+
+**Rationale.** Only SASL exercises HTTP multi-round today. Designing the standard-style interface now would be speculation squared: no in-tree implementation to validate it, on top of a capability model whose whole point is that new interfaces can be added later without disturbing existing plugins.
+
+## 2. Config-file (de)serialization of the v5 client configuration
+
+**Decision.** Deferred to a follow-up. This PIP only shapes the types so a loader is additive: `TlsPolicy` is a flat value with a `format` discriminator (not a polymorphic hierarchy), `TlsPurpose` is a plain named key usable as a config key (e.g. `tls.default.trustCertsFilePath=…`, `tls.oauth2.trustStorePath=…`), and HTTP-client plugins select TLS by purpose key, never inline material — so nothing in the auth/TLS surface resists a flat properties/JSON binding.
+
+**Options and tradeoffs.** (a) *(chosen)* defer, keep the config-friendly shapes; (b) define the schema and binding now — extra scope with no 5.0 consumer; (c) declare programmatic-only forever — forecloses a real deployment need.
+
+**Rationale.** The type shapes were the only decision that had to be made now; the loader itself has no 5.0 dependency and deserves its own focused proposal.
+
+## 3. Naming of the four capability interfaces
+
+**Decision.** Uniform `<Transport><Style>` names that read directly off the 2×2 matrix — `BinaryAuthDataProvider`, `HttpAuthHeadersProvider`, `BinaryAuthChallengeHandler`, `HttpAuthChallengeHandler` (the binary credential value follows as `BinaryAuthData`). The suffix split is kept deliberately: `…Provider` = single-pass, `…Handler` = challenge/response — the suffix alone tells the style.
+
+**Options and tradeoffs.** Keeping the earlier mixed names (`BinaryProtocolAuthDataProvider`, `ChallengeResponseHandler`, `HttpHeaderChallengeResponseHandler`) — each read naturally in isolation, but the set was uneven and the binary challenge interface carried no transport prefix at all.
+
+**Rationale.** These are unreleased types: a mechanical rename is free today and impossible after 5.0 ships. Uniform names make the matrix self-evident from the javadoc index alone.
+
+## 4. Strictness of the well-known-class contract
+
+**Decision.** Minimal mandatory core: `javax.net.ssl.SSLContext` is required only as a fallback, the framework synthesizes the Netty/Jetty objects on `Optional.empty()`, and the whole contract is probed fail-fast at startup. The naming details are settled with it: `createInstance` overloads rather than a separate `subscribe` method, one merged `TlsHandle` (the earlier `TlsInstance`/`TlsSubscription` pair was byte-identical), and Jetty's `SslContextFactory.Client` removed from the well-known set (its one in-tree consumer, the proxy's `AdminProxyHandler`, is served by framework synthesis).
+
+**Options and tradeoffs.** (a) *(chosen)* minimal core + framework fallbacks — custom factories stay trivial (one JDK `SSLContext` plus reload callbacks) and dependency-light (a KMS plugin needs no Jetty or even Netty dependency); the framework owns per-stack assembly once. (b) strict all-classes-mandatory — every factory exercises identical code paths, but every plugin drags Netty and Jetty dependencies and re-implements per-stack assembly; the tier-3 "implement one `SSLContext`" pitch collapses.
+
+**Rationale.** Complexity placed in the framework once removes it from every plugin forever; that is design principle #2 applied to the contract itself.
+
+## 5. Where the TLS and HTTP SPIs live
+
+**Decision.** Extract a **small, dependency-light API module** (`pulsar-common-api`) before anything ships. It hosts the TLS SPI (`org.apache.pulsar.common.tls`) and the HTTP SPI (`org.apache.pulsar.client.api.v5.http` — package names are independent of module coordinates); `pulsar-client-api-v5` depends on it, and the sibling broker-side PIP (JWKS/OIDC fetching) can depend on it without importing a client artifact. The heavier default implementations live where their dependencies already are: `FileBasedTlsFactory` and `TlsContexts` in `pulsar-common` under the distinct package `org.apache.pulsar.common.tls.impl` (Netty engines, no split package), `DefaultBrokerTlsFactory` in `pulsar-broker-common` (Jetty and broker configuration). One wrinkle to handle: `pulsar-common` *already* owns `org.apache.pulsar.common.tls` (a handful of hostname-verification helper classes), which would split the package across two modules once the SPI lands in `pulsar-common-api`. Those helpers are therefore **relocated** into `pulsar-common-api` (their fully-qualified names unchanged, and `pulsar-common` depends on `pulsar-common-api` anyway), so **no split package remains** — `pulsar-common`'s `org.apache.pulsar.common.tls` then holds only the `.impl` factory classes.
+
+**Options and tradeoffs.** (a) keep the HTTP SPI in `pulsar-client-api-v5` and the TLS types in `pulsar-common` — no new module, but the dependency-free v5 API module would need to see `PulsarTlsFactory` (its builder accepts one), which would drag in the heavyweight `pulsar-common`; and the broker would import a client-API artifact for HTTP. (b) *(chosen)* extract the neutral module now — one more Gradle module, coordinates final before release, both dependency problems dissolve. (c) let the broker define near-identical types later — two SPIs to document and maintain forever.
+
+**Rationale.** Released package and artifact coordinates are permanent; the extraction costs one build file today and is impossible after 5.0. It also fixes the latent v5-API→pulsar-common dependency problem in the same stroke.
+
+# General Notes
+
+**Implementation approach.** The change is naturally ordered so each step keeps the codebase releasable: the new SPI types (the `pulsar-common-api` TLS/HTTP types and the `org.apache.pulsar.client.api.v5.auth` / `.http` types) land first with no consumers; then the default `FileBasedTlsFactory` / `DefaultBrokerTlsFactory` and the server-side migration (broker, proxy, websocket, functions-worker); then the client-side migration and the v4↔v5 bridges (`LegacyV4AuthenticationAdapter` / `V5ToV4AuthenticationAdapter`, the `ClientCnx` carve-out, and the built-in v4 plugin shims); and finally the removal of `PulsarSslFactory` / `PulsarSslConfiguration` / `DefaultPulsarSslFactory` / `KeyStoreSSLContext` and the old config keys once nothing references them. Once the server-side migration is in place, a stale PIP-337 factory key (`sslFactoryPlugin` and friends) set to a non-default value is **rejected loudly at startup** rather than silently adapted — there is no compatibility shim keeping the old keys working.
+
+**Testing strategy.** Beyond "existing v4 authentication tests pass unmodified" (the acceptance criterion for the shims), the new surface needs: rotation tests (file rotation observed by subscriptions; a failed rotation serves last-good material and recovers on the next change); Jetty `reload(...)` swap tests (new connections use the new context, established connections keep their sessions); per-adapter bridge tests (credential, challenge-response, TLS extraction); fail-fast probing tests (a misconfigured purpose fails client build / server start with an actionable error); HTTP driver tests exercising the SASL `401` loop through both client APIs; and a shaded-packaging test loading a relocated factory against `pulsar-client-all`.
+
+# Appendix
+
+Supporting analysis moved out of the design sections; nothing here is normative beyond what the main text already states.
+
+## Appendix A: Jetty getSslContext override analysis
+
+Pulsar's current `JettySslContextFactory` subclasses Jetty's `SslContextFactory.Server` and overrides `getSslContext()` to return the rotating context on every call. That subverts Jetty's design: `SslContextFactory` selects its enabled protocols and cipher suites inside `load()` — run at `doStart()` and on reload — *from the context it loads*, caches everything in an internal `_factory` field guarded by the factory lock, and some internal code paths read `_factory._context` directly rather than through the overridable getter. With the override, start-time selection runs against a throwaway empty context while handshakes use whatever the override currently returns; the two are never reconciled, and rotation never re-runs selection at all. It works today only because typical JDK contexts share the same parameter universe — by accident, not by contract. The `SslContextFactory.reload(Consumer<SslContextFactory>)` mechanism used by the main design is the same one Jetty's own `KeyStoreScanner` hot-reload module uses: the consumer mutates the configuration under the factory's lock, then Jetty unloads and re-runs `load()`, atomically swapping the internal state and re-selecting protocols/ciphers from the new context.
+
+## Appendix B: delegate-swap rotation and Netty OpenSSL
+
+The delegate-swap rotation pattern keeps one immutable `SslContext` alive and swaps new material in behind a mutable delegate — the approach of `org.apache.pulsar.common.util.TrustManagerProxy` / `KeyManagerProxy`, which wrap an `X509ExtendedTrustManager` / `X509ExtendedKeyManager` whose backing instance a scheduled task replaces. The pattern works, but it interacts awkwardly with the Netty **OpenSSL** provider (all of the following verified against the Netty 4.2 sources):
+
+- A custom `KeyManager` opts out of Netty's native/caching key-manager factories (`OpenSslX509KeyManagerFactory` / `OpenSslCachingX509KeyManagerFactory`), so Netty re-derives the alias on every handshake and rebuilds the native key material whenever the backing key/cert instances change. It also requires an **extractable** private key — the OpenSSL key path needs `PrivateKey.getEncoded()` bytes — so it cannot carry a non-extractable HSM/PKCS#11 key at all, the very case this PIP targets.
+- Alias selection and material fetch are two separate calls on the key manager, and the proxy can replace its delegate mid-handshake; because the proxy uses the certificate's subject DN as its keystore alias, a rotation that changes the subject can momentarily mismatch and fail a handshake.
+- In mutual TLS, a server tells the client which CAs it will accept client certificates from by listing their names in the TLS *CertificateRequest*; Netty derives that list from the trust manager's `getAcceptedIssuers()` and writes it into the native context **once**, via `setCACertificateBio`. A delegate swap does not update it, so the advertised list stays frozen at the trust set present when the context was built. The impact is on client-certificate *selection*, not on the server's trust *decision*: after a refresh adds a CA, a client that picks its certificate by matching the server's advertised list will not offer one issued by the new CA, and the handshake fails on a missing client certificate — even though the server's current trust manager would have accepted it. A client that ignores the advertised list and always sends its configured certificate is unaffected, because validation is delegated to the up-to-date trust manager. (Netty's OpenSSL provider always routes chain validation through a Java `X509TrustManager` verify callback — built from raw CA certs or a custom trust manager alike — so the swapped delegate is honored per handshake; only the advertised name list goes stale.) This bites only a server performing client-auth; Pulsar installs the proxy on the client side, where no `CertificateRequest` is sent, so it is latent today.
+
+Rebuilding the whole context on rotation avoids these: the factory hands over an atomically built object, is free to use the native/caching key-manager factories and a fresh advertised-issuer list, and for HSM keys builds a JDK `SSLContext` from its own `KeyManagerFactory` so the key never needs to be extractable.
+
+# Links
+
+- [PIP-97: Asynchronous Authentication Provider](pip-97.md)
+- [PIP-337: SSL Factory Plugin](pip-337.md)
+- [PIP-466: New Java Client API (V5)](pip-466.md)
+- [GitHub issue 24795 (HTTP client pluggability)](https://github.com/apache/pulsar/issues/24795)
+- [GitHub PR 24944 (oauth2 trustcerts file and timeouts)](https://github.com/apache/pulsar/pull/24944)
+- Mailing List discussion thread: https://lists.apache.org/thread/s9n9jksr9vqgn9o982zmnnkcxdcncy3f
+- Mailing List voting thread:


### PR DESCRIPTION
## Motivation

This is the design document for **PIP-478**, the first PR in a stacked series that
implements it. It proposes, for the Pulsar 5.0 v5 client (PIP-466) plus a new neutral
`pulsar-common-api` module:

- an **asynchronous, capability-segregated v5 client authentication SPI** — replacing v4's
  kitchen-sink `AuthenticationDataProvider`, so credential I/O (OAuth2/Athenz token
  refresh) never blocks the Netty event loop;
- a **framework-managed `PulsarHttpClient` SPI** — so auth plugins share the client's HTTP
  runtime instead of spinning up private `AsyncHttpClient` instances (issue #24795 / #24944);
- a **purpose-driven `PulsarTlsFactory` TLS SPI** that replaces PIP-337 — decoupled from the
  auth SPI, KMS/HSM-friendly (keys never cross a Pulsar API), with rebuild-not-mutate
  rotation.

It addresses the five Motivations in the document and folds in the PIP-337 removal.

## Modifications

This PR adds only the design document `pip/pip-478.md`. The implementation follows in
subsequent PRs of the series, in dependency order:

1. **(this PR)** the design document
2. the neutral `pulsar-common-api` SPI module (TLS + HTTP client interfaces)
3. the default file-based TLS factory implementation
4. the v5 authentication SPI + v4↔v5 bridges, then the client async-auth engine + TLS/HTTP
5. server-side TLS factory integration + default switch to the new SPI
6. removal of the PIP-337 SSL factory + `SecurityUtility` decomposition + API dispositions

Each subsequent PR is independently buildable and CI-green, stacked on the previous.

### Verifications

Design doc only — no code. The document has been reconciled against the completed
implementation and reviewed for internal consistency and normative clarity.

Fork-internal PR for review-series CI validation; not for apache/pulsar as-is.