### PR TITLE
[feat][misc] PIP-478: default file-based TLS factory implementation

### DIFF
--- a/bouncy-castle/bcfips/src/main/java/org/apache/pulsar/bcloader/BouncyCastleFipsLoader.java
+++ b/bouncy-castle/bcfips/src/main/java/org/apache/pulsar/bcloader/BouncyCastleFipsLoader.java
@@ -18,7 +18,7 @@
  */
 package org.apache.pulsar.bcloader;
 
-import static org.apache.pulsar.common.util.SecurityUtility.BC_FIPS;
+import static org.apache.pulsar.common.util.tls.JcaProviders.BC_FIPS;
 import java.security.Provider;
 import java.security.Security;
 import lombok.CustomLog;

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/tls/DefaultBrokerTlsFactory.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/tls/DefaultBrokerTlsFactory.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.tls;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.client.api.Authentication;
+import org.apache.pulsar.client.api.AuthenticationDataProvider;
+import org.apache.pulsar.common.tls.TlsPolicy;
+import org.apache.pulsar.common.tls.TlsPurpose;
+import org.apache.pulsar.common.tls.impl.FileBasedTlsFactory;
+import org.apache.pulsar.common.tls.impl.FileBasedTlsFactorySettings;
+
+/**
+ * The broker's default {@code PulsarTlsFactory}: a thin {@link FileBasedTlsFactory} whose purpose&rarr;
+ * policy map is composed from a {@link ServiceConfiguration} (PIP-478).
+ *
+ * <p>It lives in {@code pulsar-broker-common} — which owns the Jetty integration and the broker
+ * configuration — so that neither the SPI module nor {@code pulsar-common} carries broker-config
+ * knowledge. The class only <em>composes</em> the map; wiring it into the broker/proxy/web services is
+ * a later stage.
+ */
+public class DefaultBrokerTlsFactory extends FileBasedTlsFactory {
+
+    /**
+     * Construct the broker factory from an already-composed purpose&rarr;policy map.
+     *
+     * @param policies the composed purpose&rarr;policy map
+     * @param settings the factory-wide engine/refresh/client-auth settings
+     */
+    public DefaultBrokerTlsFactory(Map<TlsPurpose, TlsPolicy> policies, FileBasedTlsFactorySettings settings) {
+        super(policies, settings);
+    }
+
+    /**
+     * Construct a broker factory that additionally folds the broker-client authentication's TLS material
+     * over the {@link TlsPurpose#BROKER_CLIENT} file policy (PIP-478).
+     *
+     * @param policies              the composed purpose&rarr;policy map
+     * @param settings              the factory-wide engine/refresh/client-auth settings
+     * @param authMaterialSuppliers per-purpose broker-client authentication material suppliers (may be empty)
+     */
+    public DefaultBrokerTlsFactory(Map<TlsPurpose, TlsPolicy> policies, FileBasedTlsFactorySettings settings,
+            Map<TlsPurpose, Supplier<AuthenticationDataProvider>> authMaterialSuppliers) {
+        super(policies, settings, authMaterialSuppliers);
+    }
+
+    /**
+     * Compose a {@link DefaultBrokerTlsFactory} from a {@link ServiceConfiguration}.
+     *
+     * @param conf the broker service configuration
+     * @return an uninitialized broker factory (call {@code initialize(...)} before use)
+     */
+    public static DefaultBrokerTlsFactory fromServiceConfiguration(ServiceConfiguration conf) {
+        return fromServiceConfiguration(conf, null);
+    }
+
+    /**
+     * Compose a {@link DefaultBrokerTlsFactory} from a {@link ServiceConfiguration}, optionally folding the
+     * broker's broker-client {@link Authentication} TLS material over the {@link TlsPurpose#BROKER_CLIENT}
+     * file policy (PIP-478) for the broker's own outbound (broker-to-broker / replication) connections.
+     *
+     * <p>The broker's server material is registered for the {@link TlsPurpose#BROKER},
+     * {@link TlsPurpose#PROXY} and {@link TlsPurpose#WEB} purposes; the broker's outbound
+     * (broker-to-broker) material for {@link TlsPurpose#BROKER_CLIENT}. When {@code brokerClientAuth} is
+     * supplied and a broker-client authentication plugin is configured, its in-memory cert/key override the
+     * {@code brokerClient*} file paths (auth-cert-wins), so the broker presents the right identity to its
+     * peers — the server-side mirror of the client TLS override hook.
+     *
+     * @param conf             the broker service configuration
+     * @param brokerClientAuth the broker's broker-client authentication, or {@code null} for no fold
+     * @return an uninitialized broker factory (call {@code initialize(...)} before use)
+     */
+    public static DefaultBrokerTlsFactory fromServiceConfiguration(ServiceConfiguration conf,
+            Authentication brokerClientAuth) {
+        Map<TlsPurpose, TlsPolicy> policies = new LinkedHashMap<>();
+        TlsPolicy serverPolicy = serverPolicy(conf);
+        policies.put(TlsPurpose.BROKER, serverPolicy);
+        policies.put(TlsPurpose.PROXY, serverPolicy);
+        policies.put(TlsPurpose.WEB, serverPolicy);
+        policies.put(TlsPurpose.BROKER_CLIENT, brokerClientPolicy(conf));
+
+        FileBasedTlsFactorySettings settings = FileBasedTlsFactorySettings.builder()
+                .requireTrustedClientCert(conf.isTlsRequireTrustedClientCertOnConnect())
+                .refreshIntervalSeconds(refreshIntervalSeconds(conf))
+                // Engine selection (JDK vs. OpenSSL) mapped from the broker's tlsProvider field (PIP-478
+                // stage 2b): only an explicit OPENSSL value selects the native engine; JCE provider names
+                // and null keep the JDK engine.
+                .engineProvider(TlsFactorySupport.engineProvider(conf.getTlsProvider()))
+                .build();
+        Map<TlsPurpose, Supplier<AuthenticationDataProvider>> authSuppliers =
+                (brokerClientAuth != null && StringUtils.isNotBlank(conf.getBrokerClientAuthenticationPlugin()))
+                        ? Map.of(TlsPurpose.BROKER_CLIENT, FileBasedTlsFactory.authMaterialSupplier(brokerClientAuth))
+                        : Map.of();
+        return new DefaultBrokerTlsFactory(policies, settings, authSuppliers);
+    }
+
+    private static TlsPolicy serverPolicy(ServiceConfiguration conf) {
+        TlsPolicy.Builder builder = TlsPolicy.builder()
+                .allowInsecureConnection(conf.isTlsAllowInsecureConnection())
+                .enableHostnameVerification(conf.isTlsHostnameVerificationEnabled())
+                .protocols(toList(conf.getTlsProtocols()))
+                .ciphers(toList(conf.getTlsCiphers()));
+        if (conf.isTlsEnabledWithKeyStore()) {
+            builder.format(TlsPolicy.Format.KEYSTORE)
+                    .keyStoreType(conf.getTlsKeyStoreType())
+                    .trustStoreType(conf.getTlsTrustStoreType())
+                    .keyStorePath(conf.getTlsKeyStore())
+                    .keyStorePassword(conf.getTlsKeyStorePassword())
+                    .trustStorePath(conf.getTlsTrustStore())
+                    .trustStorePassword(conf.getTlsTrustStorePassword());
+        } else {
+            builder.format(TlsPolicy.Format.PEM)
+                    .trustCertsFilePath(conf.getTlsTrustCertsFilePath())
+                    .certificateFilePath(conf.getTlsCertificateFilePath())
+                    .keyFilePath(conf.getTlsKeyFilePath());
+        }
+        return builder.build();
+    }
+
+    private static TlsPolicy brokerClientPolicy(ServiceConfiguration conf) {
+        // Outbound broker-client connections reuse the shared insecure/hostname-verification flags.
+        TlsPolicy.Builder builder = TlsPolicy.builder()
+                .allowInsecureConnection(conf.isTlsAllowInsecureConnection())
+                .enableHostnameVerification(conf.isTlsHostnameVerificationEnabled())
+                .protocols(toList(conf.getBrokerClientTlsProtocols()))
+                .ciphers(toList(conf.getBrokerClientTlsCiphers()));
+        if (conf.isBrokerClientTlsEnabledWithKeyStore()) {
+            builder.format(TlsPolicy.Format.KEYSTORE)
+                    .keyStoreType(conf.getBrokerClientTlsKeyStoreType())
+                    .trustStoreType(conf.getBrokerClientTlsTrustStoreType())
+                    .keyStorePath(conf.getBrokerClientTlsKeyStore())
+                    .keyStorePassword(conf.getBrokerClientTlsKeyStorePassword())
+                    .trustStorePath(conf.getBrokerClientTlsTrustStore())
+                    .trustStorePassword(conf.getBrokerClientTlsTrustStorePassword());
+        } else {
+            builder.format(TlsPolicy.Format.PEM)
+                    .trustCertsFilePath(conf.getBrokerClientTrustCertsFilePath())
+                    .certificateFilePath(conf.getBrokerClientCertificateFilePath())
+                    .keyFilePath(conf.getBrokerClientKeyFilePath());
+        }
+        return builder.build();
+    }
+
+    private static int refreshIntervalSeconds(ServiceConfiguration conf) {
+        long configured = conf.getTlsCertRefreshCheckDurationSec();
+        if (configured <= 0) {
+            return FileBasedTlsFactorySettings.DEFAULT_REFRESH_INTERVAL_SECONDS;
+        }
+        return (int) Math.min(configured, Integer.MAX_VALUE);
+    }
+
+    private static List<String> toList(Set<String> values) {
+        return values == null ? List.of() : List.copyOf(values);
+    }
+}

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/tls/TlsFactorySupport.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/tls/TlsFactorySupport.java
@@ -1,0 +1,259 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.tls;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.netty.handler.ssl.SslProvider;
+import io.opentelemetry.api.OpenTelemetry;
+import java.time.Clock;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Supplier;
+import lombok.CustomLog;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.pulsar.common.tls.PulsarTlsFactory;
+import org.apache.pulsar.common.tls.TlsFactoryInitContext;
+import org.apache.pulsar.common.util.ObjectMapperFactory;
+
+/**
+ * Shared scaffolding for wiring a server component onto the PIP-478 {@link PulsarTlsFactory} SPI — the only
+ * server TLS path since the PIP-337 {@code PulsarSslFactory} removal. Server components (broker,
+ * proxy, websocket, functions-worker) call these helpers to instantiate and initialize the factory, parse
+ * its parameters, and reject a stale PIP-337 {@code sslFactoryPlugin} configuration at startup via
+ * {@link #isLegacyCustom}.
+ *
+ * <p>The helper is intentionally free of Netty {@code io.netty.handler.ssl} types (the {@code SslContext}
+ * subscribe pattern stays inline in the binary-listener components that already depend on
+ * {@code netty-handler}); it carries only {@link SslProvider} from {@code netty-common}, which
+ * {@code pulsar-broker-common} already has. That keeps this class usable by every component, including the
+ * websocket proxy and functions-worker web servers whose only TLS consumer is Jetty.
+ */
+@CustomLog
+public final class TlsFactorySupport {
+
+    /**
+     * Reserved {@code tlsFactoryClassName} value selecting the component's built-in default
+     * {@link PulsarTlsFactory} (composed from the component configuration) via the new SPI, rather than a
+     * reflectively-instantiated custom factory.
+     */
+    public static final String DEFAULT_FACTORY = "default";
+
+    /**
+     * FQCN of the removed PIP-337 default SSL factory. Matched as a string literal (the class itself is
+     * removed in PIP-478) so a blank {@code sslFactoryPlugin} value OR this literal is treated as
+     * "the default" — any other non-blank value names a (removed) custom PIP-337 plugin.
+     */
+    static final String REMOVED_DEFAULT_SSL_FACTORY_CLASS_NAME =
+            "org.apache.pulsar.common.util.DefaultPulsarSslFactory";
+
+    private TlsFactorySupport() {
+    }
+
+    /**
+     * Whether a {@code sslFactoryPlugin}-family value names a removed PIP-337 custom factory — a non-blank
+     * value that is not the removed default's FQCN. The PIP-337 path no longer exists, so a
+     * component fails loudly at startup when this returns {@code true}.
+     *
+     * @param legacyPluginClassName a {@code sslFactoryPlugin}-family value
+     * @return whether it names a (removed) custom PIP-337 factory
+     */
+    public static boolean isLegacyCustom(String legacyPluginClassName) {
+        return StringUtils.isNotBlank(legacyPluginClassName)
+                && !REMOVED_DEFAULT_SSL_FACTORY_CLASS_NAME.equals(legacyPluginClassName.trim());
+    }
+
+    /**
+     * Instantiate the PIP-478 factory for the new path. A blank value, the literal {@link #DEFAULT_FACTORY},
+     * or the default factory's own class name selects the supplied built-in default (composed from the
+     * component configuration); any other value is instantiated reflectively via its public no-arg
+     * constructor.
+     *
+     * @param tlsFactoryClassName the configured factory class name (or blank/{@code default})
+     * @param defaultFactoryClass the class of the built-in default factory (for name matching); may be null
+     * @param defaultFactory      supplies the built-in default factory
+     * @return an uninitialized {@link PulsarTlsFactory} (call {@link #initializeBlocking} before use)
+     * @throws ReflectiveOperationException if a named custom class cannot be instantiated
+     */
+    public static PulsarTlsFactory createFactory(String tlsFactoryClassName,
+                                                 Class<? extends PulsarTlsFactory> defaultFactoryClass,
+                                                 Supplier<PulsarTlsFactory> defaultFactory)
+            throws ReflectiveOperationException {
+        Objects.requireNonNull(defaultFactory, "defaultFactory must not be null");
+        String className = tlsFactoryClassName == null ? "" : tlsFactoryClassName.trim();
+        if (className.isEmpty()
+                || DEFAULT_FACTORY.equalsIgnoreCase(className)
+                || (defaultFactoryClass != null && defaultFactoryClass.getName().equals(className))) {
+            return defaultFactory.get();
+        }
+        return (PulsarTlsFactory) Class.forName(className).getConstructor().newInstance();
+    }
+
+    /**
+     * Build a production {@link TlsFactoryInitContext} with a no-op {@link OpenTelemetry}. For components
+     * (websocket proxy, functions worker) whose module does not carry {@code opentelemetry-api} on its
+     * compile classpath and only need TLS for the Jetty web path.
+     *
+     * @param params           the factory params (from {@link #parseFactoryConfig}); never null
+     * @param scheduler        the framework scheduler for file-watch polling and rotation
+     * @param blockingExecutor the executor for potentially-blocking material loading
+     * @return a {@link TlsFactoryInitContext} with {@link OpenTelemetry#noop()}
+     */
+    public static TlsFactoryInitContext initContext(Map<String, String> params,
+                                                    ScheduledExecutorService scheduler,
+                                                    Executor blockingExecutor) {
+        return initContext(params, scheduler, blockingExecutor, OpenTelemetry.noop());
+    }
+
+    /**
+     * Build a production {@link TlsFactoryInitContext}.
+     *
+     * @param params           the factory params (from {@link #parseFactoryConfig}); never null
+     * @param scheduler        the framework scheduler for file-watch polling and rotation
+     * @param blockingExecutor the executor for potentially-blocking material loading
+     * @param openTelemetry    the telemetry root, or {@code null} for {@link OpenTelemetry#noop()}
+     * @return a {@link TlsFactoryInitContext}
+     */
+    public static TlsFactoryInitContext initContext(Map<String, String> params,
+                                                    ScheduledExecutorService scheduler,
+                                                    Executor blockingExecutor,
+                                                    OpenTelemetry openTelemetry) {
+        Map<String, String> safeParams = params == null ? Map.of() : Map.copyOf(params);
+        OpenTelemetry ot = openTelemetry == null ? OpenTelemetry.noop() : openTelemetry;
+        return new TlsFactoryInitContext() {
+            @Override
+            public Map<String, String> params() {
+                return safeParams;
+            }
+
+            @Override
+            public ScheduledExecutorService scheduler() {
+                return scheduler;
+            }
+
+            @Override
+            public Executor blockingExecutor() {
+                return blockingExecutor;
+            }
+
+            @Override
+            public Clock clock() {
+                return Clock.systemUTC();
+            }
+
+            @Override
+            public OpenTelemetry openTelemetry() {
+                return ot;
+            }
+        };
+    }
+
+    /**
+     * Initialize a factory and block until it is ready, per the fail-fast contract (a failed
+     * {@code initialize} is fatal to the owning component's startup). Unwraps
+     * {@link CompletionException}/{@link ExecutionException} to the underlying cause.
+     *
+     * @param factory the factory to initialize
+     * @param context the init context
+     * @throws Exception the underlying initialization failure, if any
+     */
+    public static void initializeBlocking(PulsarTlsFactory factory, TlsFactoryInitContext context)
+            throws Exception {
+        try {
+            factory.initialize(context).get();
+        } catch (ExecutionException e) {
+            throw asException(e.getCause());
+        } catch (CompletionException e) {
+            throw asException(e.getCause());
+        }
+    }
+
+    /**
+     * Parse a {@code tlsFactoryConfig} string into the factory params map. A blank value yields an empty
+     * map; a value starting with <code>{</code> is parsed as a JSON object; otherwise it is parsed as a
+     * comma-separated {@code key=value} list.
+     *
+     * @param tlsFactoryConfig the configured factory params (may be null/blank)
+     * @return an immutable params map (possibly empty)
+     */
+    public static Map<String, String> parseFactoryConfig(String tlsFactoryConfig) {
+        if (StringUtils.isBlank(tlsFactoryConfig)) {
+            return Map.of();
+        }
+        String trimmed = tlsFactoryConfig.trim();
+        if (trimmed.startsWith("{")) {
+            try {
+                Map<String, String> parsed = ObjectMapperFactory.getMapper().reader()
+                        .forType(new TypeReference<Map<String, String>>() {})
+                        .readValue(trimmed);
+                return parsed == null ? Map.of() : Map.copyOf(parsed);
+            } catch (Exception e) {
+                throw new IllegalArgumentException("Failed to parse tlsFactoryConfig as a JSON object", e);
+            }
+        }
+        Map<String, String> map = new LinkedHashMap<>();
+        for (String pair : trimmed.split(",")) {
+            String entry = pair.trim();
+            if (entry.isEmpty()) {
+                continue;
+            }
+            int eq = entry.indexOf('=');
+            if (eq < 0) {
+                map.put(entry, "");
+            } else {
+                map.put(entry.substring(0, eq).trim(), entry.substring(eq + 1).trim());
+            }
+        }
+        return Map.copyOf(map);
+    }
+
+    /**
+     * Map a component's provider string to the Netty {@link SslProvider} engine used by the default
+     * file-based factory. Conservative: only an explicit {@code OPENSSL}/{@code OPENSSL_REFCNT} value selects
+     * the native engine — JCE provider names (e.g. {@code Conscrypt}, {@code SunJSSE}) and {@code null} map
+     * to the {@link SslProvider#JDK} engine (the safe default). The provider string is still passed
+     * separately to Jetty as its JCE provider for the web path.
+     *
+     * @param providerString the component's provider string (may be null/blank)
+     * @return the Netty {@link SslProvider} engine selection
+     */
+    public static SslProvider engineProvider(String providerString) {
+        if (StringUtils.isNotBlank(providerString)) {
+            String provider = providerString.trim();
+            if ("OPENSSL".equalsIgnoreCase(provider) || "OPENSSL_REFCNT".equalsIgnoreCase(provider)) {
+                return SslProvider.OPENSSL;
+            }
+        }
+        return SslProvider.JDK;
+    }
+
+    private static Exception asException(Throwable cause) {
+        if (cause == null) {
+            return new Exception("TLS factory initialization failed");
+        }
+        if (cause instanceof Exception e) {
+            return e;
+        }
+        return new Exception(cause);
+    }
+}

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/tls/package-info.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/tls/package-info.java
@@ -16,31 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pulsar.bcloader;
-
-import static org.apache.pulsar.common.util.tls.JcaProviders.BC;
-import java.security.Provider;
-import java.security.Security;
-import lombok.CustomLog;
-import org.apache.pulsar.common.util.BCLoader;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
 /**
- * This is a Bouncy Castle provider Loader.
+ * Broker-side wiring for the PIP-478 TLS SPI: {@code DefaultBrokerTlsFactory} composes the default
+ * file-based factory from a {@code ServiceConfiguration}.
  */
-@CustomLog
-public class BouncyCastleLoader implements BCLoader {
-    public static Provider provider;
-    static {
-        if (Security.getProvider(BC) == null) {
-            Security.addProvider(new BouncyCastleProvider());
-        }
-        provider = Security.getProvider(BC);
-        log.info().attr("provider", provider).log("BouncyCastle Provider BC loaded");
-    }
-
-    @Override
-    public Provider getProvider() {
-        return Security.getProvider(BC);
-    }
-}
+package org.apache.pulsar.broker.tls;

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/jetty/tls/JettyTlsFactory.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/jetty/tls/JettyTlsFactory.java
@@ -1,0 +1,281 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.jetty.tls;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Consumer;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
+import lombok.CustomLog;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.pulsar.common.tls.PulsarTlsFactory;
+import org.apache.pulsar.common.tls.TlsHandle;
+import org.apache.pulsar.common.tls.TlsPurpose;
+import org.apache.pulsar.common.tls.impl.TlsContexts;
+import org.apache.pulsar.common.util.tls.JcaProviders;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+
+/**
+ * The framework's Jetty integration for the PIP-478 TLS SPI: synthesizes a <em>vanilla</em> (never
+ * subclassed) {@link SslContextFactory.Server} / {@link SslContextFactory.Client} from a
+ * {@link PulsarTlsFactory} that returns {@code empty()} for the Jetty class.
+ *
+ * <p>This deliberately abandons the unsound {@code getSslContext()} override of the removed PIP-337
+ * {@code JettySslContextFactory}. Instead it uses
+ * Jetty's documented hot-reload API — the same one {@code KeyStoreScanner} uses: an {@code SSLContext}
+ * subscription drives {@link SslContextFactory#setSslContext(SSLContext)} before start, and on each
+ * later delivery {@link SslContextFactory#reload(Consumer)} atomically swaps the context and re-selects
+ * protocols/ciphers. Existing connections keep their sessions; new connections use the new context.
+ *
+ * <p><b>{@code SSLParameters} companion (PIP-478).</b> Because these are synthesized paths (the factory
+ * returned {@code empty()} for the Jetty class and supplies only the {@code SSLContext}), the framework also
+ * asks the factory for its optional {@code javax.net.ssl.SSLParameters} companion — the engine-level baseline
+ * a bare {@code SSLContext} cannot express — and maps its non-null members onto the Jetty setters: enabled
+ * protocols ({@link SslContextFactory#setIncludeProtocols}) and cipher suites
+ * ({@link SslContextFactory#setIncludeCipherSuites}), and (server side, merge rule 4) the authoritative
+ * client-auth mode ({@link SslContextFactory.Server#setNeedClientAuth} /
+ * {@link SslContextFactory.Server#setWantClientAuth}). The companion is requested one-shot (a
+ * factory-supplied {@code SslContextFactory.Server} would reload internally, but this synthesized factory
+ * applies protocols/ciphers/client-auth once at build time — they cannot change on a bare {@code reload});
+ * {@code empty()} leaves the consumer's configuration in force, exactly as before.
+ */
+@CustomLog
+public final class JettyTlsFactory {
+
+    static {
+        // DO NOT EDIT - Load Conscrypt provider
+        if (JcaProviders.CONSCRYPT_PROVIDER != null) {
+        }
+    }
+
+    private JettyTlsFactory() {
+    }
+
+    /**
+     * A synthesized, self-reloading Jetty server factory together with the subscription that drives it;
+     * dispose the {@link #subscription()} when the web service stops.
+     *
+     * @param sslContextFactory the (unstarted) Jetty server factory
+     * @param subscription      the reload subscription backing the factory
+     */
+    public record ReloadableServerTls(SslContextFactory.Server sslContextFactory,
+                                      TlsHandle<SSLContext> subscription) {
+    }
+
+    /**
+     * A synthesized, self-reloading Jetty client factory together with the subscription that drives it;
+     * dispose the {@link #subscription()} when the owning HTTP client / servlet is destroyed.
+     *
+     * @param sslContextFactory the (unstarted) Jetty client factory
+     * @param subscription      the reload subscription backing the factory
+     */
+    public record ReloadableClientTls(SslContextFactory.Client sslContextFactory,
+                                      TlsHandle<SSLContext> subscription) {
+    }
+
+    /**
+     * Build a self-reloading {@link SslContextFactory.Server} for a purpose, handed back <em>unstarted</em>
+     * (Jetty starts it with the connector lifecycle) with its initial {@code SSLContext} already set.
+     *
+     * @param factory                  the TLS factory to subscribe to
+     * @param purpose                  the server purpose (e.g. {@link TlsPurpose#WEB})
+     * @param sslProviderString        the JCE provider name, or {@code null}/empty for the default
+     * @param requireTrustedClientCert whether to require (vs. request) a trusted client certificate
+     * @param allowInsecureConnection  whether an untrusted client cert is accepted under optional client auth
+     * @param ciphers                  enabled cipher suites, or {@code null} for defaults
+     * @param protocols                enabled protocols, or {@code null} for defaults
+     * @return the reloading factory and its subscription handle
+     */
+    public static ReloadableServerTls createReloadingServerFactory(PulsarTlsFactory factory, TlsPurpose purpose,
+                                                                   String sslProviderString,
+                                                                   boolean requireTrustedClientCert,
+                                                                   boolean allowInsecureConnection,
+                                                                   Set<String> ciphers, Set<String> protocols) {
+        SslContextFactory.Server sslContextFactory = new SslContextFactory.Server();
+        applyServerConfig(sslContextFactory, sslProviderString, requireTrustedClientCert, allowInsecureConnection,
+                ciphers, protocols);
+        // Merge the factory's engine-policy companion (if any) over the consumer config, before start.
+        resolveBaselineParameters(factory, purpose)
+                .ifPresent(baseline -> applyServerBaseline(sslContextFactory, baseline));
+
+        Consumer<SSLContext> onLoadOrReload = newContext -> {
+            if (sslContextFactory.isStarted()) {
+                try {
+                    sslContextFactory.reload(f -> ((SslContextFactory.Server) f).setSslContext(newContext));
+                } catch (Exception e) {
+                    log.warn().attr("purpose", purpose).exception(e)
+                            .log("Failed to reload Jetty SslContextFactory; keeping the running context");
+                }
+            } else {
+                // Initial load (or a reload before the connector started): set directly before start.
+                sslContextFactory.setSslContext(newContext);
+            }
+        };
+
+        TlsHandle<SSLContext> subscription = factory.createInstance(purpose, SSLContext.class, onLoadOrReload)
+                .join()
+                .orElseThrow(() -> new IllegalStateException(
+                        "TLS factory supplied no SSLContext for purpose " + purpose));
+        return new ReloadableServerTls(sslContextFactory, subscription);
+    }
+
+    /**
+     * Build a self-reloading {@link SslContextFactory.Client} for a purpose (used by the proxy's
+     * {@code AdminProxyHandler}, whose Jetty {@code HttpClient} outlives broker-client material rotation),
+     * handed back <em>unstarted</em> with its initial {@code SSLContext} already set. This mirrors
+     * {@link #createReloadingServerFactory}: an {@code SSLContext} subscription drives
+     * {@link SslContextFactory#setSslContext(SSLContext)} before start, and on each later delivery
+     * {@link SslContextFactory#reload(Consumer)} atomically swaps the context so new connections use the
+     * rotated material. Dispose the returned {@link ReloadableClientTls#subscription()} when the owning
+     * client is destroyed.
+     *
+     * @param factory           the TLS factory to subscribe to
+     * @param purpose           the client purpose (e.g. {@link TlsPurpose#BROKER_CLIENT})
+     * @param sslProviderString the JCE provider name, or {@code null}/empty for the default
+     * @return the reloading client factory and its subscription handle
+     */
+    public static ReloadableClientTls createReloadingClientFactory(PulsarTlsFactory factory, TlsPurpose purpose,
+                                                                   String sslProviderString) {
+        SslContextFactory.Client client = new SslContextFactory.Client();
+        if (StringUtils.isNotBlank(sslProviderString)) {
+            client.setProvider(sslProviderString);
+        }
+        // Pin the {TLSv1.3, TLSv1.2} floor (B3), matching the native path; a factory companion overrides it below.
+        client.setIncludeProtocols(TlsContexts.DEFAULT_ENABLED_PROTOCOLS.toArray(new String[0]));
+        // Merge the factory's engine-policy companion (if any): protocols/ciphers only — client-auth is a
+        // server concept, and SNI/hostname verification stay per-connection.
+        resolveBaselineParameters(factory, purpose)
+                .ifPresent(baseline -> applyClientBaseline(client, baseline));
+
+        Consumer<SSLContext> onLoadOrReload = newContext -> {
+            if (client.isStarted()) {
+                try {
+                    client.reload(f -> ((SslContextFactory.Client) f).setSslContext(newContext));
+                } catch (Exception e) {
+                    log.warn().attr("purpose", purpose).exception(e)
+                            .log("Failed to reload Jetty client SslContextFactory; keeping the running context");
+                }
+            } else {
+                // Initial load (or a reload before the client started): set directly before start.
+                client.setSslContext(newContext);
+            }
+        };
+
+        TlsHandle<SSLContext> subscription = factory.createInstance(purpose, SSLContext.class, onLoadOrReload)
+                .join()
+                .orElseThrow(() -> new IllegalStateException(
+                        "TLS factory supplied no SSLContext for purpose " + purpose));
+        return new ReloadableClientTls(client, subscription);
+    }
+
+    private static void applyServerConfig(SslContextFactory.Server sslContextFactory, String sslProviderString,
+                                          boolean requireTrustedClientCertOnConnect, boolean allowInsecureConnection,
+                                          Set<String> ciphers, Set<String> protocols) {
+        if (ciphers != null && !ciphers.isEmpty()) {
+            sslContextFactory.setIncludeCipherSuites(ciphers.toArray(new String[0]));
+        }
+        // Pin the enabled protocols even when unconfigured, matching the {TLSv1.3, TLSv1.2} floor the native
+        // Netty path applies rather than deferring to the provider default (B3). A factory-supplied companion,
+        // applied afterwards by applyServerBaseline, still overrides this.
+        if (protocols != null && !protocols.isEmpty()) {
+            sslContextFactory.setIncludeProtocols(protocols.toArray(new String[0]));
+        } else {
+            sslContextFactory.setIncludeProtocols(TlsContexts.DEFAULT_ENABLED_PROTOCOLS.toArray(new String[0]));
+        }
+        if (StringUtils.isNotBlank(sslProviderString)) {
+            sslContextFactory.setProvider(sslProviderString);
+        }
+        if (requireTrustedClientCertOnConnect) {
+            sslContextFactory.setNeedClientAuth(true);
+            sslContextFactory.setTrustAll(false);
+        } else {
+            // PIP-478 (F2): optional client auth requests but does not require a client cert. An untrusted
+            // client cert is accepted at the handshake only when tlsAllowInsecureConnection=true, aligning the
+            // web listener with the Netty binary listener's D3 semantics and diverging from the pre-5.0 Jetty
+            // path, which trusted any presented client cert whenever client auth was optional (see PIP-478
+            // Security Considerations).
+            //
+            // The actual enforcement is the trust managers baked into the SSLContext the framework hands to
+            // Jetty via setSslContext (built from the WEB TlsPolicy's allowInsecureConnection: CA-validating
+            // when secure, insecure-trust-all when insecure). Jetty's own setTrustAll only takes effect when
+            // Jetty builds the SSLContext itself, so it is inert on this setSslContext path; we still scope it
+            // to the insecure flag so the two never disagree (defence in depth) rather than leaving the
+            // inherited unconditional setTrustAll(true).
+            sslContextFactory.setWantClientAuth(true);
+            sslContextFactory.setTrustAll(allowInsecureConnection);
+        }
+        // https://jetty.org/docs/jetty/12.1/operations-guide/protocols/index.html#ssl-sni
+        // Set to false for backwards compatibility with Jetty 9.x
+        sslContextFactory.setSniRequired(false);
+    }
+
+    /**
+     * Request the factory's optional {@code SSLParameters} companion for a purpose (one-shot), returning the
+     * supplied instance or {@link Optional#empty()} when the factory supplies none. Runs at factory-build time,
+     * off any event loop; the handle is disposed immediately (a companion carries no reference-counted state).
+     */
+    private static Optional<SSLParameters> resolveBaselineParameters(PulsarTlsFactory factory, TlsPurpose purpose) {
+        return factory.createInstance(purpose, SSLParameters.class)
+                .join()
+                .map(handle -> {
+                    try {
+                        return handle.get();
+                    } finally {
+                        handle.dispose();
+                    }
+                });
+    }
+
+    /**
+     * Overlay a factory-supplied engine baseline onto a synthesized server factory (PIP-478 merge order):
+     * enabled protocols/cipher suites when the companion sets them, and the companion's client-auth mode as
+     * authoritative (rule 4) — {@code needClientAuth} wins over {@code wantClientAuth}, neither means none.
+     */
+    private static void applyServerBaseline(SslContextFactory.Server sslContextFactory, SSLParameters baseline) {
+        if (baseline.getProtocols() != null) {
+            sslContextFactory.setIncludeProtocols(baseline.getProtocols());
+        }
+        if (baseline.getCipherSuites() != null) {
+            sslContextFactory.setIncludeCipherSuites(baseline.getCipherSuites());
+        }
+        if (baseline.getNeedClientAuth()) {
+            sslContextFactory.setNeedClientAuth(true);
+        } else if (baseline.getWantClientAuth()) {
+            sslContextFactory.setNeedClientAuth(false);
+            sslContextFactory.setWantClientAuth(true);
+        } else {
+            sslContextFactory.setNeedClientAuth(false);
+            sslContextFactory.setWantClientAuth(false);
+        }
+    }
+
+    /**
+     * Overlay a factory-supplied engine baseline onto a synthesized client factory: enabled protocols/cipher
+     * suites only (client-auth is a server concept; SNI/hostname verification remain per-connection).
+     */
+    private static void applyClientBaseline(SslContextFactory.Client client, SSLParameters baseline) {
+        if (baseline.getProtocols() != null) {
+            client.setIncludeProtocols(baseline.getProtocols());
+        }
+        if (baseline.getCipherSuites() != null) {
+            client.setIncludeCipherSuites(baseline.getCipherSuites());
+        }
+    }
+}

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/tls/DefaultBrokerTlsFactoryTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/tls/DefaultBrokerTlsFactoryTest.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.tls;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import com.google.common.io.Resources;
+import io.netty.handler.ssl.SslContext;
+import io.opentelemetry.api.OpenTelemetry;
+import java.io.File;
+import java.time.Clock;
+import java.util.Map;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import javax.net.ssl.SSLContext;
+import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.client.api.Authentication;
+import org.apache.pulsar.client.api.AuthenticationDataProvider;
+import org.apache.pulsar.common.tls.TlsFactoryInitContext;
+import org.apache.pulsar.common.tls.TlsPurpose;
+import org.apache.pulsar.common.util.tls.PemReader;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class DefaultBrokerTlsFactoryTest {
+
+    private static final String CA = resource("certificate-authority/certs/ca.cert.pem");
+    private static final String BROKER_CERT = resource("certificate-authority/server-keys/broker.cert.pem");
+    private static final String BROKER_KEY = resource("certificate-authority/server-keys/broker.key-pk8.pem");
+    private static final String ADMIN_CERT = resource("certificate-authority/client-keys/admin.cert.pem");
+    private static final String ADMIN_KEY = resource("certificate-authority/client-keys/admin.key-pk8.pem");
+    private static final String KEYSTORE = resource("certificate-authority/jks/broker.keystore.jks");
+    private static final String TRUSTSTORE = resource("certificate-authority/jks/broker.truststore.jks");
+
+    private ScheduledExecutorService scheduler;
+
+    @BeforeMethod
+    public void setUp() {
+        scheduler = Executors.newSingleThreadScheduledExecutor();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void tearDown() {
+        scheduler.shutdownNow();
+    }
+
+    @Test
+    public void composesAllPurposesFromPemConfig() throws Exception {
+        ServiceConfiguration conf = new ServiceConfiguration();
+        conf.setTlsTrustCertsFilePath(CA);
+        conf.setTlsCertificateFilePath(BROKER_CERT);
+        conf.setTlsKeyFilePath(BROKER_KEY);
+        conf.setBrokerClientTrustCertsFilePath(CA);
+        conf.setBrokerClientCertificateFilePath(ADMIN_CERT);
+        conf.setBrokerClientKeyFilePath(ADMIN_KEY);
+
+        DefaultBrokerTlsFactory factory = DefaultBrokerTlsFactory.fromServiceConfiguration(conf);
+        factory.initialize(initContext()).join();
+
+        // Server purposes build server contexts; the broker-client purpose builds a client context.
+        for (TlsPurpose purpose : new TlsPurpose[] {TlsPurpose.BROKER, TlsPurpose.PROXY, TlsPurpose.WEB,
+                TlsPurpose.BROKER_CLIENT}) {
+            assertThat(factory.createInstance(purpose, SslContext.class).join())
+                    .as("Netty context for " + purpose).isPresent();
+            assertThat(factory.createInstance(purpose, SSLContext.class).join())
+                    .as("JDK context for " + purpose).isPresent();
+        }
+        factory.close();
+    }
+
+    @Test
+    public void composesServerPurposesFromKeystoreConfig() throws Exception {
+        ServiceConfiguration conf = new ServiceConfiguration();
+        conf.setTlsEnabledWithKeyStore(true);
+        conf.setTlsKeyStoreType("JKS");
+        conf.setTlsKeyStore(KEYSTORE);
+        conf.setTlsKeyStorePassword("111111");
+        conf.setTlsTrustStoreType("JKS");
+        conf.setTlsTrustStore(TRUSTSTORE);
+        conf.setTlsTrustStorePassword("111111");
+
+        DefaultBrokerTlsFactory factory = DefaultBrokerTlsFactory.fromServiceConfiguration(conf);
+        factory.initialize(initContext()).join();
+
+        assertThat(factory.createInstance(TlsPurpose.BROKER, SslContext.class).join()).isPresent();
+        assertThat(factory.createInstance(TlsPurpose.WEB, SSLContext.class).join()).isPresent();
+        factory.close();
+    }
+
+    @Test
+    public void foldsBrokerClientAuthMaterialOverBlankFilePolicy() throws Exception {
+        // No brokerClient*FilePath cert/key: the broker-client authentication plugin supplies the identity.
+        ServiceConfiguration conf = new ServiceConfiguration();
+        conf.setTlsTrustCertsFilePath(CA);
+        conf.setTlsCertificateFilePath(BROKER_CERT);
+        conf.setTlsKeyFilePath(BROKER_KEY);
+        conf.setBrokerClientTrustCertsFilePath(CA);
+        conf.setBrokerClientAuthenticationPlugin("org.apache.pulsar.client.impl.auth.AuthenticationTls");
+
+        AuthenticationDataProvider authData = mock(AuthenticationDataProvider.class);
+        when(authData.hasDataForTls()).thenReturn(true);
+        when(authData.getTlsCertificates()).thenReturn(PemReader.loadCertificatesFromPemFile(ADMIN_CERT));
+        when(authData.getTlsPrivateKey()).thenReturn(PemReader.loadPrivateKeyFromPemFile(ADMIN_KEY));
+        Authentication brokerClientAuth = mock(Authentication.class);
+        when(brokerClientAuth.getAuthData()).thenReturn(authData);
+
+        DefaultBrokerTlsFactory factory = DefaultBrokerTlsFactory.fromServiceConfiguration(conf, brokerClientAuth);
+        factory.initialize(initContext()).join();
+
+        // The BROKER_CLIENT client context builds from the folded auth material (blank file cert/key would
+        // otherwise yield no client identity). The fold semantics are proven in AuthProvidedMaterialFoldTest.
+        assertThat(factory.createInstance(TlsPurpose.BROKER_CLIENT, SslContext.class).join())
+                .as("BROKER_CLIENT context folds the broker-client authentication material").isPresent();
+        assertThat(factory.createInstance(TlsPurpose.BROKER_CLIENT, SSLContext.class).join()).isPresent();
+        factory.close();
+    }
+
+    private TlsFactoryInitContext initContext() {
+        Executor direct = Runnable::run;
+        return new TlsFactoryInitContext() {
+            @Override
+            public Map<String, String> params() {
+                return Map.of();
+            }
+
+            @Override
+            public ScheduledExecutorService scheduler() {
+                return scheduler;
+            }
+
+            @Override
+            public Executor blockingExecutor() {
+                return direct;
+            }
+
+            @Override
+            public Clock clock() {
+                return Clock.systemUTC();
+            }
+
+            @Override
+            public OpenTelemetry openTelemetry() {
+                return OpenTelemetry.noop();
+            }
+        };
+    }
+
+    private static String resource(String name) {
+        return new File(Resources.getResource(name).getPath()).getAbsolutePath();
+    }
+}

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/tls/TlsFactorySupportTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/tls/TlsFactorySupportTest.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.tls;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import io.netty.handler.ssl.SslProvider;
+import io.opentelemetry.api.OpenTelemetry;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+import org.apache.pulsar.common.tls.PulsarTlsFactory;
+import org.apache.pulsar.common.tls.TlsFactoryInitContext;
+import org.apache.pulsar.common.tls.TlsHandle;
+import org.apache.pulsar.common.tls.TlsPurpose;
+import org.testng.annotations.Test;
+
+/**
+ * Unit tests for the PIP-478 {@link TlsFactorySupport} helpers (the only server TLS path since the PIP-337
+ * removal, stage 4c).
+ */
+public class TlsFactorySupportTest {
+
+    @Test
+    public void isLegacyCustomDetectsRemovedPip337Plugin() {
+        // A non-blank, non-default sslFactoryPlugin names a removed PIP-337 factory -> the fail-loud trigger
+        // at server startup (stage 4c).
+        assertThat(TlsFactorySupport.isLegacyCustom("com.example.CustomSslFactory")).isTrue();
+        // A blank value OR the removed default's FQCN is treated as "the default" -> no failure.
+        assertThat(TlsFactorySupport.isLegacyCustom("org.apache.pulsar.common.util.DefaultPulsarSslFactory"))
+                .isFalse();
+        assertThat(TlsFactorySupport.isLegacyCustom("")).isFalse();
+        assertThat(TlsFactorySupport.isLegacyCustom(null)).isFalse();
+    }
+
+    @Test
+    public void createFactoryUsesDefaultForBlankSentinelOrDefaultClassName() throws Exception {
+        PulsarTlsFactory sentinel = new NoOpTlsFactory();
+        assertThat(TlsFactorySupport.createFactory("", NoOpTlsFactory.class, () -> sentinel)).isSameAs(sentinel);
+        assertThat(TlsFactorySupport.createFactory("default", NoOpTlsFactory.class, () -> sentinel))
+                .isSameAs(sentinel);
+        assertThat(TlsFactorySupport.createFactory("DEFAULT", NoOpTlsFactory.class, () -> sentinel))
+                .isSameAs(sentinel);
+        assertThat(TlsFactorySupport.createFactory(NoOpTlsFactory.class.getName(), NoOpTlsFactory.class,
+                () -> sentinel)).isSameAs(sentinel);
+    }
+
+    @Test
+    public void createFactoryInstantiatesNamedCustomClassReflectively() throws Exception {
+        PulsarTlsFactory sentinel = new NoOpTlsFactory();
+        PulsarTlsFactory created =
+                TlsFactorySupport.createFactory(NoOpTlsFactory.class.getName(), null, () -> sentinel);
+        // With no defaultFactoryClass to match, the class name is instantiated reflectively (a new instance).
+        assertThat(created).isInstanceOf(NoOpTlsFactory.class).isNotSameAs(sentinel);
+    }
+
+    @Test
+    public void parseFactoryConfigHandlesBlankJsonAndKeyValue() {
+        assertThat(TlsFactorySupport.parseFactoryConfig("")).isEmpty();
+        assertThat(TlsFactorySupport.parseFactoryConfig(null)).isEmpty();
+        assertThat(TlsFactorySupport.parseFactoryConfig("{\"a\":\"1\",\"b\":\"2\"}"))
+                .containsEntry("a", "1").containsEntry("b", "2");
+        assertThat(TlsFactorySupport.parseFactoryConfig("a=1, b = 2 ,c="))
+                .containsEntry("a", "1").containsEntry("b", "2").containsEntry("c", "");
+    }
+
+    @Test
+    public void engineProviderMapsOnlyExplicitOpenSsl() {
+        assertThat(TlsFactorySupport.engineProvider(null)).isEqualTo(SslProvider.JDK);
+        assertThat(TlsFactorySupport.engineProvider("Conscrypt")).isEqualTo(SslProvider.JDK);
+        assertThat(TlsFactorySupport.engineProvider("SunJSSE")).isEqualTo(SslProvider.JDK);
+        assertThat(TlsFactorySupport.engineProvider("openssl")).isEqualTo(SslProvider.OPENSSL);
+        assertThat(TlsFactorySupport.engineProvider("OPENSSL_REFCNT")).isEqualTo(SslProvider.OPENSSL);
+    }
+
+    @Test
+    public void initContextWiresServicesAndDefaultsOpenTelemetry() {
+        TlsFactoryInitContext ctx = TlsFactorySupport.initContext(java.util.Map.of("k", "v"), null, null, null);
+        assertThat(ctx.params()).containsEntry("k", "v");
+        assertThat(ctx.clock()).isNotNull();
+        assertThat(ctx.openTelemetry()).isSameAs(OpenTelemetry.noop());
+    }
+
+    /** A public no-arg {@link PulsarTlsFactory} for reflective-instantiation testing. */
+    public static final class NoOpTlsFactory implements PulsarTlsFactory {
+        @Override
+        public CompletableFuture<Void> initialize(TlsFactoryInitContext context) {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        @Override
+        public <T> CompletableFuture<Optional<TlsHandle<T>>> createInstance(TlsPurpose purpose,
+                                                                            Class<T> instanceClass) {
+            return CompletableFuture.completedFuture(Optional.empty());
+        }
+
+        @Override
+        public <T> CompletableFuture<Optional<TlsHandle<T>>> createInstance(TlsPurpose purpose,
+                                                                            Class<T> instanceClass,
+                                                                            Consumer<T> onLoadOrReload) {
+            return CompletableFuture.completedFuture(Optional.empty());
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+}

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/jetty/tls/JettyTlsFactoryTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/jetty/tls/JettyTlsFactoryTest.java
@@ -1,0 +1,652 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.jetty.tls;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import com.google.common.io.Resources;
+import io.opentelemetry.api.OpenTelemetry;
+import java.io.File;
+import java.io.IOException;
+import java.math.BigInteger;
+import java.net.Socket;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.FileTime;
+import java.security.KeyStore;
+import java.security.Principal;
+import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
+import java.time.Clock;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLServerSocket;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509ExtendedKeyManager;
+import org.apache.commons.io.FileUtils;
+import org.apache.pulsar.common.tls.PulsarTlsFactory;
+import org.apache.pulsar.common.tls.TlsFactoryInitContext;
+import org.apache.pulsar.common.tls.TlsHandle;
+import org.apache.pulsar.common.tls.TlsPolicy;
+import org.apache.pulsar.common.tls.TlsPurpose;
+import org.apache.pulsar.common.tls.impl.FileBasedTlsFactory;
+import org.apache.pulsar.common.tls.impl.FileBasedTlsFactorySettings;
+import org.apache.pulsar.common.util.tls.JdkSslContexts;
+import org.apache.pulsar.common.util.tls.PemReader;
+import org.awaitility.Awaitility;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class JettyTlsFactoryTest {
+
+    private static final String CA = resource("certificate-authority/certs/ca.cert.pem");
+    private static final String BROKER_CERT = resource("certificate-authority/server-keys/broker.cert.pem");
+    private static final String BROKER_KEY = resource("certificate-authority/server-keys/broker.key-pk8.pem");
+    private static final String PROXY_CERT = resource("certificate-authority/server-keys/proxy.cert.pem");
+    private static final String PROXY_KEY = resource("certificate-authority/server-keys/proxy.key-pk8.pem");
+    // Client certificates (clientAuth EKU) trusted by the shared CA above.
+    private static final String TRUSTED_CLIENT_CERT = resource("certificate-authority/client-keys/admin.cert.pem");
+    private static final String TRUSTED_CLIENT_KEY = resource("certificate-authority/client-keys/admin.key-pk8.pem");
+    private static final String USER1_CLIENT_CERT = resource("certificate-authority/client-keys/user1.cert.pem");
+    private static final String USER1_CLIENT_KEY = resource("certificate-authority/client-keys/user1.key-pk8.pem");
+    // A self-signed client certificate NOT signed by the shared CA (from a separate my-ca root).
+    private static final String UNTRUSTED_CLIENT_CERT = resource("ssl/my-ca/client-ca.pem");
+    private static final String UNTRUSTED_CLIENT_KEY = resource("ssl/my-ca/client-key.pem");
+
+    private ScheduledExecutorService scheduler;
+    private Path tempDir;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        scheduler = Executors.newSingleThreadScheduledExecutor();
+        tempDir = Files.createTempDirectory("pip478-jetty-");
+        Files.copy(Paths.get(CA), tempDir.resolve("ca.pem"), StandardCopyOption.REPLACE_EXISTING);
+        Files.copy(Paths.get(BROKER_CERT), tempDir.resolve("cert.pem"), StandardCopyOption.REPLACE_EXISTING);
+        Files.copy(Paths.get(BROKER_KEY), tempDir.resolve("key.pem"), StandardCopyOption.REPLACE_EXISTING);
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void tearDown() throws Exception {
+        scheduler.shutdownNow();
+        if (tempDir != null) {
+            FileUtils.deleteDirectory(tempDir.toFile());
+        }
+    }
+
+    @Test
+    public void reloadingServerFactoryServesRotatedCertificateToNewConnections() throws Exception {
+        FileBasedTlsFactory factory = new FileBasedTlsFactory(
+                Map.of(TlsPurpose.WEB, TlsPolicy.pem(tempDir.resolve("ca.pem").toString(),
+                        tempDir.resolve("cert.pem").toString(), tempDir.resolve("key.pem").toString())),
+                FileBasedTlsFactorySettings.builder().refreshIntervalSeconds(1).build());
+        factory.initialize(initContext()).join();
+
+        JettyTlsFactory.ReloadableServerTls reloadable = JettyTlsFactory.createReloadingServerFactory(
+                factory, TlsPurpose.WEB, null, false, false, null, null);
+
+        Server server = new Server();
+        ServerConnector connector = new ServerConnector(server, reloadable.sslContextFactory());
+        connector.setPort(0);
+        server.setConnectors(new ServerConnector[] {connector});
+        server.start();
+        try {
+            SSLContext clientContext = JdkSslContexts.createSslContext(false,
+                    PemReader.loadCertificatesFromPemFile(CA), null, null);
+            int port = connector.getLocalPort();
+
+            BigInteger initialSerial = serverCertSerial(clientContext, port);
+            assertThat(initialSerial).isEqualTo(certSerial(BROKER_CERT));
+
+            // Rotate the server material to a different (proxy) certificate signed by the same CA.
+            Files.copy(Paths.get(PROXY_CERT), tempDir.resolve("cert.pem"), StandardCopyOption.REPLACE_EXISTING);
+            Files.copy(Paths.get(PROXY_KEY), tempDir.resolve("key.pem"), StandardCopyOption.REPLACE_EXISTING);
+            long later = System.currentTimeMillis() + 5000;
+            Files.setLastModifiedTime(tempDir.resolve("cert.pem"), FileTime.fromMillis(later));
+            Files.setLastModifiedTime(tempDir.resolve("key.pem"), FileTime.fromMillis(later));
+
+            BigInteger proxySerial = certSerial(PROXY_CERT);
+            Awaitility.await().atMost(Duration.ofSeconds(15))
+                    .until(() -> serverCertSerial(clientContext, port).equals(proxySerial));
+            assertThat(serverCertSerial(clientContext, port))
+                    .as("new connections use the rotated certificate")
+                    .isEqualTo(proxySerial).isNotEqualTo(initialSerial);
+        } finally {
+            reloadable.subscription().dispose();
+            server.stop();
+            factory.close();
+        }
+    }
+
+    /**
+     * PIP-478 (F3): a self-reloading {@link SslContextFactory.Client} presents rotated client-certificate
+     * material to new connections while the factory stays alive (mirrors the stage-2a server rotation test).
+     */
+    @Test
+    public void reloadingClientFactoryPresentsRotatedClientCertOnNewConnections() throws Exception {
+        // Distinct filenames from the server rotation test's cert.pem/key.pem; these hold a client-auth
+        // certificate (the broker/proxy server certs carry a serverAuth-only EKU and cannot be presented as
+        // a client identity).
+        Path clientCert = tempDir.resolve("clientcert.pem");
+        Path clientKey = tempDir.resolve("clientkey.pem");
+        Files.copy(Paths.get(TRUSTED_CLIENT_CERT), clientCert, StandardCopyOption.REPLACE_EXISTING);
+        Files.copy(Paths.get(TRUSTED_CLIENT_KEY), clientKey, StandardCopyOption.REPLACE_EXISTING);
+
+        FileBasedTlsFactory factory = new FileBasedTlsFactory(
+                Map.of(TlsPurpose.BROKER_CLIENT, TlsPolicy.pem(tempDir.resolve("ca.pem").toString(),
+                        clientCert.toString(), clientKey.toString())),
+                FileBasedTlsFactorySettings.builder().refreshIntervalSeconds(1).build());
+        factory.initialize(initContext()).join();
+
+        JettyTlsFactory.ReloadableClientTls reloadable = JettyTlsFactory.createReloadingClientFactory(
+                factory, TlsPurpose.BROKER_CLIENT, null);
+        SslContextFactory.Client clientFactory = reloadable.sslContextFactory();
+        clientFactory.start();
+        try {
+            assertThat(presentedClientCertSerial(clientFactory)).isEqualTo(certSerial(TRUSTED_CLIENT_CERT));
+
+            // Rotate the client identity to a different client certificate signed by the same CA.
+            Files.copy(Paths.get(USER1_CLIENT_CERT), clientCert, StandardCopyOption.REPLACE_EXISTING);
+            Files.copy(Paths.get(USER1_CLIENT_KEY), clientKey, StandardCopyOption.REPLACE_EXISTING);
+            long later = System.currentTimeMillis() + 5000;
+            Files.setLastModifiedTime(clientCert, FileTime.fromMillis(later));
+            Files.setLastModifiedTime(clientKey, FileTime.fromMillis(later));
+
+            BigInteger rotatedSerial = certSerial(USER1_CLIENT_CERT);
+            Awaitility.await().atMost(Duration.ofSeconds(15))
+                    .until(() -> presentedClientCertSerial(clientFactory).equals(rotatedSerial));
+            assertThat(presentedClientCertSerial(clientFactory))
+                    .as("new connections present the rotated client certificate")
+                    .isEqualTo(rotatedSerial).isNotEqualTo(certSerial(TRUSTED_CLIENT_CERT));
+        } finally {
+            clientFactory.stop();
+            reloadable.subscription().dispose();
+            factory.close();
+        }
+    }
+
+    // Handshake the reloading client factory's current context against a client-auth-requiring server and
+    // return the serial of the client certificate the server observed.
+    private BigInteger presentedClientCertSerial(SslContextFactory.Client clientFactory) throws Exception {
+        SSLContext serverContext = JdkSslContexts.createSslContext(false, CA, BROKER_CERT, BROKER_KEY, null);
+        try (SSLServerSocket serverSocket =
+                     (SSLServerSocket) serverContext.getServerSocketFactory().createServerSocket(0)) {
+            serverSocket.setNeedClientAuth(true);
+            // TLSv1.2 so client auth completes symmetrically within the handshake (avoids the TLS 1.3
+            // post-handshake close race where the server closes before the client flushes its Finished).
+            serverSocket.setEnabledProtocols(new String[] {"TLSv1.2"});
+            serverSocket.setSoTimeout(15000);
+            int port = serverSocket.getLocalPort();
+            CompletableFuture<BigInteger> serverSaw = new CompletableFuture<>();
+            Thread serverThread = new Thread(() -> {
+                try (SSLSocket accepted = (SSLSocket) serverSocket.accept()) {
+                    accepted.setSoTimeout(15000);
+                    accepted.startHandshake();
+                    X509Certificate peer = (X509Certificate) accepted.getSession().getPeerCertificates()[0];
+                    serverSaw.complete(peer.getSerialNumber());
+                } catch (Throwable t) {
+                    serverSaw.completeExceptionally(t);
+                }
+            });
+            serverThread.setDaemon(true);
+            serverThread.start();
+
+            SSLContext clientContext = clientFactory.getSslContext();
+            try (SSLSocket clientSocket =
+                         (SSLSocket) clientContext.getSocketFactory().createSocket("localhost", port)) {
+                clientSocket.setEnabledProtocols(new String[] {"TLSv1.2"});
+                clientSocket.setSoTimeout(15000);
+                clientSocket.startHandshake();
+            }
+            return serverSaw.get(15, TimeUnit.SECONDS);
+        }
+    }
+
+    /**
+     * PIP-478 (F2): under optional client auth ({@code requireTrustedClientCert=false}), an <em>untrusted</em>
+     * client certificate is rejected at the web listener's handshake when {@code allowInsecureConnection=false}
+     * and accepted when it is true; a trusted client certificate is accepted in both cases.
+     */
+    @Test
+    public void optionalClientAuthScopesTrustAllToInsecureFlag() throws Exception {
+        // Secure (insecure=false): untrusted client cert is rejected, trusted client cert is accepted. The
+        // server aborts the handshake, surfaced to the client either as an SSLHandshakeException or, once the
+        // server has already sent its close/alert, as a broken-pipe SocketException — both are handshake
+        // failures.
+        try (JettyServer secure = startWebServer(false)) {
+            assertThatThrownBy(() -> handshakeWithClientCert(secure.port, UNTRUSTED_CLIENT_CERT, UNTRUSTED_CLIENT_KEY))
+                    .as("an untrusted client cert must be rejected when insecure=false")
+                    .isInstanceOf(IOException.class);
+            handshakeWithClientCert(secure.port, TRUSTED_CLIENT_CERT, TRUSTED_CLIENT_KEY);
+        }
+        // Insecure (insecure=true): both untrusted and trusted client certs are accepted (trust-all).
+        try (JettyServer insecure = startWebServer(true)) {
+            handshakeWithClientCert(insecure.port, UNTRUSTED_CLIENT_CERT, UNTRUSTED_CLIENT_KEY);
+            handshakeWithClientCert(insecure.port, TRUSTED_CLIENT_CERT, TRUSTED_CLIENT_KEY);
+        }
+    }
+
+    /**
+     * PIP-478: a factory that supplies its {@code SSLContext} together with an {@code SSLParameters} companion
+     * drives the synthesized server {@link SslContextFactory.Server} — its enabled protocols/ciphers and its
+     * client-auth mode are mapped from the companion, the latter authoritatively (merge rule 4).
+     */
+    @Test
+    public void serverFactoryMapsCompanionProtocolsAndClientAuth() throws Exception {
+        SSLParameters companion = new SSLParameters();
+        companion.setProtocols(new String[] {"TLSv1.2"});
+        companion.setCipherSuites(new String[] {"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"});
+        companion.setNeedClientAuth(true);
+
+        FileBasedTlsFactory delegate = new FileBasedTlsFactory(
+                Map.of(TlsPurpose.WEB, TlsPolicy.pem(tempDir.resolve("ca.pem").toString(),
+                        tempDir.resolve("cert.pem").toString(), tempDir.resolve("key.pem").toString())),
+                FileBasedTlsFactorySettings.builder().build());
+        CompanionFactory factory = new CompanionFactory(delegate, companion);
+        factory.initialize(initContext()).join();
+
+        // Consumer config asks for no protocol/cipher restriction and only optional client auth; the companion
+        // overrides all three.
+        JettyTlsFactory.ReloadableServerTls reloadable = JettyTlsFactory.createReloadingServerFactory(
+                factory, TlsPurpose.WEB, null, false, false, null, null);
+        SslContextFactory.Server sslContextFactory = reloadable.sslContextFactory();
+        try {
+            assertThat(sslContextFactory.getIncludeProtocols()).containsExactly("TLSv1.2");
+            assertThat(sslContextFactory.getIncludeCipherSuites())
+                    .containsExactly("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256");
+            assertThat(sslContextFactory.getNeedClientAuth()).isTrue();
+        } finally {
+            reloadable.subscription().dispose();
+            factory.close();
+        }
+    }
+
+    /**
+     * T4: the companion's protocol restriction and {@code needClientAuth} are not just mapped onto the
+     * synthesized Jetty {@link SslContextFactory.Server} getters — they decide a real handshake against a live
+     * server. A trusted client certificate over the allowed protocol succeeds; a client presenting no
+     * certificate is rejected (needClientAuth); a client offering only a disallowed protocol is rejected.
+     */
+    @Test
+    public void serverCompanionNeedClientAuthAndProtocolEnforcedAtHandshake() throws Exception {
+        SSLParameters companion = new SSLParameters();
+        companion.setProtocols(new String[] {"TLSv1.2"});
+        companion.setNeedClientAuth(true);
+
+        FileBasedTlsFactory delegate = new FileBasedTlsFactory(
+                Map.of(TlsPurpose.WEB, TlsPolicy.pem(tempDir.resolve("ca.pem").toString(),
+                        tempDir.resolve("cert.pem").toString(), tempDir.resolve("key.pem").toString())),
+                FileBasedTlsFactorySettings.builder().build());
+        CompanionFactory factory = new CompanionFactory(delegate, companion);
+        factory.initialize(initContext()).join();
+
+        // Consumer config asks for no protocol restriction and only optional client auth; the companion wins.
+        JettyTlsFactory.ReloadableServerTls reloadable = JettyTlsFactory.createReloadingServerFactory(
+                factory, TlsPurpose.WEB, null, false, false, null, null);
+        Server server = new Server();
+        ServerConnector connector = new ServerConnector(server, reloadable.sslContextFactory());
+        connector.setPort(0);
+        server.setConnectors(new ServerConnector[] {connector});
+        server.start();
+        int port = connector.getLocalPort();
+        try {
+            // A trusted client certificate over the allowed protocol completes the handshake.
+            handshakeWithClientCert(port, TRUSTED_CLIENT_CERT, TRUSTED_CLIENT_KEY);
+            // The companion's needClientAuth rejects a client that presents no certificate.
+            assertThatThrownBy(() -> handshakeWithoutClientCert(port))
+                    .as("needClientAuth from the companion rejects a client with no certificate")
+                    .isInstanceOf(IOException.class);
+            // The companion's TLSv1.2-only restriction rejects a client offering only TLSv1.3.
+            assertThatThrownBy(() -> handshakeWithClientCert(port, TRUSTED_CLIENT_CERT, TRUSTED_CLIENT_KEY,
+                    "TLSv1.3"))
+                    .as("a TLSv1.3-only client cannot handshake with the companion-pinned TLSv1.2 server")
+                    .isInstanceOf(IOException.class);
+        } finally {
+            reloadable.subscription().dispose();
+            server.stop();
+            factory.close();
+        }
+    }
+
+    /**
+     * B3: with no configured protocols and no factory companion, the synthesized Jetty server/client factories
+     * pin the {@code {TLSv1.3, TLSv1.2}} floor (matching the native Netty path) rather than deferring to the
+     * provider default.
+     */
+    @Test
+    public void defaultProtocolsPinnedWhenUnconfigured() throws Exception {
+        FileBasedTlsFactory factory = new FileBasedTlsFactory(
+                Map.of(TlsPurpose.WEB, TlsPolicy.pem(tempDir.resolve("ca.pem").toString(),
+                        tempDir.resolve("cert.pem").toString(), tempDir.resolve("key.pem").toString())),
+                FileBasedTlsFactorySettings.builder().build());
+        factory.initialize(initContext()).join();
+
+        JettyTlsFactory.ReloadableServerTls server = JettyTlsFactory.createReloadingServerFactory(
+                factory, TlsPurpose.WEB, null, false, false, null, null);
+        JettyTlsFactory.ReloadableClientTls client = JettyTlsFactory.createReloadingClientFactory(
+                factory, TlsPurpose.WEB, null);
+        try {
+            assertThat(server.sslContextFactory().getIncludeProtocols())
+                    .containsExactlyInAnyOrder("TLSv1.3", "TLSv1.2");
+            assertThat(client.sslContextFactory().getIncludeProtocols())
+                    .containsExactlyInAnyOrder("TLSv1.3", "TLSv1.2");
+        } finally {
+            server.subscription().dispose();
+            client.subscription().dispose();
+            factory.close();
+        }
+    }
+
+    /**
+     * PIP-478: the synthesized client {@link SslContextFactory.Client} maps the companion's enabled
+     * protocols/ciphers (client-auth is a server concept and is not mapped on the client factory).
+     */
+    @Test
+    public void clientFactoryMapsCompanionProtocols() throws Exception {
+        Path clientCert = tempDir.resolve("clientcert.pem");
+        Path clientKey = tempDir.resolve("clientkey.pem");
+        Files.copy(Paths.get(TRUSTED_CLIENT_CERT), clientCert, StandardCopyOption.REPLACE_EXISTING);
+        Files.copy(Paths.get(TRUSTED_CLIENT_KEY), clientKey, StandardCopyOption.REPLACE_EXISTING);
+
+        SSLParameters companion = new SSLParameters();
+        companion.setProtocols(new String[] {"TLSv1.2"});
+
+        FileBasedTlsFactory delegate = new FileBasedTlsFactory(
+                Map.of(TlsPurpose.BROKER_CLIENT, TlsPolicy.pem(tempDir.resolve("ca.pem").toString(),
+                        clientCert.toString(), clientKey.toString())),
+                FileBasedTlsFactorySettings.builder().build());
+        CompanionFactory factory = new CompanionFactory(delegate, companion);
+        factory.initialize(initContext()).join();
+
+        JettyTlsFactory.ReloadableClientTls reloadable = JettyTlsFactory.createReloadingClientFactory(
+                factory, TlsPurpose.BROKER_CLIENT, null);
+        try {
+            assertThat(reloadable.sslContextFactory().getIncludeProtocols()).containsExactly("TLSv1.2");
+        } finally {
+            reloadable.subscription().dispose();
+            factory.close();
+        }
+    }
+
+    /**
+     * A factory that delegates every request to a {@link FileBasedTlsFactory} except the {@code SSLParameters}
+     * companion, which it supplies from a fixed instance (the file-based factory returns {@code empty()} for it).
+     */
+    private static final class CompanionFactory implements PulsarTlsFactory {
+        private final FileBasedTlsFactory delegate;
+        private final SSLParameters companion;
+
+        CompanionFactory(FileBasedTlsFactory delegate, SSLParameters companion) {
+            this.delegate = delegate;
+            this.companion = companion;
+        }
+
+        @Override
+        public CompletableFuture<Void> initialize(TlsFactoryInitContext context) {
+            return delegate.initialize(context);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> CompletableFuture<Optional<TlsHandle<T>>> createInstance(TlsPurpose purpose,
+                                                                            Class<T> instanceClass) {
+            if (instanceClass == SSLParameters.class) {
+                return CompletableFuture.completedFuture(Optional.of((TlsHandle<T>) companionHandle()));
+            }
+            return delegate.createInstance(purpose, instanceClass);
+        }
+
+        @Override
+        public <T> CompletableFuture<Optional<TlsHandle<T>>> createInstance(
+                TlsPurpose purpose, Class<T> instanceClass, Consumer<T> onLoadOrReload) {
+            return delegate.createInstance(purpose, instanceClass, onLoadOrReload);
+        }
+
+        private TlsHandle<SSLParameters> companionHandle() {
+            return new TlsHandle<>() {
+                @Override
+                public SSLParameters get() {
+                    return companion;
+                }
+
+                @Override
+                public void dispose() {
+                }
+            };
+        }
+
+        @Override
+        public void close() {
+            delegate.close();
+        }
+    }
+
+    /** A running Jetty HTTPS server (WEB purpose, optional client auth) and its resources. */
+    private final class JettyServer implements AutoCloseable {
+        private final Server server;
+        private final FileBasedTlsFactory factory;
+        private final JettyTlsFactory.ReloadableServerTls reloadable;
+        private final int port;
+
+        JettyServer(boolean allowInsecureConnection) throws Exception {
+            // The trust gate lives in the WEB SSLContext's trust managers (built from the policy's insecure
+            // flag), which the framework hands to Jetty via setSslContext — Jetty's own setTrustAll is inert
+            // on that path. So the policy's allowInsecureConnection is what actually scopes client-cert trust.
+            factory = new FileBasedTlsFactory(
+                    Map.of(TlsPurpose.WEB, TlsPolicy.builder()
+                            .format(TlsPolicy.Format.PEM)
+                            .trustCertsFilePath(CA).certificateFilePath(BROKER_CERT).keyFilePath(BROKER_KEY)
+                            .allowInsecureConnection(allowInsecureConnection)
+                            .enableHostnameVerification(false)
+                            .build()),
+                    FileBasedTlsFactorySettings.builder().build());
+            factory.initialize(initContext()).join();
+            // Optional client auth (requireTrustedClientCert=false); TLSv1.2 so an untrusted-cert rejection
+            // surfaces synchronously in the client handshake rather than as a post-handshake alert.
+            reloadable = JettyTlsFactory.createReloadingServerFactory(factory, TlsPurpose.WEB, null,
+                    false, allowInsecureConnection, null, Set.of("TLSv1.2"));
+            server = new Server();
+            ServerConnector connector = new ServerConnector(server, reloadable.sslContextFactory());
+            connector.setPort(0);
+            server.setConnectors(new ServerConnector[] {connector});
+            server.start();
+            port = connector.getLocalPort();
+        }
+
+        @Override
+        public void close() throws Exception {
+            reloadable.subscription().dispose();
+            server.stop();
+            factory.close();
+        }
+    }
+
+    private JettyServer startWebServer(boolean allowInsecureConnection) throws Exception {
+        return new JettyServer(allowInsecureConnection);
+    }
+
+    // Connect presenting a client certificate over TLSv1.2 and complete the handshake (throws on rejection).
+    // The key manager is forced to always present the given certificate regardless of the server's advertised
+    // acceptable-CA list, so an untrusted certificate is actually sent (and therefore rejected) rather than
+    // silently withheld by the default JSSE key manager.
+    private void handshakeWithClientCert(int port, String clientCert, String clientKey) throws Exception {
+        handshakeWithClientCert(port, clientCert, clientKey, "TLSv1.2");
+    }
+
+    private void handshakeWithClientCert(int port, String clientCert, String clientKey, String protocol)
+            throws Exception {
+        SSLContext clientContext = forcingClientContext(clientCert, clientKey);
+        SSLSocketFactory socketFactory = clientContext.getSocketFactory();
+        try (SSLSocket socket = (SSLSocket) socketFactory.createSocket("localhost", port)) {
+            socket.setEnabledProtocols(new String[] {protocol});
+            socket.setSoTimeout(10000);
+            socket.startHandshake();
+        }
+    }
+
+    // Connect trusting the CA but presenting no client certificate; a needClientAuth server rejects this.
+    private void handshakeWithoutClientCert(int port) throws Exception {
+        KeyStore trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
+        trustStore.load(null, null);
+        X509Certificate[] ca = PemReader.loadCertificatesFromPemFile(CA);
+        for (int i = 0; i < ca.length; i++) {
+            trustStore.setCertificateEntry("ca-" + i, ca[i]);
+        }
+        TrustManagerFactory tmf = TrustManagerFactory.getInstance("PKIX");
+        tmf.init(trustStore);
+        SSLContext clientContext = SSLContext.getInstance("TLS");
+        clientContext.init(null, tmf.getTrustManagers(), null);
+        SSLSocketFactory socketFactory = clientContext.getSocketFactory();
+        try (SSLSocket socket = (SSLSocket) socketFactory.createSocket("localhost", port)) {
+            socket.setEnabledProtocols(new String[] {"TLSv1.2"});
+            socket.setSoTimeout(10000);
+            socket.startHandshake();
+        }
+    }
+
+    private static SSLContext forcingClientContext(String clientCert, String clientKey) throws Exception {
+        X509Certificate[] chain = PemReader.loadCertificatesFromPemFile(clientCert);
+        PrivateKey key = PemReader.loadPrivateKeyFromPemFile(clientKey);
+        KeyStore trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
+        trustStore.load(null, null);
+        X509Certificate[] ca = PemReader.loadCertificatesFromPemFile(CA);
+        for (int i = 0; i < ca.length; i++) {
+            trustStore.setCertificateEntry("ca-" + i, ca[i]);
+        }
+        TrustManagerFactory tmf = TrustManagerFactory.getInstance("PKIX");
+        tmf.init(trustStore);
+        SSLContext context = SSLContext.getInstance("TLS");
+        context.init(new KeyManager[] {new ForcingKeyManager(chain, key)}, tmf.getTrustManagers(), null);
+        return context;
+    }
+
+    /** A key manager that always presents a fixed certificate chain, ignoring the server's CA hints. */
+    private static final class ForcingKeyManager extends X509ExtendedKeyManager {
+        private static final String ALIAS = "client";
+        private final X509Certificate[] chain;
+        private final PrivateKey key;
+
+        ForcingKeyManager(X509Certificate[] chain, PrivateKey key) {
+            this.chain = chain;
+            this.key = key;
+        }
+
+        @Override
+        public String[] getClientAliases(String keyType, Principal[] issuers) {
+            return new String[] {ALIAS};
+        }
+
+        @Override
+        public String chooseClientAlias(String[] keyType, Principal[] issuers, Socket socket) {
+            return ALIAS;
+        }
+
+        @Override
+        public String chooseEngineClientAlias(String[] keyType, Principal[] issuers, SSLEngine engine) {
+            return ALIAS;
+        }
+
+        @Override
+        public String[] getServerAliases(String keyType, Principal[] issuers) {
+            return null;
+        }
+
+        @Override
+        public String chooseServerAlias(String keyType, Principal[] issuers, Socket socket) {
+            return null;
+        }
+
+        @Override
+        public X509Certificate[] getCertificateChain(String alias) {
+            return chain;
+        }
+
+        @Override
+        public PrivateKey getPrivateKey(String alias) {
+            return key;
+        }
+    }
+
+    private static BigInteger serverCertSerial(SSLContext clientContext, int port) throws Exception {
+        SSLSocketFactory socketFactory = clientContext.getSocketFactory();
+        try (SSLSocket socket = (SSLSocket) socketFactory.createSocket("localhost", port)) {
+            socket.setSoTimeout(10000);
+            socket.startHandshake();
+            X509Certificate leaf = (X509Certificate) socket.getSession().getPeerCertificates()[0];
+            return leaf.getSerialNumber();
+        }
+    }
+
+    private static BigInteger certSerial(String pemPath) throws Exception {
+        return PemReader.loadCertificatesFromPemFile(pemPath)[0].getSerialNumber();
+    }
+
+    private TlsFactoryInitContext initContext() {
+        Executor direct = Runnable::run;
+        return new TlsFactoryInitContext() {
+            @Override
+            public Map<String, String> params() {
+                return Map.of();
+            }
+
+            @Override
+            public ScheduledExecutorService scheduler() {
+                return scheduler;
+            }
+
+            @Override
+            public Executor blockingExecutor() {
+                return direct;
+            }
+
+            @Override
+            public Clock clock() {
+                return Clock.systemUTC();
+            }
+
+            @Override
+            public OpenTelemetry openTelemetry() {
+                return OpenTelemetry.noop();
+            }
+        };
+    }
+
+    private static String resource(String name) {
+        return new File(Resources.getResource(name).getPath()).getAbsolutePath();
+    }
+}

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/tls/impl/AuthProvidedMaterialSource.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/tls/impl/AuthProvidedMaterialSource.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.tls.impl;
+
+import java.io.InputStream;
+import java.security.PrivateKey;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Supplier;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.pulsar.client.api.AuthenticationDataProvider;
+import org.apache.pulsar.client.api.KeyStoreParams;
+import org.apache.pulsar.common.util.tls.PemReader;
+
+/**
+ * A {@link MaterialSource} that folds a server component's broker-client {@code Authentication} TLS
+ * material over a file-based base source for the {@code BROKER_CLIENT} purpose (PIP-478). This is the
+ * server-side mirror of the client TLS override hook, preserving the removed PIP-337 auth-data behavior:
+ * when the broker-client authentication plugin (e.g.
+ * {@code AuthenticationTls}) supplies key material, its in-memory certificate/key <em>override</em> the
+ * configured {@code brokerClient*} file paths, so a proxy or broker presents the right identity to the
+ * broker and forwarded-principal authorization works.
+ *
+ * <p>Precedence per material slot:
+ * <ul>
+ *   <li><b>key + certificate chain</b>: the authentication plugin's material wins when it supplies both;
+ *       otherwise the base file material is used;</li>
+ *   <li><b>trust certificates</b>: the base (file) trust material wins; only when the base has none is the
+ *       authentication plugin's trust-store stream consulted.</li>
+ * </ul>
+ *
+ * <p><b>Rotation.</b> {@link #refresh()} re-reads the authentication data on every call (the plugin may
+ * hot-reload its own files) and rebuilds the combined material, signalling a change through
+ * {@link TlsMaterial} value equality — so a rotated auth certificate is picked up independently of whether
+ * the base files changed. A transient authentication failure keeps the last-good combined material.
+ */
+final class AuthProvidedMaterialSource implements MaterialSource {
+
+    private final TlsMaterialSource base;
+    private final Supplier<AuthenticationDataProvider> authDataSupplier;
+    private TlsMaterial cached;
+
+    AuthProvidedMaterialSource(TlsMaterialSource base, Supplier<AuthenticationDataProvider> authDataSupplier) {
+        this.base = Objects.requireNonNull(base, "base");
+        this.authDataSupplier = Objects.requireNonNull(authDataSupplier, "authDataSupplier");
+    }
+
+    @Override
+    public RefreshOutcome refresh() throws Exception {
+        TlsMaterial baseMaterial = base.refresh().material();
+        AuthenticationDataProvider authData;
+        try {
+            authData = authDataSupplier.get();
+        } catch (RuntimeException e) {
+            // Transient auth failure: keep the last-good combined material and retry on the next poll.
+            if (cached != null) {
+                return new RefreshOutcome(cached, false);
+            }
+            throw e;
+        }
+        TlsMaterial combined = overlay(baseMaterial, authData);
+        boolean changed = cached == null || !combined.equals(cached);
+        if (changed) {
+            cached = combined;
+        }
+        return new RefreshOutcome(cached, changed);
+    }
+
+    private TlsMaterial overlay(TlsMaterial base, AuthenticationDataProvider authData) throws Exception {
+        List<X509Certificate> authChain = null;
+        PrivateKey authKey = null;
+        if (authData != null && authData.hasDataForTls()) {
+            authChain = resolveKeyCertChain(authData);
+            authKey = resolvePrivateKey(authData);
+        }
+        boolean useAuthKey = authKey != null && authChain != null && !authChain.isEmpty();
+        PrivateKey privateKey = useAuthKey ? authKey : base.privateKey();
+        List<X509Certificate> keyCertChain = useAuthKey ? authChain : base.keyCertChain();
+
+        List<X509Certificate> trustCerts = base.trustCerts();
+        if (trustCerts.isEmpty() && authData != null) {
+            trustCerts = resolveTrustFromAuth(authData);
+        }
+        return new TlsMaterial(privateKey, keyCertChain, trustCerts);
+    }
+
+    private static List<X509Certificate> resolveKeyCertChain(AuthenticationDataProvider authData) throws Exception {
+        Certificate[] certificates = authData.getTlsCertificates();
+        if (certificates != null && certificates.length > 0) {
+            return toX509(certificates);
+        }
+        String certFilePath = authData.getTlsCertificateFilePath();
+        if (StringUtils.isNotBlank(certFilePath)) {
+            X509Certificate[] certs = PemReader.loadCertificatesFromPemFile(certFilePath);
+            return certs == null ? null : List.of(certs);
+        }
+        KeyStoreParams params = authData.getTlsKeyStoreParams();
+        if (params != null && StringUtils.isNotBlank(params.getKeyStorePath())) {
+            return TlsKeyStoreLoader.extractCertificateChain(loadKeyStore(params));
+        }
+        return null;
+    }
+
+    private static PrivateKey resolvePrivateKey(AuthenticationDataProvider authData) throws Exception {
+        PrivateKey privateKey = authData.getTlsPrivateKey();
+        if (privateKey != null) {
+            return privateKey;
+        }
+        String keyFilePath = authData.getTlsPrivateKeyFilePath();
+        if (StringUtils.isNotBlank(keyFilePath)) {
+            return PemReader.loadPrivateKeyFromPemFile(keyFilePath);
+        }
+        KeyStoreParams params = authData.getTlsKeyStoreParams();
+        if (params != null && StringUtils.isNotBlank(params.getKeyStorePath())) {
+            return TlsKeyStoreLoader.extractPrivateKey(loadKeyStore(params), params.getKeyStorePassword());
+        }
+        return null;
+    }
+
+    private static List<X509Certificate> resolveTrustFromAuth(AuthenticationDataProvider authData) throws Exception {
+        try (InputStream trustStoreStream = authData.getTlsTrustStoreStream()) {
+            if (trustStoreStream != null) {
+                X509Certificate[] certs = PemReader.loadCertificatesFromPemStream(trustStoreStream);
+                return certs == null ? List.of() : List.of(certs);
+            }
+        }
+        return List.of();
+    }
+
+    private static java.security.KeyStore loadKeyStore(KeyStoreParams params) throws Exception {
+        return TlsKeyStoreLoader.loadKeyStore(params.getKeyStoreType(), params.getKeyStorePath(),
+                params.getKeyStorePassword());
+    }
+
+    private static List<X509Certificate> toX509(Certificate[] certificates) {
+        List<X509Certificate> result = new ArrayList<>(certificates.length);
+        for (Certificate certificate : certificates) {
+            if (certificate instanceof X509Certificate x509) {
+                result.add(x509);
+            }
+        }
+        return result;
+    }
+}

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/tls/impl/FileBasedTlsFactory.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/tls/impl/FileBasedTlsFactory.java
@@ -1,0 +1,623 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.tls.impl;
+
+import io.netty.handler.ssl.SslContext;
+import io.netty.util.ReferenceCountUtil;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import javax.net.ssl.SSLContext;
+import lombok.CustomLog;
+import org.apache.pulsar.client.api.Authentication;
+import org.apache.pulsar.client.api.AuthenticationDataProvider;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.common.tls.PulsarTlsFactory;
+import org.apache.pulsar.common.tls.TlsEndpoint;
+import org.apache.pulsar.common.tls.TlsFactoryInitContext;
+import org.apache.pulsar.common.tls.TlsHandle;
+import org.apache.pulsar.common.tls.TlsPolicy;
+import org.apache.pulsar.common.tls.TlsPurpose;
+
+/**
+ * The default, file-based {@link PulsarTlsFactory} (PIP-478).
+ *
+ * <p>Immutable after construction: the complete {@code TlsPurpose -> TlsPolicy} map and the
+ * factory-wide {@link FileBasedTlsFactorySettings} are fixed by the constructor and never mutated. The
+ * owning component (the v5 client builder, or {@code DefaultBrokerTlsFactory} on the server side)
+ * composes the final map before constructing the factory.
+ *
+ * <p>Natively supplies the Netty {@code SslContext} (on the configured engine — JDK or OpenSSL) and the
+ * JDK {@code SSLContext}; returns {@code empty()} for every other class (notably Jetty's
+ * {@code SslContextFactory.Server}), which the framework synthesizes from the JDK {@code SSLContext}. It also
+ * returns {@code empty()} for the {@code javax.net.ssl.SSLParameters} companion (PIP-478): this factory bakes
+ * its engine policy (protocols, ciphers, client-auth mode, hostname verification) natively into the Netty and
+ * JDK contexts it builds, so it exposes no separate baseline for the framework to overlay.
+ *
+ * <p><b>Purpose resolution.</b> A request resolves the requested purpose, then walks its single-level
+ * {@link TlsPurpose#fallback() fallback} chain; the first purpose configured with a policy wins. When
+ * nothing along the chain is configured, a {@code CLIENT}-role purpose resolves to the system default
+ * (OS trust store, no client certificate) and a {@code SERVER}-role purpose fails the request. A
+ * resolved-but-unbuildable request completes the future <em>exceptionally</em> — never {@code empty()},
+ * which strictly means "unsupported {@code (purpose, class)} combination".
+ *
+ * <p><b>Rotation.</b> One {@link TlsMaterialSource} is shared per configured purpose. Server-side
+ * subscribers are pushed rebuilt instances by a background poll (interval from the settings, on the
+ * framework scheduler); client-side one-shot callers re-stat on each request and pick up rotation
+ * naturally. A failed rebuild keeps the last-good instance, logs at WARN, and retries on the next
+ * change; a subscriber callback that throws is caught and logged, and the subscription stays live.
+ */
+@CustomLog
+public class FileBasedTlsFactory implements PulsarTlsFactory {
+
+    private final Map<TlsPurpose, RegisteredSource> registry;
+    private final FileBasedTlsFactorySettings settings;
+
+    private volatile TlsFactoryInitContext initContext;
+    private volatile TlsReloadMetrics metrics;
+    private volatile RegisteredSource systemDefaultSource;
+    private volatile ScheduledFuture<?> pollFuture;
+    private volatile boolean closed;
+
+    /**
+     * Construct an immutable file-based factory.
+     *
+     * @param policies the complete purpose&rarr;policy map (defensively copied)
+     * @param settings the factory-wide engine/refresh settings
+     */
+    public FileBasedTlsFactory(Map<TlsPurpose, TlsPolicy> policies, FileBasedTlsFactorySettings settings) {
+        this(policies, settings, Map.of());
+    }
+
+    /**
+     * Construct an immutable file-based factory that additionally folds an authentication plugin's TLS
+     * material over the configured file policy for the named purposes (the server-side {@code BROKER_CLIENT}
+     * fold — PIP-478). For a purpose present in {@code authMaterialSuppliers}, the supplier's
+     * {@code Authentication} material overrides the file policy's key/cert per
+     * {@link AuthProvidedMaterialSource} (auth-cert-wins); other purposes use the file policy unchanged.
+     *
+     * @param policies              the complete purpose&rarr;policy map (defensively copied)
+     * @param settings              the factory-wide engine/refresh settings
+     * @param authMaterialSuppliers per-purpose broker-client authentication material suppliers (may be empty)
+     */
+    public FileBasedTlsFactory(Map<TlsPurpose, TlsPolicy> policies, FileBasedTlsFactorySettings settings,
+            Map<TlsPurpose, Supplier<AuthenticationDataProvider>> authMaterialSuppliers) {
+        Objects.requireNonNull(policies, "policies must not be null");
+        this.settings = Objects.requireNonNull(settings, "settings must not be null");
+        Objects.requireNonNull(authMaterialSuppliers, "authMaterialSuppliers must not be null");
+        Map<TlsPurpose, RegisteredSource> built = new LinkedHashMap<>();
+        for (Map.Entry<TlsPurpose, TlsPolicy> entry : policies.entrySet()) {
+            TlsPurpose purpose = Objects.requireNonNull(entry.getKey(), "purpose key must not be null");
+            TlsPolicy policy = Objects.requireNonNull(entry.getValue(), "policy must not be null");
+            TlsMaterialSource fileSource = new TlsMaterialSource(policy);
+            Supplier<AuthenticationDataProvider> authSupplier = authMaterialSuppliers.get(purpose);
+            MaterialSource source = authSupplier == null
+                    ? fileSource
+                    : new AuthProvidedMaterialSource(fileSource, authSupplier);
+            built.put(purpose, new RegisteredSource(purpose, policy, source));
+        }
+        this.registry = Map.copyOf(built);
+    }
+
+    /**
+     * Adapt a component's broker-client {@link Authentication} to a per-refresh
+     * {@link AuthenticationDataProvider} supplier for use with the {@code BROKER_CLIENT} fold constructor.
+     * The supplier re-reads {@code getAuthData()} on each poll so credential rotation is observed; a checked
+     * {@link PulsarClientException} is rethrown unchecked and handled by the factory's keep-last-good poll.
+     *
+     * @param authentication the broker-client authentication plugin (never {@code null})
+     * @return a supplier of the plugin's current authentication data
+     */
+    public static Supplier<AuthenticationDataProvider> authMaterialSupplier(Authentication authentication) {
+        Objects.requireNonNull(authentication, "authentication must not be null");
+        return () -> {
+            try {
+                return resolveAuthData(authentication);
+            } catch (PulsarClientException e) {
+                throw new RuntimeException("Failed to obtain broker-client authentication TLS material", e);
+            }
+        };
+    }
+
+    // The BROKER_CLIENT TLS fold is host-agnostic — TLS key material does not vary by peer — so the
+    // host-less getAuthData() is exactly what we want; isolate its deprecation here.
+    @SuppressWarnings("deprecation")
+    private static AuthenticationDataProvider resolveAuthData(Authentication authentication)
+            throws PulsarClientException {
+        return authentication.getAuthData();
+    }
+
+    @Override
+    public CompletableFuture<Void> initialize(TlsFactoryInitContext context) {
+        try {
+            this.initContext = Objects.requireNonNull(context, "context must not be null");
+            this.metrics = TlsReloadMetrics.create(context.openTelemetry(), context.clock());
+            // Cancel any poll scheduled by a prior initialize() so a second call does not orphan the first
+            // (F9): the field is overwritten below and the old task would otherwise run forever.
+            ScheduledFuture<?> previousPoll = this.pollFuture;
+            if (previousPoll != null) {
+                previousPoll.cancel(false);
+            }
+            int interval = settings.refreshIntervalSeconds();
+            if (interval > 0 && context.scheduler() != null) {
+                this.pollFuture = context.scheduler().scheduleWithFixedDelay(
+                        this::pollSafely, interval, interval, TimeUnit.SECONDS);
+            }
+            log.debug().attr("purposes", registry.keySet()).attr("refreshIntervalSeconds", interval)
+                    .log("Initialized FileBasedTlsFactory");
+            return CompletableFuture.completedFuture(null);
+        } catch (Throwable t) {
+            return CompletableFuture.failedFuture(t);
+        }
+    }
+
+    @Override
+    public <T> CompletableFuture<Optional<TlsHandle<T>>> createInstance(TlsPurpose purpose, Class<T> instanceClass) {
+        return createOneShot(purpose, instanceClass);
+    }
+
+    @Override
+    public <T> CompletableFuture<Optional<TlsHandle<T>>> createInstance(
+            TlsPurpose purpose, TlsEndpoint endpoint, Class<T> instanceClass) {
+        // The default file-based factory serves purpose-scoped material and ignores the endpoint hint.
+        return createOneShot(purpose, instanceClass);
+    }
+
+    @Override
+    public <T> CompletableFuture<Optional<TlsHandle<T>>> createInstance(
+            TlsPurpose purpose, Class<T> instanceClass, Consumer<T> onLoadOrReload) {
+        Objects.requireNonNull(onLoadOrReload, "onLoadOrReload must not be null");
+        if (!isSupported(instanceClass)) {
+            return CompletableFuture.completedFuture(Optional.empty());
+        }
+        if (closed) {
+            return CompletableFuture.failedFuture(new IllegalStateException("FileBasedTlsFactory is closed"));
+        }
+        return runAsync(() -> {
+            RegisteredSource source = resolve(purpose);
+            synchronized (source) {
+                T instance = loadInitialInstance(source, instanceClass);
+                Subscription<T> subscription = new Subscription<>(instanceClass, onLoadOrReload);
+                // Initial delivery happens-before the returned future completes (same thread, ordered).
+                subscription.deliver(instance);
+                source.subscriptions.add(subscription);
+                return Optional.of((TlsHandle<T>) new SubscriptionHandle<>(source, subscription));
+            }
+        });
+    }
+
+    private <T> CompletableFuture<Optional<TlsHandle<T>>> createOneShot(TlsPurpose purpose, Class<T> instanceClass) {
+        if (!isSupported(instanceClass)) {
+            return CompletableFuture.completedFuture(Optional.empty());
+        }
+        if (closed) {
+            return CompletableFuture.failedFuture(new IllegalStateException("FileBasedTlsFactory is closed"));
+        }
+        return runAsync(() -> {
+            RegisteredSource source = resolve(purpose);
+            synchronized (source) {
+                T instance = loadInitialInstance(source, instanceClass);
+                retain(instance);
+                return Optional.of((TlsHandle<T>) new OneShotHandle<>(instance));
+            }
+        });
+    }
+
+    /**
+     * Load (or reuse the cached) instance of {@code instanceClass} for the resolved source, recording a
+     * {@code pulsar.tls.reload} attempt for the source's purpose. A resolution failure upstream (an
+     * unconfigured server purpose) is a startup configuration error and is not counted here — only actual
+     * material loads are. Must be called while holding the source monitor.
+     */
+    private <T> T loadInitialInstance(RegisteredSource source, Class<T> instanceClass) throws Exception {
+        try {
+            TlsMaterial material = source.currentMaterial();
+            T instance = source.acquireInstance(instanceClass, material, settings);
+            recordLoad(source.purpose, true);
+            return instance;
+        } catch (Exception e) {
+            recordLoad(source.purpose, false);
+            // Keep-last-good (PIP-478 F4): a one-shot (or initial subscribing) acquisition during a
+            // non-atomic rotation window — e.g. the cert file briefly unreadable while it is being replaced —
+            // must not fail when a prior load already built a context of this class. Serve that last-good
+            // instance and WARN; the reload-failure metric was recorded above. Fail only when there is no
+            // last-good to fall back on (a genuine startup misconfiguration, per the fail-fast contract).
+            T cached = source.cachedInstance(instanceClass);
+            if (cached != null) {
+                log.warn().attr("purpose", source.purpose).exception(e)
+                        .log("Failed to load TLS material; serving the last-good instance");
+                return cached;
+            }
+            throw e;
+        }
+    }
+
+    private void recordLoad(TlsPurpose purpose, boolean success) {
+        TlsReloadMetrics m = this.metrics;
+        if (m != null) {
+            m.recordLoad(purpose, success);
+        }
+    }
+
+    @Override
+    public void close() {
+        closed = true;
+        ScheduledFuture<?> poll = this.pollFuture;
+        if (poll != null) {
+            poll.cancel(false);
+        }
+        for (RegisteredSource source : registry.values()) {
+            source.releaseAll();
+        }
+        RegisteredSource systemDefault = this.systemDefaultSource;
+        if (systemDefault != null) {
+            systemDefault.releaseAll();
+        }
+        TlsReloadMetrics m = this.metrics;
+        if (m != null) {
+            m.close();
+        }
+    }
+
+    /**
+     * Resolve a requested purpose to the {@link RegisteredSource} that owns its material, following the
+     * single-level fallback chain and the role's empty-fallback rule.
+     *
+     * @throws TlsMaterialUnavailableException when a server-role purpose has no material configured
+     */
+    private RegisteredSource resolve(TlsPurpose purpose) {
+        Objects.requireNonNull(purpose, "purpose must not be null");
+        for (TlsPurpose candidate = purpose; candidate != null; candidate = candidate.fallback().orElse(null)) {
+            RegisteredSource source = registry.get(candidate);
+            if (source != null) {
+                return source;
+            }
+        }
+        if (purpose.role() == TlsPurpose.Role.CLIENT) {
+            return systemDefaultSource();
+        }
+        throw new TlsMaterialUnavailableException(
+                "No TLS material configured for server purpose " + purpose + " (and it has no fallback)");
+    }
+
+    private RegisteredSource systemDefaultSource() {
+        RegisteredSource existing = this.systemDefaultSource;
+        if (existing != null) {
+            return existing;
+        }
+        synchronized (this) {
+            if (this.systemDefaultSource == null) {
+                // System default: verify hostnames, OS trust store, no client certificate. A constant
+                // source (no files, never rotates).
+                TlsPolicy defaultPolicy = TlsPolicy.builder().build();
+                this.systemDefaultSource = new RegisteredSource(
+                        TlsPurpose.CLIENT_DEFAULT, defaultPolicy, null);
+            }
+            return this.systemDefaultSource;
+        }
+    }
+
+    private void pollSafely() {
+        if (closed) {
+            return;
+        }
+        try {
+            for (RegisteredSource source : registry.values()) {
+                source.poll(settings, metrics);
+            }
+        } catch (Throwable t) {
+            log.warn().exception(t).log("Unexpected error during TLS material poll");
+        }
+    }
+
+    private <R> CompletableFuture<R> runAsync(Callable<R> task) {
+        CompletableFuture<R> future = new CompletableFuture<>();
+        TlsFactoryInitContext context = this.initContext;
+        Executor executor = context != null && context.blockingExecutor() != null
+                ? context.blockingExecutor() : Runnable::run;
+        try {
+            executor.execute(() -> {
+                try {
+                    future.complete(task.call());
+                } catch (Throwable t) {
+                    future.completeExceptionally(t);
+                }
+            });
+        } catch (Throwable t) {
+            future.completeExceptionally(t);
+        }
+        return future;
+    }
+
+    private static boolean isSupported(Class<?> instanceClass) {
+        return instanceClass == SslContext.class || instanceClass == SSLContext.class;
+    }
+
+    private static void retain(Object instance) {
+        if (instance != null) {
+            ReferenceCountUtil.retain(instance);
+        }
+    }
+
+    private static void release(Object instance) {
+        if (instance != null) {
+            ReferenceCountUtil.release(instance);
+        }
+    }
+
+    /**
+     * A configured purpose's material source together with the cached, factory-owned context instances
+     * and the active subscriptions. All state is guarded by the instance monitor.
+     */
+    private static final class RegisteredSource {
+        private final TlsPurpose purpose;
+        private final TlsPolicy policy;
+        // Null for the system-default source, whose constant material never rotates.
+        private final MaterialSource source;
+        private final CopyOnWriteArrayList<Subscription<?>> subscriptions = new CopyOnWriteArrayList<>();
+
+        private SslContext nettyContext;
+        private TlsMaterial nettyMaterial;
+        private SSLContext jdkContext;
+        private TlsMaterial jdkMaterial;
+        // Set when a rotation's rebuild/delivery to some subscriber failed, so the next poll re-attempts the
+        // rebuild even if the source now reports changed=false (PIP-478 L1 reload-wedge guard).
+        private boolean pendingRedeliver;
+
+        RegisteredSource(TlsPurpose purpose, TlsPolicy policy, MaterialSource source) {
+            this.purpose = purpose;
+            this.policy = policy;
+            this.source = source;
+        }
+
+        synchronized TlsMaterial currentMaterial() throws Exception {
+            if (source == null) {
+                return TlsMaterial.SYSTEM_DEFAULT;
+            }
+            return source.refresh().material();
+        }
+
+        /**
+         * Return the cached context of the requested class, rebuilding it (and releasing the superseded
+         * one) only when the material changed in value. The returned instance is the factory-owned memo;
+         * callers that hand it to a consumer {@link FileBasedTlsFactory#retain(Object) retain} it.
+         */
+        synchronized <T> T acquireInstance(Class<T> instanceClass, TlsMaterial material,
+                                           FileBasedTlsFactorySettings settings) throws Exception {
+            if (instanceClass == SslContext.class) {
+                if (nettyContext == null || !material.equals(nettyMaterial)) {
+                    SslContext built = purpose.role() == TlsPurpose.Role.SERVER
+                            ? TlsContexts.buildNettyServerContext(material, policy, settings.engineProvider(),
+                                    settings.requireTrustedClientCert())
+                            : TlsContexts.buildNettyClientContext(material, policy, settings.engineProvider());
+                    release(nettyContext);
+                    nettyContext = built;
+                    nettyMaterial = material;
+                }
+                return instanceClass.cast(nettyContext);
+            }
+            if (instanceClass == SSLContext.class) {
+                if (jdkContext == null || !material.equals(jdkMaterial)) {
+                    jdkContext = TlsContexts.buildJdkContext(material, policy);
+                    jdkMaterial = material;
+                }
+                return instanceClass.cast(jdkContext);
+            }
+            throw new IllegalArgumentException("Unsupported instance class " + instanceClass);
+        }
+
+        /**
+         * The last-good cached context of the requested class, or {@code null} if none has been built yet.
+         * Used by the keep-last-good one-shot path (F4) when a fresh load fails mid-rotation.
+         */
+        synchronized <T> T cachedInstance(Class<T> instanceClass) {
+            if (instanceClass == SslContext.class && nettyContext != null) {
+                return instanceClass.cast(nettyContext);
+            }
+            if (instanceClass == SSLContext.class && jdkContext != null) {
+                return instanceClass.cast(jdkContext);
+            }
+            return null;
+        }
+
+        synchronized void poll(FileBasedTlsFactorySettings settings, TlsReloadMetrics metrics) {
+            if (source == null || subscriptions.isEmpty()) {
+                return;
+            }
+            MaterialSource.RefreshOutcome outcome;
+            try {
+                outcome = source.refresh();
+            } catch (Exception e) {
+                // Keep-last-good: leave every subscription on its current instance and retry next change.
+                recordLoad(metrics, false);
+                log.warn().attr("purpose", purpose).exception(e)
+                        .log("Failed to reload TLS material; keeping the last-good instance");
+                return;
+            }
+            // A poll that finds no change is not a reload — do not count it, so the reload counter and the
+            // last-success gauge reflect real (re)load events only. But if a prior rotation's rebuild/delivery
+            // to some subscriber failed (pendingRedeliver), retry it even when the source now reports
+            // changed=false: otherwise, once the source commits the new baseline, every later poll sees
+            // changed=false and that subscriber stays wedged on the old instance until the next file change
+            // (L1). The retry rebuilds against the current last-good material.
+            if (!outcome.changed() && !pendingRedeliver) {
+                return;
+            }
+            boolean allRebuilt = true;
+            for (Subscription<?> subscription : subscriptions) {
+                try {
+                    Object rebuilt = acquireInstance(subscription.instanceClass, outcome.material(), settings);
+                    subscription.deliverErased(rebuilt);
+                } catch (Exception e) {
+                    allRebuilt = false;
+                    log.warn().attr("purpose", purpose).attr("class", subscription.instanceClass.getName())
+                            .exception(e).log("Failed to rebuild rotated TLS instance; keeping the last-good one");
+                }
+            }
+            // Re-attempt on the next poll until every subscriber has the rotated instance (L1).
+            pendingRedeliver = !allRebuilt;
+            recordLoad(metrics, allRebuilt);
+        }
+
+        private void recordLoad(TlsReloadMetrics metrics, boolean success) {
+            if (metrics != null) {
+                metrics.recordLoad(purpose, success);
+            }
+        }
+
+        synchronized void removeSubscription(Subscription<?> subscription) {
+            if (subscriptions.remove(subscription)) {
+                subscription.releaseCurrent();
+            }
+        }
+
+        synchronized void releaseAll() {
+            for (Subscription<?> subscription : subscriptions) {
+                subscription.releaseCurrent();
+            }
+            subscriptions.clear();
+            release(nettyContext);
+            nettyContext = null;
+            nettyMaterial = null;
+            jdkContext = null;
+            jdkMaterial = null;
+        }
+    }
+
+    /** A live server-side subscription: its instance class, callback, and last-delivered instances. */
+    private static final class Subscription<T> {
+        private final Class<T> instanceClass;
+        private final Consumer<T> callback;
+        private T current;
+        // Deferred release (PIP-478 F1 use-after-free): the instance superseded by the most recent delivery
+        // is kept alive one extra generation rather than released immediately. Consumers hold a bare volatile
+        // borrow of the delivered instance and later call newHandler/newEngine on it off a different thread;
+        // releasing the superseded Netty/OpenSSL context to refcount 0 on the poll thread the instant the new
+        // one is published would free the native SSL_CTX out from under such an in-flight borrow. Retaining it
+        // for one further rotation gives every reader a full poll interval to finish. Pairs with per-use
+        // pinning at the consumers (see TlsContextAcquisition.withPinnedContext) for the descheduling case.
+        private T previous;
+
+        Subscription(Class<T> instanceClass, Consumer<T> callback) {
+            this.instanceClass = instanceClass;
+            this.callback = callback;
+        }
+
+        void deliver(T instance) {
+            retain(instance);
+            // Release the instance delivered two rotations ago (N-1) on this (N+1th) delivery, not the one
+            // just superseded, so the just-superseded instance survives one more generation for readers.
+            release(previous);
+            previous = current;
+            current = instance;
+            safeInvoke(instance);
+        }
+
+        @SuppressWarnings("unchecked")
+        void deliverErased(Object instance) {
+            deliver((T) instance);
+        }
+
+        T current() {
+            return current;
+        }
+
+        void releaseCurrent() {
+            release(current);
+            current = null;
+            release(previous);
+            previous = null;
+        }
+
+        private void safeInvoke(T instance) {
+            try {
+                callback.accept(instance);
+            } catch (Throwable t) {
+                // A throwing consumer callback must not kill the subscription; later deliveries proceed.
+                log.warn().exception(t).log("TLS reload callback threw; subscription stays live");
+            }
+        }
+    }
+
+    /** A one-shot handle: exposes the built instance and releases its retained reference on dispose. */
+    private static final class OneShotHandle<T> implements TlsHandle<T> {
+        private final T instance;
+        private volatile boolean disposed;
+
+        OneShotHandle(T instance) {
+            this.instance = instance;
+        }
+
+        @Override
+        public T get() {
+            return instance;
+        }
+
+        @Override
+        public void dispose() {
+            if (!disposed) {
+                disposed = true;
+                release(instance);
+            }
+        }
+    }
+
+    /** A subscribing handle: exposes the most-recently-delivered instance and unregisters on dispose. */
+    private static final class SubscriptionHandle<T> implements TlsHandle<T> {
+        private final RegisteredSource source;
+        private final Subscription<T> subscription;
+        private volatile boolean disposed;
+
+        SubscriptionHandle(RegisteredSource source, Subscription<T> subscription) {
+            this.source = source;
+            this.subscription = subscription;
+        }
+
+        @Override
+        public T get() {
+            return subscription.current();
+        }
+
+        @Override
+        public void dispose() {
+            if (!disposed) {
+                disposed = true;
+                source.removeSubscription(subscription);
+            }
+        }
+    }
+
+    /** Thrown when a resolved server purpose has no configured material (a resolved-but-unbuildable case). */
+    static final class TlsMaterialUnavailableException extends IllegalStateException {
+        private static final long serialVersionUID = 1L;
+
+        TlsMaterialUnavailableException(String message) {
+            super(message);
+        }
+    }
+}

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/tls/impl/FileBasedTlsFactorySettings.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/tls/impl/FileBasedTlsFactorySettings.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.tls.impl;
+
+import io.netty.handler.ssl.SslProvider;
+import java.util.Objects;
+
+/**
+ * The factory-wide (not per-purpose) settings for a {@link FileBasedTlsFactory} (PIP-478).
+ *
+ * <p>These are the knobs that a {@code TlsPolicy} deliberately does not carry, because they describe
+ * how the factory builds and refreshes contexts rather than which material to load:
+ * <ul>
+ *   <li><b>engine selection</b> — the Netty {@link SslProvider} the native contexts are built on
+ *       (JDK, or an OpenSSL-based provider where the {@code netty-tcnative} binding is present);</li>
+ *   <li><b>server client-auth requirement</b> — whether server contexts require (vs. merely request) a
+ *       trusted client certificate; a single flag mirroring the broker-wide
+ *       {@code tlsRequireTrustedClientCert} property, applied to every server purpose;</li>
+ *   <li><b>refresh interval</b> — how often the factory polls its material sources for rotation; a
+ *       value {@code <= 0} disables background polling.</li>
+ * </ul>
+ */
+public final class FileBasedTlsFactorySettings {
+
+    /** Default rotation poll interval, in seconds (PIP-478). */
+    public static final int DEFAULT_REFRESH_INTERVAL_SECONDS = 60;
+
+    private final SslProvider engineProvider;
+    private final boolean requireTrustedClientCert;
+    private final int refreshIntervalSeconds;
+
+    private FileBasedTlsFactorySettings(Builder builder) {
+        this.engineProvider = builder.engineProvider;
+        this.requireTrustedClientCert = builder.requireTrustedClientCert;
+        this.refreshIntervalSeconds = builder.refreshIntervalSeconds;
+    }
+
+    /** @return default settings: JDK engine, client-auth requested (not required), 60s poll */
+    public static FileBasedTlsFactorySettings defaults() {
+        return builder().build();
+    }
+
+    /** @return a new {@link Builder} */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /** @return the Netty SSL provider for the native contexts (never {@code null}) */
+    public SslProvider engineProvider() {
+        return engineProvider;
+    }
+
+    /** @return whether server contexts require (vs. merely request) a trusted client certificate */
+    public boolean requireTrustedClientCert() {
+        return requireTrustedClientCert;
+    }
+
+    /** @return the rotation poll interval in seconds ({@code <= 0} disables polling) */
+    public int refreshIntervalSeconds() {
+        return refreshIntervalSeconds;
+    }
+
+    /**
+     * Builder for {@link FileBasedTlsFactorySettings}. Defaults to the JDK engine, client-auth
+     * requested (not required), and the {@link #DEFAULT_REFRESH_INTERVAL_SECONDS} poll interval.
+     */
+    public static final class Builder {
+        private SslProvider engineProvider = SslProvider.JDK;
+        private boolean requireTrustedClientCert = false;
+        private int refreshIntervalSeconds = DEFAULT_REFRESH_INTERVAL_SECONDS;
+
+        private Builder() {
+        }
+
+        /**
+         * @param engineProvider the Netty SSL provider (engine selection)
+         * @return this builder
+         */
+        public Builder engineProvider(SslProvider engineProvider) {
+            this.engineProvider = Objects.requireNonNull(engineProvider, "engineProvider must not be null");
+            return this;
+        }
+
+        /**
+         * @param requireTrustedClientCert whether server contexts require a trusted client certificate
+         * @return this builder
+         */
+        public Builder requireTrustedClientCert(boolean requireTrustedClientCert) {
+            this.requireTrustedClientCert = requireTrustedClientCert;
+            return this;
+        }
+
+        /**
+         * @param refreshIntervalSeconds the rotation poll interval in seconds ({@code <= 0} disables it)
+         * @return this builder
+         */
+        public Builder refreshIntervalSeconds(int refreshIntervalSeconds) {
+            this.refreshIntervalSeconds = refreshIntervalSeconds;
+            return this;
+        }
+
+        /** @return a new immutable {@link FileBasedTlsFactorySettings} */
+        public FileBasedTlsFactorySettings build() {
+            return new FileBasedTlsFactorySettings(this);
+        }
+    }
+}

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/tls/impl/MaterialSource.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/tls/impl/MaterialSource.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.tls.impl;
+
+/**
+ * A source of loaded {@link TlsMaterial} for one {@code TlsPurpose} inside the default
+ * {@code FileBasedTlsFactory} (PIP-478). Implementations re-read their backing (files, and — for the
+ * server-side {@code BROKER_CLIENT} fold — an authentication plugin's material) on {@link #refresh()},
+ * reporting via {@link RefreshOutcome#changed()} whether the material's <em>value</em> changed since the
+ * previous refresh, so equal reloads suppress spurious context rebuilds.
+ *
+ * <p>Not thread-safe on its own; the owning factory serialises access under its per-source monitor.
+ */
+interface MaterialSource {
+
+    /**
+     * Re-read the backing material, reloading only when it changed since the last successful load.
+     *
+     * @return the current (possibly rebuilt) material together with whether it changed in value
+     * @throws Exception if the material could not be loaded (the last-good material is left untouched so
+     *                   the next call retries)
+     */
+    RefreshOutcome refresh() throws Exception;
+
+    /**
+     * The result of a {@link #refresh()}: the current material and whether it changed in value since the
+     * previous refresh.
+     *
+     * @param material the current (last-good) material
+     * @param changed  {@code true} when the material's value changed (first load counts as a change)
+     */
+    record RefreshOutcome(TlsMaterial material, boolean changed) {
+    }
+}

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/tls/impl/SynthesizedEngineSslContext.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/tls/impl/SynthesizedEngineSslContext.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.tls.impl;
+
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.handler.ssl.ApplicationProtocolNegotiator;
+import io.netty.handler.ssl.SslContext;
+import java.util.List;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLSessionContext;
+
+/**
+ * A Netty {@link SslContext} that applies an engine-level {@link SSLParameters} <em>overlay</em> to every
+ * {@link SSLEngine} it produces, wrapping a framework-synthesized JDK-backed context (PIP-478).
+ *
+ * <p>The universal {@code javax.net.ssl.SSLContext} fallback the framework synthesizes a Netty context from is
+ * always JDK-backed — a {@link io.netty.handler.ssl.JdkSslContext} wrapping the factory-supplied
+ * {@code SSLContext}. A JDK {@code SSLContext} carries no engine-level policy: the endpoint-identification
+ * algorithm, the enabled protocols and cipher suites, algorithm constraints, the application protocols, and
+ * (server side) the client-auth mode are all {@link SSLParameters} settings, and a bare {@code SSLContext} has
+ * no setter for them. So the framework composes the desired baseline — the factory's own {@code SSLParameters}
+ * companion (see {@link TlsContexts}), merged with the consumer's hostname-verification / client-auth flags —
+ * and applies it here, per engine.
+ *
+ * <p>This is the faithful equivalent of the native {@code FileBasedTlsFactory} path, which bakes the same
+ * settings into the context via {@code SslContextBuilder} at build time — consumers rely on the context to
+ * carry the policy and never re-apply it per connection. It is sound because the synthesized context is always
+ * the JDK backend, on which a per-{@code SSLEngine} override cleanly takes effect (unlike Netty's OpenSSL
+ * backend, which fixes several of these at build time); see PIP-478 Detailed Design,
+ * "client-side hostname verification".
+ *
+ * <p><b>SNI is never overlaid.</b> {@code getSSLParameters()} returns a snapshot of the engine's full
+ * configuration — including the SNI {@code serverNames} the delegate already set for this connection from the
+ * peer host — and this class overlays only the {@code non-null} baseline members onto that snapshot before
+ * writing it back, leaving {@code serverNames} untouched. That realizes merge rule 3: the per-connection SNI
+ * always wins over any factory baseline.
+ */
+final class SynthesizedEngineSslContext extends SslContext {
+
+    private final SslContext delegate;
+    private final SSLParameters overlay;
+    private final boolean applyClientAuth;
+
+    /**
+     * @param delegate        the JDK-backed Netty context whose engines are reconfigured
+     * @param overlay         the composed baseline; only its non-null members are applied (and, when
+     *                        {@code applyClientAuth} is set, its need/want-client-auth flags)
+     * @param applyClientAuth whether to apply the overlay's {@code needClientAuth}/{@code wantClientAuth}
+     *                        (server purposes with a factory-supplied baseline — merge rule 4); client
+     *                        engines ignore client-auth, so it is left {@code false} for them
+     */
+    SynthesizedEngineSslContext(SslContext delegate, SSLParameters overlay, boolean applyClientAuth) {
+        this.delegate = delegate;
+        this.overlay = overlay;
+        this.applyClientAuth = applyClientAuth;
+    }
+
+    @Override
+    public boolean isClient() {
+        return delegate.isClient();
+    }
+
+    @Override
+    public List<String> cipherSuites() {
+        return delegate.cipherSuites();
+    }
+
+    @Override
+    @SuppressWarnings("deprecation") // ApplicationProtocolNegotiator is a deprecated but still-abstract SPI type
+    public ApplicationProtocolNegotiator applicationProtocolNegotiator() {
+        return delegate.applicationProtocolNegotiator();
+    }
+
+    @Override
+    public SSLSessionContext sessionContext() {
+        return delegate.sessionContext();
+    }
+
+    @Override
+    public SSLEngine newEngine(ByteBufAllocator alloc) {
+        return applyOverlay(delegate.newEngine(alloc));
+    }
+
+    @Override
+    public SSLEngine newEngine(ByteBufAllocator alloc, String peerHost, int peerPort) {
+        return applyOverlay(delegate.newEngine(alloc, peerHost, peerPort));
+    }
+
+    private SSLEngine applyOverlay(SSLEngine engine) {
+        SSLParameters engineParams = engine.getSSLParameters();
+        if (overlay.getProtocols() != null) {
+            engineParams.setProtocols(overlay.getProtocols());
+        }
+        if (overlay.getCipherSuites() != null) {
+            engineParams.setCipherSuites(overlay.getCipherSuites());
+        }
+        if (overlay.getAlgorithmConstraints() != null) {
+            engineParams.setAlgorithmConstraints(overlay.getAlgorithmConstraints());
+        }
+        if (overlay.getApplicationProtocols() != null) {
+            engineParams.setApplicationProtocols(overlay.getApplicationProtocols());
+        }
+        if (overlay.getEndpointIdentificationAlgorithm() != null) {
+            engineParams.setEndpointIdentificationAlgorithm(overlay.getEndpointIdentificationAlgorithm());
+        }
+        if (applyClientAuth) {
+            // Merge rule 4: a factory-supplied SSLParameters is authoritative for the server client-auth mode.
+            // needClientAuth wins over wantClientAuth; neither set means "no client certificate requested".
+            if (overlay.getNeedClientAuth()) {
+                engineParams.setNeedClientAuth(true);
+            } else if (overlay.getWantClientAuth()) {
+                engineParams.setWantClientAuth(true);
+            } else {
+                engineParams.setWantClientAuth(false);
+            }
+        }
+        // serverNames deliberately left as the delegate set them (per-connection SNI wins — merge rule 3).
+        engine.setSSLParameters(engineParams);
+        return engine;
+    }
+}

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/tls/impl/TlsContextAcquisition.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/tls/impl/TlsContextAcquisition.java
@@ -1,0 +1,338 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.tls.impl;
+
+import io.netty.handler.ssl.SslContext;
+import io.netty.util.IllegalReferenceCountException;
+import io.netty.util.ReferenceCountUtil;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
+import org.apache.pulsar.common.tls.PulsarTlsFactory;
+import org.apache.pulsar.common.tls.TlsEndpoint;
+import org.apache.pulsar.common.tls.TlsHandle;
+import org.apache.pulsar.common.tls.TlsPurpose;
+
+/**
+ * The single framework entry point every Netty-{@code SslContext} consumer uses to acquire its context from
+ * a {@link PulsarTlsFactory}, applying the PIP-478 {@code SSLContext}-fallback synthesis (the "well-known
+ * classes" tier-3 story).
+ *
+ * <p>For a {@code (purpose, class)} the framework first asks the factory for the Netty
+ * {@link SslContext} a consumer actually needs; only when the factory returns {@link Optional#empty()} —
+ * meaning it does not build the Netty class directly — does the framework request
+ * {@code javax.net.ssl.SSLContext} for the same purpose (in the same one-shot vs. subscribing form) and
+ * synthesize the Netty context from it. Because the default {@code FileBasedTlsFactory} natively supplies
+ * the Netty class, the fallback fires only for a custom factory that implements only the JDK
+ * {@code SSLContext}. If neither class is supported the returned {@link Optional} is empty, exactly as the
+ * raw {@code createInstance} call would be — the consumer keeps its existing "supplied no context" failure.
+ *
+ * <p>The synthesized context bakes the role-appropriate settings the factory could not apply, carried by the
+ * {@link TlsSynthesisSpec}: for a client purpose the hostname-verification algorithm (see
+ * {@link TlsContexts#synthesizeNettyClientFromJdk}); for a server purpose the client-auth requirement (see
+ * {@link TlsContexts#synthesizeNettyServerFromJdk}). For a subscribing acquisition the synthesis re-wraps on
+ * every delivery, so rotated JDK material reaches the consumer as a freshly synthesized Netty context.
+ *
+ * <p><b>{@code SSLParameters} companion (PIP-478).</b> On the synthesis path the framework additionally asks
+ * the factory for {@code createInstance(purpose, SSLParameters.class)} — the optional engine-policy companion
+ * carrying the factory's baseline a bare {@code SSLContext} cannot express (enabled protocols/ciphers,
+ * algorithm constraints, application protocols, endpoint identification, and the server client-auth mode). It
+ * is requested in the same form as the {@code SSLContext} (one-shot, or endpoint-carrying), and on a
+ * subscribing acquisition it is re-requested with each {@code SSLContext} delivery so engine policy may rotate
+ * with material. The merge is deterministic (see {@link TlsContexts#synthesizeNettyClientFromJdk} /
+ * {@link TlsContexts#synthesizeNettyServerFromJdk}): the factory companion forms the engine baseline (non-null
+ * members only); {@code endpointIdentificationAlgorithm} is the factory's when set, otherwise the consumer's
+ * hostname-verification flag applies {@code "HTTPS"} on client purposes; SNI is always set per connection from
+ * the target endpoint (never taken from the companion); and on server purposes the companion's
+ * {@code needClientAuth}/{@code wantClientAuth} are authoritative when it is supplied, else the consumer's
+ * client-auth flag maps as usual. A factory-supplied companion is mutable, so the framework snapshots it once
+ * per acquisition (see {@link TlsContexts}); {@code empty()} means the consumer's configuration applies, as
+ * before. The subscribing form requests the companion synchronously within the reload callback — which the SPI
+ * runs off any event loop — so a factory that supplies it must complete that request without depending on the
+ * thread delivering the {@code SSLContext}.
+ */
+public final class TlsContextAcquisition {
+
+    private TlsContextAcquisition() {
+    }
+
+    /**
+     * Default bound (5 minutes) on how long an AsyncHttpClient pooled HTTPS connection may keep using
+     * pre-rotation TLS material on the rotating PIP-478 factory path. Trades prompt rotation against
+     * connection churn.
+     */
+    public static final int DEFAULT_HTTP_TLS_ROTATION_CONNECTION_TTL_MS = 5 * 60 * 1000;
+
+    /** System property overriding {@link #DEFAULT_HTTP_TLS_ROTATION_CONNECTION_TTL_MS} (injectable for tests). */
+    public static final String HTTP_TLS_ROTATION_CONNECTION_TTL_PROPERTY = "pulsar.tls.http.connectionTtlMillis";
+
+    /**
+     * The connection-TTL (millis) that bounds how long an AsyncHttpClient pooled HTTPS connection may keep
+     * using pre-rotation TLS material on the rotating PIP-478 factory path (review L2/H4). Since AsyncHttpClient
+     * fixes its TLS configuration at build time and the framework installs a rotating {@code SslEngineFactory},
+     * new connections pick up rotated material immediately, but an established pooled connection would otherwise
+     * keep pre-rotation material indefinitely; this TTL caps that, making rotation effective "within the TTL
+     * bound" rather than merely eventually (PIP-478 "TLS rotation behind PulsarHttpClient"). Read per call so it
+     * is injectable at runtime via {@link #HTTP_TLS_ROTATION_CONNECTION_TTL_PROPERTY}; defaults to 5 minutes.
+     */
+    public static int httpTlsRotationConnectionTtlMillis() {
+        return Integer.getInteger(HTTP_TLS_ROTATION_CONNECTION_TTL_PROPERTY,
+                DEFAULT_HTTP_TLS_ROTATION_CONNECTION_TTL_MS);
+    }
+
+    /**
+     * Build something from a rotating factory-owned Netty {@link SslContext} borrow while <em>pinning</em> the
+     * context across the build (PIP-478 F1 use-after-free guard). A subscribing consumer holds the latest
+     * context in a volatile that the reload callback updates on rotation; it then reads that volatile and calls
+     * {@code newHandler}/{@code newEngine} on it — potentially on a different thread and after the poll thread
+     * has moved on. On the OpenSSL engine a rotated context whose refcount reaches zero has its native
+     * {@code SSL_CTX} freed, so an unpinned build races a free.
+     *
+     * <p>This reads the current borrow from {@code source}, retains it for the duration of {@code build}, and
+     * releases it afterward — a <em>balanced</em> pin that nets to zero and never disturbs the factory's own
+     * ownership (consumers still treat the context as an immutable borrow per the SPI contract). If the borrow
+     * was already superseded and freed between the read and the pin (an {@link IllegalReferenceCountException}
+     * from {@code retain()}), the current borrow is re-read and the build retried: the factory publishes the
+     * new context to the volatile before the old one can be released two generations later (see
+     * {@code FileBasedTlsFactory.Subscription} deferred release), so the re-read always yields a live context.
+     * On the JDK engine {@code retain}/{@code release} are no-ops and this reduces to a plain build.
+     *
+     * @param source a supplier of the current (possibly rotated) factory-owned context borrow
+     * @param build  the build to run against the pinned context (e.g. {@code ctx -> ctx.newHandler(alloc)})
+     * @return the build result
+     * @throws IllegalStateException if no context is available (e.g. the factory was closed)
+     */
+    public static <R> R withPinnedContext(Supplier<SslContext> source, Function<SslContext, R> build) {
+        // Bounded retry: in steady state the first read yields a live context; the loop only re-reads if a
+        // rotation freed the just-read borrow between the read and the pin. The bound prevents an unbounded
+        // spin in the narrow shutdown race where the factory closed and the volatile still points at a freed
+        // context — there the last attempt's IllegalReferenceCountException propagates and the connection fails
+        // cleanly, which is correct during shutdown.
+        IllegalReferenceCountException lastFreed = null;
+        for (int attempt = 0; attempt < 8; attempt++) {
+            SslContext context = source.get();
+            if (context == null) {
+                throw new IllegalStateException("No TLS context available (factory not initialized or closed)");
+            }
+            try {
+                ReferenceCountUtil.retain(context);
+            } catch (IllegalReferenceCountException superseded) {
+                // The borrow was released to refcount 0 (rotated out) between the read and the pin; re-read.
+                lastFreed = superseded;
+                continue;
+            }
+            try {
+                return build.apply(context);
+            } finally {
+                ReferenceCountUtil.release(context);
+            }
+        }
+        throw lastFreed != null ? lastFreed
+                : new IllegalReferenceCountException("TLS context repeatedly unavailable while pinning");
+    }
+
+    /**
+     * One-shot acquisition of the Netty {@link SslContext} for {@code purpose}, falling back to synthesis
+     * from the JDK {@code SSLContext}.
+     *
+     * @param factory   the (initialized) TLS factory
+     * @param purpose   the purpose to resolve
+     * @param synthesis the settings to bake if the Netty class must be synthesized from the JDK context
+     * @return a future of the handle, or {@link Optional#empty()} when the factory supports neither class
+     */
+    public static CompletableFuture<Optional<TlsHandle<SslContext>>> acquireNettyContext(
+            PulsarTlsFactory factory, TlsPurpose purpose, TlsSynthesisSpec synthesis) {
+        return factory.createInstance(purpose, SslContext.class)
+                .thenCompose(direct -> direct.isPresent()
+                        ? CompletableFuture.completedFuture(direct)
+                        : synthesizeFromFallback(factory.createInstance(purpose, SSLContext.class),
+                                () -> factory.createInstance(purpose, SSLParameters.class), purpose, synthesis));
+    }
+
+    /**
+     * One-shot acquisition carrying the destination endpoint hint (client purposes), falling back to
+     * synthesis from the JDK {@code SSLContext} requested with the same endpoint.
+     *
+     * @param factory   the (initialized) TLS factory
+     * @param purpose   the purpose to resolve
+     * @param endpoint  the destination host/port hint
+     * @param synthesis the settings to bake if the Netty class must be synthesized from the JDK context
+     * @return a future of the handle, or {@link Optional#empty()} when the factory supports neither class
+     */
+    public static CompletableFuture<Optional<TlsHandle<SslContext>>> acquireNettyContext(
+            PulsarTlsFactory factory, TlsPurpose purpose, TlsEndpoint endpoint, TlsSynthesisSpec synthesis) {
+        return factory.createInstance(purpose, endpoint, SslContext.class)
+                .thenCompose(direct -> direct.isPresent()
+                        ? CompletableFuture.completedFuture(direct)
+                        : synthesizeFromFallback(factory.createInstance(purpose, endpoint, SSLContext.class),
+                                () -> factory.createInstance(purpose, endpoint, SSLParameters.class), purpose,
+                                synthesis));
+    }
+
+    /**
+     * Subscribing acquisition of the Netty {@link SslContext} for {@code purpose}, falling back to a
+     * subscription on the JDK {@code SSLContext} whose deliveries are re-wrapped into Netty contexts.
+     *
+     * @param factory        the (initialized) TLS factory
+     * @param purpose        the purpose to resolve
+     * @param synthesis      the settings to bake if the Netty class must be synthesized from the JDK context
+     * @param onLoadOrReload receives the context on first load and on every rebuild (native or synthesized)
+     * @return a future of the subscribing handle, or {@link Optional#empty()} when neither class is supported
+     */
+    public static CompletableFuture<Optional<TlsHandle<SslContext>>> acquireNettyContext(
+            PulsarTlsFactory factory, TlsPurpose purpose, TlsSynthesisSpec synthesis,
+            Consumer<SslContext> onLoadOrReload) {
+        return factory.createInstance(purpose, SslContext.class, onLoadOrReload)
+                .thenCompose(direct -> {
+                    if (direct.isPresent()) {
+                        return CompletableFuture.completedFuture(direct);
+                    }
+                    // Pre-fetch the SSLParameters companion ONCE, before subscribing, and reuse it across
+                    // deliveries (F8): joining the companion inside the per-delivery callback self-deadlocks
+                    // when a custom factory dispatches its creation to the same single-thread executor that
+                    // runs the reload callback (e.g. the admin connector wiring scheduler==blockingExecutor).
+                    // The companion is composed here (never joined), off the delivery thread. Material still
+                    // rotates on every delivery; the engine-policy companion is snapshotted at subscribe time
+                    // (the default file-based factory has no companion, so this is a no-op for it).
+                    return factory.createInstance(purpose, SSLParameters.class).thenCompose(paramsHandle -> {
+                        SSLParameters factoryBaseline = extractBaseline(paramsHandle);
+                        SynthesizingSubscription subscription =
+                                new SynthesizingSubscription(purpose, synthesis, factoryBaseline, onLoadOrReload);
+                        return factory.createInstance(purpose, SSLContext.class, subscription::onDelivery)
+                                .thenApply(jdk -> jdk.map(subscription::bind));
+                    });
+                });
+    }
+
+    /**
+     * Complete the synthesis fallback once the JDK {@code SSLContext} is resolved: when present, request the
+     * factory's optional {@code SSLParameters} companion (lazily, via {@code paramsSupplier}, so it is not
+     * requested when the JDK context is unsupported) and synthesize the Netty context from both.
+     */
+    private static CompletableFuture<Optional<TlsHandle<SslContext>>> synthesizeFromFallback(
+            CompletableFuture<Optional<TlsHandle<SSLContext>>> jdkFuture,
+            Supplier<CompletableFuture<Optional<TlsHandle<SSLParameters>>>> paramsSupplier,
+            TlsPurpose purpose, TlsSynthesisSpec synthesis) {
+        return jdkFuture.thenCompose(jdk -> {
+            if (jdk.isEmpty()) {
+                return CompletableFuture.<Optional<TlsHandle<SslContext>>>completedFuture(Optional.empty());
+            }
+            return paramsSupplier.get().thenApply(paramsHandle ->
+                    Optional.of(synthesizeOneShot(jdk.get(), purpose, synthesis, extractBaseline(paramsHandle))));
+        });
+    }
+
+    private static TlsHandle<SslContext> synthesizeOneShot(TlsHandle<SSLContext> jdkHandle, TlsPurpose purpose,
+                                                           TlsSynthesisSpec synthesis, SSLParameters factoryBaseline) {
+        SslContext context = synthesize(jdkHandle.get(), purpose, synthesis, factoryBaseline);
+        return new TlsHandle<>() {
+            @Override
+            public SslContext get() {
+                return context;
+            }
+
+            @Override
+            public void dispose() {
+                jdkHandle.dispose();
+            }
+        };
+    }
+
+    private static SslContext synthesize(SSLContext jdkContext, TlsPurpose purpose, TlsSynthesisSpec synthesis,
+                                         SSLParameters factoryBaseline) {
+        if (purpose.role() == TlsPurpose.Role.CLIENT) {
+            return TlsContexts.synthesizeNettyClientFromJdk(jdkContext, synthesis.enableHostnameVerification(),
+                    factoryBaseline);
+        }
+        return TlsContexts.synthesizeNettyServerFromJdk(jdkContext, synthesis.requireTrustedClientCert(),
+                factoryBaseline);
+    }
+
+    /**
+     * Extract the factory's {@code SSLParameters} companion from its handle, disposing the handle afterwards.
+     * Returns {@code null} when the factory returned {@code empty()} (no companion for this purpose). The
+     * synthesis takes its own defensive snapshot of the returned (mutable) object.
+     */
+    private static SSLParameters extractBaseline(Optional<TlsHandle<SSLParameters>> handle) {
+        if (handle.isEmpty()) {
+            return null;
+        }
+        TlsHandle<SSLParameters> paramsHandle = handle.get();
+        try {
+            return paramsHandle.get();
+        } finally {
+            paramsHandle.dispose();
+        }
+    }
+
+    /**
+     * A {@link TlsHandle} over a JDK {@code SSLContext} subscription that synthesizes a Netty context on each
+     * delivery, forwards it to the consumer callback, and exposes the latest synthesized context via
+     * {@link #get()}.
+     */
+    private static final class SynthesizingSubscription implements TlsHandle<SslContext> {
+
+        private final TlsPurpose purpose;
+        private final TlsSynthesisSpec synthesis;
+        // Snapshotted once at subscribe time (F8) rather than re-fetched inside the delivery callback.
+        private final SSLParameters factoryBaseline;
+        private final Consumer<SslContext> onLoadOrReload;
+        private volatile SslContext latest;
+        private volatile TlsHandle<SSLContext> underlying;
+
+        SynthesizingSubscription(TlsPurpose purpose, TlsSynthesisSpec synthesis, SSLParameters factoryBaseline,
+                                 Consumer<SslContext> onLoadOrReload) {
+            this.purpose = purpose;
+            this.synthesis = synthesis;
+            this.factoryBaseline = factoryBaseline;
+            this.onLoadOrReload = onLoadOrReload;
+        }
+
+        // Serial per subscription (SPI contract); the first delivery happens-before the subscribe future
+        // completes, so `latest` is set by the time bind() runs. Material rotates on every delivery; the
+        // engine-policy companion is the pre-fetched snapshot (no blocking join on the delivery thread, F8).
+        void onDelivery(SSLContext jdkContext) {
+            SslContext wrapped = synthesize(jdkContext, purpose, synthesis, factoryBaseline);
+            this.latest = wrapped;
+            onLoadOrReload.accept(wrapped);
+        }
+
+        TlsHandle<SslContext> bind(TlsHandle<SSLContext> jdkHandle) {
+            this.underlying = jdkHandle;
+            return this;
+        }
+
+        @Override
+        public SslContext get() {
+            return latest;
+        }
+
+        @Override
+        public void dispose() {
+            TlsHandle<SSLContext> jdkHandle = underlying;
+            if (jdkHandle != null) {
+                jdkHandle.dispose();
+            }
+        }
+    }
+}

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/tls/impl/TlsContexts.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/tls/impl/TlsContexts.java
@@ -1,0 +1,332 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.tls.impl;
+
+import io.netty.handler.ssl.ApplicationProtocolConfig;
+import io.netty.handler.ssl.ClientAuth;
+import io.netty.handler.ssl.IdentityCipherSuiteFilter;
+import io.netty.handler.ssl.JdkSslContext;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.SslProvider;
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import java.security.cert.Certificate;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
+import lombok.CustomLog;
+import org.apache.pulsar.common.tls.TlsPolicy;
+import org.apache.pulsar.common.util.tls.JdkSslContexts;
+
+/**
+ * Builds the well-known TLS instance classes from loaded {@link TlsMaterial} and a {@link TlsPolicy}
+ * for the default {@code FileBasedTlsFactory}, and synthesizes the richer objects from a JDK
+ * {@code SSLContext} for the framework fallback (PIP-478).
+ *
+ * <p>This class owns TLS context assembly end-to-end, composing the focused low-level primitives rather
+ * than a general-purpose helper: it consumes already-parsed in-memory {@link TlsMaterial} (PEM and keystore
+ * parsing lives in the material sources), builds the JDK {@code SSLContext} through {@link JdkSslContexts},
+ * and assembles the Netty {@link SslContext} objects inline through {@link SslContextBuilder}. The Netty
+ * contexts are built here rather than delegated because two per-context settings must be baked at build time
+ * from the in-memory material:
+ * <ul>
+ *   <li><b>Client hostname verification</b> — set via
+ *       {@link SslContextBuilder#endpointIdentificationAlgorithm(String)} to {@code "HTTPS"} when the
+ *       policy enables it. It cannot be left to a per-{@code SSLEngine} override: Netty's OpenSSL
+ *       backend fixes the endpoint-identification algorithm at build time.</li>
+ *   <li><b>Server insecure trust</b> — {@code policy.allowInsecureConnection()} on a
+ *       server context installs {@link InsecureTrustManagerFactory#INSTANCE} so an untrusted client
+ *       certificate still completes the handshake and remains available for TLS authentication, while
+ *       client-auth stays {@link ClientAuth#REQUIRE}/{@link ClientAuth#OPTIONAL} (never
+ *       {@link ClientAuth#NONE}, per {@code tlsRequireTrustedClientCert} semantics).</li>
+ * </ul>
+ */
+@CustomLog
+public final class TlsContexts {
+
+    /**
+     * The default enabled TLS protocol set, applied whenever the effective protocol list is empty — a policy
+     * with no {@code protocols()}, or a synthesized context whose factory companion set none. This preserves
+     * the {@code {TLSv1.3, TLSv1.2}} floor the removed {@code DefaultPulsarSslFactory} forced at engine build
+     * (B3): without it the PIP-478 path would silently defer to the JVM/provider default protocol set, a
+     * security-relevant drift on upgrade.
+     */
+    public static final List<String> DEFAULT_ENABLED_PROTOCOLS = List.of("TLSv1.3", "TLSv1.2");
+
+    // WARN-once dedup for the insecure (trust-all) mode, keyed by policy value so a rotation's context rebuilds
+    // (and both the Netty and JDK builds of the same policy) log at most once (S-F1).
+    private static final Set<TlsPolicy> INSECURE_WARNED = ConcurrentHashMap.newKeySet();
+
+    private TlsContexts() {
+    }
+
+    /**
+     * Log a one-time WARN when an insecure (trust-all) TLS policy is applied at context build (S-F1): peer
+     * certificates are not validated. Deduplicated per policy value so rotation rebuilds do not spam the log.
+     */
+    private static void warnInsecureModeOnce(TlsPolicy policy) {
+        if (policy.allowInsecureConnection() && INSECURE_WARNED.add(policy)) {
+            log.warn().log("TLS insecure mode is enabled (allowInsecureConnection=true): peer certificates are "
+                    + "NOT validated (trust-all). This disables authentication of the remote peer and must be "
+                    + "used only for testing.");
+        }
+    }
+
+    /**
+     * Build a client Netty {@link SslContext}, baking hostname verification when the policy enables it.
+     *
+     * @param material the loaded client material
+     * @param policy   the policy (flags, protocols, ciphers)
+     * @param provider the Netty SSL provider (engine selection)
+     * @return the built client context
+     * @throws Exception if the context cannot be built
+     */
+    static SslContext buildNettyClientContext(TlsMaterial material, TlsPolicy policy, SslProvider provider)
+            throws Exception {
+        SslContextBuilder builder = SslContextBuilder.forClient().sslProvider(provider);
+        applyClientTrust(builder, material, policy);
+        if (material.hasKeyMaterial()) {
+            builder.keyManager(material.privateKey(), material.keyCertChainArray());
+        }
+        applyCiphersAndProtocols(builder, policy);
+        if (policy.enableHostnameVerification()) {
+            builder.endpointIdentificationAlgorithm("HTTPS");
+        }
+        return builder.build();
+    }
+
+    /**
+     * Build a server Netty {@link SslContext} honoring the D3 insecure rule.
+     *
+     * @param material                 the loaded server material
+     * @param policy                   the policy (flags, protocols, ciphers)
+     * @param provider                 the Netty SSL provider (engine selection)
+     * @param requireTrustedClientCert whether to require (vs. merely request) a trusted client cert
+     * @return the built server context
+     * @throws Exception if the context cannot be built
+     */
+    static SslContext buildNettyServerContext(TlsMaterial material, TlsPolicy policy, SslProvider provider,
+                                              boolean requireTrustedClientCert) throws Exception {
+        SslContextBuilder builder = SslContextBuilder.forServer(material.privateKey(), material.keyCertChainArray())
+                .sslProvider(provider);
+        applyServerTrust(builder, material, policy);
+        applyCiphersAndProtocols(builder, policy);
+        // Never drop to ClientAuth.NONE, even when insecure: a captured client cert powers TLS auth.
+        builder.clientAuth(requireTrustedClientCert ? ClientAuth.REQUIRE : ClientAuth.OPTIONAL);
+        return builder.build();
+    }
+
+    /**
+     * Build a JDK {@link SSLContext} for the material (the universal fallback and non-Netty consumers).
+     *
+     * @param material the loaded material
+     * @param policy   the policy (only the insecure flag affects a JDK context)
+     * @return the built JDK context
+     * @throws Exception if the context cannot be built
+     */
+    static SSLContext buildJdkContext(TlsMaterial material, TlsPolicy policy) throws Exception {
+        warnInsecureModeOnce(policy);
+        Certificate[] keyCertChain = material.keyCertChainArray();
+        return JdkSslContexts.createSslContext(policy.allowInsecureConnection(), material.trustCertsArray(),
+                keyCertChain, material.privateKey());
+    }
+
+    /**
+     * Wrap a JDK {@link SSLContext} as a Netty {@link SslContext} via {@link JdkSslContext}. Used by the
+     * framework when a custom factory returns {@code empty()} for the Netty class but supplies the JDK
+     * {@code SSLContext} fallback.
+     *
+     * @param sslContext               the JDK context to wrap
+     * @param isClient                 whether the wrapped context is for client-mode engines
+     * @param requireTrustedClientCert server-side client-auth requirement (ignored when {@code isClient})
+     * @return a Netty context backed by the JDK context
+     */
+    public static SslContext synthesizeNettyFromJdk(SSLContext sslContext, boolean isClient,
+                                                    boolean requireTrustedClientCert) {
+        ClientAuth clientAuth = isClient ? ClientAuth.NONE
+                : (requireTrustedClientCert ? ClientAuth.REQUIRE : ClientAuth.OPTIONAL);
+        return new JdkSslContext(sslContext, isClient, null, IdentityCipherSuiteFilter.INSTANCE,
+                ApplicationProtocolConfig.DISABLED, clientAuth, null, false);
+    }
+
+    /**
+     * Synthesize a <em>client</em> Netty {@link SslContext} from a JDK {@link SSLContext}, applying the
+     * factory's engine-policy {@code SSLParameters} companion (when present) and the consumer's
+     * hostname-verification flag to the produced engines. Used by the framework when a custom factory returns
+     * {@code empty()} for the Netty class on a client purpose but supplies the JDK {@code SSLContext} fallback.
+     *
+     * <p>Engine-level policy cannot be encoded in the JDK {@code SSLContext} itself — the enabled protocols
+     * and cipher suites, algorithm constraints, application protocols, and the endpoint-identification
+     * algorithm are all {@link SSLParameters} settings — so the composed baseline is applied per engine by a
+     * {@link SynthesizedEngineSslContext} wrapper. This mirrors the native path, where
+     * {@link #buildNettyClientContext} bakes the same settings into the context via {@code SslContextBuilder};
+     * consumers rely on the context to carry the policy and never re-apply it per connection.
+     *
+     * <p>Merge order (PIP-478): the factory {@code SSLParameters} form the baseline (non-null members only);
+     * for {@code endpointIdentificationAlgorithm} the factory's value wins when set, otherwise
+     * {@code enableHostnameVerification} applies {@code "HTTPS"}; SNI {@code serverNames} are never taken from
+     * the factory (the per-connection SNI wins). When the factory companion sets no enabled protocols, the
+     * {@link #DEFAULT_ENABLED_PROTOCOLS} floor is applied so a synthesized client engine matches the native
+     * path's default (B3).
+     *
+     * @param sslContext                 the JDK context to wrap
+     * @param enableHostnameVerification whether the client policy enables hostname verification
+     * @param factoryBaseline            the factory's engine-policy companion, or {@code null} if none supplied
+     * @return a Netty client context backed by the JDK context, carrying the composed engine policy
+     */
+    public static SslContext synthesizeNettyClientFromJdk(SSLContext sslContext,
+                                                          boolean enableHostnameVerification,
+                                                          SSLParameters factoryBaseline) {
+        SslContext clientContext = synthesizeNettyFromJdk(sslContext, true, false);
+        SSLParameters overlay = composeClientOverlay(factoryBaseline, enableHostnameVerification);
+        return new SynthesizedEngineSslContext(clientContext, overlay, false);
+    }
+
+    /**
+     * Synthesize a <em>server</em> Netty {@link SslContext} from a JDK {@link SSLContext}, applying the
+     * factory's engine-policy {@code SSLParameters} companion (when present) to the produced engines. Used by
+     * the framework when a custom factory returns {@code empty()} for the Netty class on a server purpose but
+     * supplies the JDK {@code SSLContext} fallback.
+     *
+     * <p>The consumer's {@code requireTrustedClientCert} is mapped onto the base context as usual
+     * ({@link ClientAuth#REQUIRE}/{@link ClientAuth#OPTIONAL}). When a companion is supplied its non-null
+     * baseline members (protocols/ciphers/algorithm-constraints/application-protocols) are overlaid per engine
+     * and — merge rule 4 — its {@code needClientAuth}/{@code wantClientAuth} are authoritative for the
+     * client-auth mode; with no companion the base context's client-auth mode is left untouched. In both cases,
+     * when no enabled protocols were set the {@link #DEFAULT_ENABLED_PROTOCOLS} floor is applied (B3).
+     *
+     * @param sslContext               the JDK context to wrap
+     * @param requireTrustedClientCert the consumer's client-auth requirement (used when no companion supplied)
+     * @param factoryBaseline          the factory's engine-policy companion, or {@code null} if none supplied
+     * @return a Netty server context backed by the JDK context, carrying the composed engine policy
+     */
+    public static SslContext synthesizeNettyServerFromJdk(SSLContext sslContext,
+                                                          boolean requireTrustedClientCert,
+                                                          SSLParameters factoryBaseline) {
+        SslContext serverContext = synthesizeNettyFromJdk(sslContext, false, requireTrustedClientCert);
+        // Apply the companion's client-auth mode (merge rule 4) only when a companion was supplied; with none,
+        // the base context already carries the consumer's client-auth mode and the overlay pins only protocols.
+        SSLParameters overlay = factoryBaseline == null ? new SSLParameters() : copyBaselineMembers(factoryBaseline);
+        applyDefaultProtocolsIfUnset(overlay);
+        return new SynthesizedEngineSslContext(serverContext, overlay, factoryBaseline != null);
+    }
+
+    /**
+     * Compose the per-engine overlay for a client purpose. Always non-null: at minimum it pins the
+     * {@link #DEFAULT_ENABLED_PROTOCOLS} floor (B3), plus the factory's baseline members and — merge rule 2 —
+     * the endpoint-identification algorithm (factory wins when set, else the consumer's hostname-verification
+     * flag applies {@code "HTTPS"}).
+     */
+    private static SSLParameters composeClientOverlay(SSLParameters factoryBaseline,
+                                                      boolean enableHostnameVerification) {
+        SSLParameters overlay = factoryBaseline == null ? new SSLParameters() : copyBaselineMembers(factoryBaseline);
+        applyDefaultProtocolsIfUnset(overlay);
+        // Merge rule 2: the factory's endpointIdentificationAlgorithm wins when set; otherwise the consumer's
+        // hostname-verification flag applies "HTTPS".
+        if (overlay.getEndpointIdentificationAlgorithm() == null && enableHostnameVerification) {
+            overlay.setEndpointIdentificationAlgorithm("HTTPS");
+        }
+        return overlay;
+    }
+
+    /** Pin {@link #DEFAULT_ENABLED_PROTOCOLS} on an overlay whose enabled protocols were left unset (B3). */
+    private static void applyDefaultProtocolsIfUnset(SSLParameters overlay) {
+        if (overlay.getProtocols() == null) {
+            overlay.setProtocols(DEFAULT_ENABLED_PROTOCOLS.toArray(new String[0]));
+        }
+    }
+
+    /**
+     * Take the framework's single defensive snapshot of a factory-supplied {@link SSLParameters} — a mutable
+     * object — copying only the engine-baseline members the framework overlays per engine. SNI
+     * {@code serverNames} are deliberately excluded (merge rule 3: the per-connection SNI always wins). The
+     * returned object is owned by the framework and never mutated after composition, so a later mutation of
+     * the factory's original object cannot affect an already-acquired context.
+     */
+    private static SSLParameters copyBaselineMembers(SSLParameters source) {
+        SSLParameters overlay = new SSLParameters();
+        if (source.getProtocols() != null) {
+            overlay.setProtocols(source.getProtocols().clone());
+        }
+        if (source.getCipherSuites() != null) {
+            overlay.setCipherSuites(source.getCipherSuites().clone());
+        }
+        if (source.getAlgorithmConstraints() != null) {
+            overlay.setAlgorithmConstraints(source.getAlgorithmConstraints());
+        }
+        if (source.getApplicationProtocols() != null) {
+            overlay.setApplicationProtocols(source.getApplicationProtocols().clone());
+        }
+        if (source.getEndpointIdentificationAlgorithm() != null) {
+            overlay.setEndpointIdentificationAlgorithm(source.getEndpointIdentificationAlgorithm());
+        }
+        // Client-auth mode is carried on the overlay for server purposes (applied by
+        // SynthesizedEngineSslContext when applyClientAuth is set); needClientAuth wins over wantClientAuth.
+        if (source.getNeedClientAuth()) {
+            overlay.setNeedClientAuth(true);
+        } else if (source.getWantClientAuth()) {
+            overlay.setWantClientAuth(true);
+        }
+        return overlay;
+    }
+
+    private static void applyClientTrust(SslContextBuilder builder, TlsMaterial material, TlsPolicy policy) {
+        if (policy.allowInsecureConnection()) {
+            warnInsecureModeOnce(policy);
+            builder.trustManager(InsecureTrustManagerFactory.INSTANCE);
+        } else if (material.trustCertsArray().length > 0) {
+            builder.trustManager(material.trustCertsArray());
+        }
+        // else: leave the platform default trust manager (system trust store).
+    }
+
+    private static void applyServerTrust(SslContextBuilder builder, TlsMaterial material, TlsPolicy policy) {
+        if (policy.allowInsecureConnection()) {
+            warnInsecureModeOnce(policy);
+            builder.trustManager(InsecureTrustManagerFactory.INSTANCE);
+        } else if (material.trustCertsArray().length > 0) {
+            builder.trustManager(material.trustCertsArray());
+        }
+        // else: leave the platform default trust manager (system trust store).
+    }
+
+    private static void applyCiphersAndProtocols(SslContextBuilder builder, TlsPolicy policy) {
+        Set<String> ciphers = toSet(policy.ciphers());
+        Set<String> protocols = toSet(policy.protocols());
+        if (ciphers != null) {
+            builder.ciphers(ciphers);
+        }
+        // Pin the enabled protocols even when the policy configured none, preserving the {TLSv1.3, TLSv1.2}
+        // floor the removed DefaultPulsarSslFactory forced rather than deferring to the provider default (B3).
+        String[] enabledProtocols = protocols != null
+                ? protocols.toArray(new String[0])
+                : DEFAULT_ENABLED_PROTOCOLS.toArray(new String[0]);
+        builder.protocols(enabledProtocols);
+    }
+
+    private static Set<String> toSet(List<String> values) {
+        if (values == null || values.isEmpty()) {
+            return null;
+        }
+        return new LinkedHashSet<>(values);
+    }
+}

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/tls/impl/TlsFactoryProbe.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/tls/impl/TlsFactoryProbe.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.tls.impl;
+
+import java.util.Optional;
+import java.util.concurrent.CompletionException;
+import org.apache.pulsar.common.tls.PulsarTlsFactory;
+import org.apache.pulsar.common.tls.TlsHandle;
+import org.apache.pulsar.common.tls.TlsPurpose;
+
+/**
+ * Fail-fast probe support for the framework's boot-time contract enforcement (PIP-478).
+ *
+ * <p>The framework probes every {@code (purpose, class)} pair it needs at startup so that a
+ * misconfiguration surfaces as a boot error rather than at first connection. A probe uses the
+ * one-shot, endpoint-less {@code createInstance} form and <strong>retains</strong> the returned handle
+ * as the initial cached instance — the probe is the first load, not a throwaway.
+ */
+public final class TlsFactoryProbe {
+
+    private TlsFactoryProbe() {
+    }
+
+    /**
+     * Eagerly build (probe) the instance of {@code instanceClass} for {@code purpose}, returning the
+     * retained handle. Blocks until the factory completes the request.
+     *
+     * @param factory       the factory to probe
+     * @param purpose       the purpose to probe
+     * @param instanceClass the well-known instance class to probe
+     * @param <T>           the instance type
+     * @return the retained handle whose {@link TlsHandle#get()} is the initial instance
+     * @throws IllegalStateException if the factory does not support the {@code (purpose, class)}
+     *                               combination, or completes the request exceptionally (a boot error)
+     */
+    public static <T> TlsHandle<T> probe(PulsarTlsFactory factory, TlsPurpose purpose, Class<T> instanceClass) {
+        Optional<TlsHandle<T>> handle;
+        try {
+            handle = factory.createInstance(purpose, instanceClass).join();
+        } catch (CompletionException e) {
+            Throwable cause = e.getCause() != null ? e.getCause() : e;
+            throw new IllegalStateException(
+                    "Failed to build TLS " + instanceClass.getName() + " for purpose " + purpose, cause);
+        }
+        return handle.orElseThrow(() -> new IllegalStateException(
+                "TLS factory does not support building " + instanceClass.getName() + " for purpose " + purpose));
+    }
+}

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/tls/impl/TlsKeyStoreLoader.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/tls/impl/TlsKeyStoreLoader.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.tls.impl;
+
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.security.Key;
+import java.security.KeyStore;
+import java.security.PrivateKey;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Loads TLS material (private key, certificate chain, trust certificates) from a PKCS12/JKS keystore for
+ * the default {@code FileBasedTlsFactory} (PIP-478). Shared by the file-based {@link TlsMaterialSource}
+ * and the {@code BROKER_CLIENT} authentication overlay ({@link AuthProvidedMaterialSource}) so a single
+ * alias-walk implementation serves both.
+ */
+final class TlsKeyStoreLoader {
+
+    private TlsKeyStoreLoader() {
+    }
+
+    static KeyStore loadKeyStore(String type, String path, String password) throws Exception {
+        String storeType = StringUtils.isNotBlank(type) ? type : KeyStore.getDefaultType();
+        KeyStore keyStore = KeyStore.getInstance(storeType);
+        try (InputStream input = new FileInputStream(path)) {
+            keyStore.load(input, password == null ? null : password.toCharArray());
+        }
+        return keyStore;
+    }
+
+    static List<X509Certificate> extractTrustCerts(KeyStore trustStore) throws Exception {
+        List<X509Certificate> certs = new ArrayList<>();
+        Enumeration<String> aliases = trustStore.aliases();
+        while (aliases.hasMoreElements()) {
+            Certificate certificate = trustStore.getCertificate(aliases.nextElement());
+            if (certificate instanceof X509Certificate x509) {
+                certs.add(x509);
+            }
+        }
+        return certs;
+    }
+
+    static PrivateKey extractPrivateKey(KeyStore keyStore, String password) throws Exception {
+        char[] pwd = password == null ? null : password.toCharArray();
+        Enumeration<String> aliases = keyStore.aliases();
+        while (aliases.hasMoreElements()) {
+            String alias = aliases.nextElement();
+            if (keyStore.isKeyEntry(alias)) {
+                Key key = keyStore.getKey(alias, pwd);
+                if (key instanceof PrivateKey privateKey) {
+                    return privateKey;
+                }
+            }
+        }
+        return null;
+    }
+
+    static List<X509Certificate> extractCertificateChain(KeyStore keyStore) throws Exception {
+        Enumeration<String> aliases = keyStore.aliases();
+        while (aliases.hasMoreElements()) {
+            String alias = aliases.nextElement();
+            if (keyStore.isKeyEntry(alias)) {
+                Certificate[] chain = keyStore.getCertificateChain(alias);
+                if (chain != null && chain.length > 0) {
+                    List<X509Certificate> result = new ArrayList<>(chain.length);
+                    for (Certificate certificate : chain) {
+                        if (certificate instanceof X509Certificate x509) {
+                            result.add(x509);
+                        }
+                    }
+                    if (!result.isEmpty()) {
+                        return result;
+                    }
+                }
+            }
+        }
+        return List.of();
+    }
+}

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/tls/impl/TlsMaterial.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/tls/impl/TlsMaterial.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.tls.impl;
+
+import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
+import java.util.List;
+
+/**
+ * The loaded TLS material for one {@code TlsPurpose}: the private key, its certificate chain, and the
+ * trust certificates (PIP-478, internal to the default {@code FileBasedTlsFactory}).
+ *
+ * <p>This is a value type with structural {@code equals}/{@code hashCode} (a record). The default
+ * factory uses value equality to detect real rotations: a {@code TlsMaterialSource} that re-reads its
+ * files but finds identical content produces an {@code equal} instance, which suppresses spurious
+ * context rebuilds and reload callbacks (a file touched without content change fires nothing).
+ *
+ * <p>Role-neutral: the policy flags (insecure, hostname verification, client-auth requirement) and the
+ * protocols/ciphers are fixed at construction and live on the owning {@code TlsPolicy}/factory
+ * settings, not here — only the crypto material rotates.
+ *
+ * @param privateKey   the private key (client key for mTLS, server key on the server side), or
+ *                     {@code null} when none is configured
+ * @param keyCertChain the certificate chain matching {@link #privateKey()} (never {@code null})
+ * @param trustCerts   the trusted CA certificates, or empty to use the platform default trust store
+ */
+record TlsMaterial(PrivateKey privateKey, List<X509Certificate> keyCertChain, List<X509Certificate> trustCerts) {
+
+    /** The "system default" material: no key, no configured trust (resolves to the platform trust store). */
+    static final TlsMaterial SYSTEM_DEFAULT = new TlsMaterial(null, List.of(), List.of());
+
+    TlsMaterial {
+        keyCertChain = keyCertChain == null ? List.of() : List.copyOf(keyCertChain);
+        trustCerts = trustCerts == null ? List.of() : List.copyOf(trustCerts);
+    }
+
+    /** @return {@code true} when both a private key and a non-empty certificate chain are present */
+    boolean hasKeyMaterial() {
+        return privateKey != null && !keyCertChain.isEmpty();
+    }
+
+    /** @return the certificate chain as an array, or {@code null} when empty (Netty/JSSE "unset") */
+    X509Certificate[] keyCertChainArray() {
+        return keyCertChain.isEmpty() ? null : keyCertChain.toArray(new X509Certificate[0]);
+    }
+
+    /** @return the trust certificates as an array (never {@code null}; empty means platform default) */
+    X509Certificate[] trustCertsArray() {
+        return trustCerts.toArray(new X509Certificate[0]);
+    }
+}

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/tls/impl/TlsMaterialSource.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/tls/impl/TlsMaterialSource.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.tls.impl;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.attribute.FileTime;
+import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.pulsar.common.tls.TlsPolicy;
+import org.apache.pulsar.common.util.tls.PemReader;
+
+/**
+ * Loads, watches and caches ONE material set (the crypto for a single {@code TlsPurpose}) from a
+ * {@link TlsPolicy} for the default {@code FileBasedTlsFactory} (PIP-478).
+ *
+ * <p>This collapses the old branch's {@code FileBasedClient/ServerTlsMaterialSource} split into a
+ * single, role-neutral class: the difference was only the value builder and a few flags, while the
+ * watch/cache machinery was duplicated verbatim.
+ *
+ * <p><b>Keystore-over-PEM per-field precedence.</b> For each of the three material slots (trust
+ * certs, private key, key certificate chain) the keystore location wins when set, otherwise the PEM
+ * location is used. PEM material is loaded via {@link PemReader}; keystores (PKCS12/JKS) are read
+ * with the raw {@link KeyStore} API and an alias walk.
+ *
+ * <p><b>Rotation detection (fixed mtime baseline).</b> Change detection snapshots the modification
+ * times of every configured file, and — unlike the old {@code FileModifiedTimeUpdater}-based scheme,
+ * which advanced the baseline <em>before</em> the load and so never retried a failed rotation until the
+ * next mtime change — commits the new baseline <strong>only after a successful load</strong>. A load
+ * that throws (a half-written or invalid rotated file, the canonical incident) leaves both the baseline
+ * and the last-good material untouched, so the next poll observes the same change again and retries.
+ * When mtimes advanced but the loaded material is byte-for-byte {@link TlsMaterial#equals(Object)
+ * equal} to the cached one (a file touched without content change), the baseline is committed but no
+ * change is signalled.
+ *
+ * <p>Not thread-safe on its own; the owning factory serialises access under its per-source monitor.
+ */
+final class TlsMaterialSource implements MaterialSource {
+
+    /** Sentinel modification time recorded for a path that is currently missing or unreadable. */
+    private static final FileTime MISSING = FileTime.fromMillis(Long.MIN_VALUE);
+
+    private final TlsPolicy policy;
+    private final List<String> watchedPaths;
+
+    private Map<String, FileTime> baseline;
+    private TlsMaterial cached;
+
+    TlsMaterialSource(TlsPolicy policy) {
+        this.policy = Objects.requireNonNull(policy, "policy must not be null");
+        this.watchedPaths = watchedPathsFor(policy);
+    }
+
+    TlsPolicy policy() {
+        return policy;
+    }
+
+    /**
+     * Re-stat the configured files, reloading the material when they changed since the last successful
+     * load. Returns the current (possibly rebuilt) material together with whether it changed in value.
+     *
+     * @return the refresh outcome
+     * @throws Exception if the material could not be loaded (the last-good material and baseline are
+     *                   left untouched so the next call retries)
+     */
+    @Override
+    public MaterialSource.RefreshOutcome refresh() throws Exception {
+        Map<String, FileTime> snapshot = snapshotModificationTimes();
+        if (cached != null && snapshot.equals(baseline)) {
+            return new MaterialSource.RefreshOutcome(cached, false);
+        }
+        TlsMaterial loaded = load();
+        boolean changed = cached == null || !loaded.equals(cached);
+        // Commit the baseline only after a successful load (keep-last-good + retry-on-next-change).
+        baseline = snapshot;
+        if (changed) {
+            cached = loaded;
+        }
+        return new MaterialSource.RefreshOutcome(cached, changed);
+    }
+
+    private TlsMaterial load() throws Exception {
+        PrivateKey privateKey = loadPrivateKey();
+        List<X509Certificate> keyCertChain = loadCertificateChain();
+        List<X509Certificate> trustCerts = loadTrustCerts();
+        return new TlsMaterial(privateKey, keyCertChain, trustCerts);
+    }
+
+    private List<X509Certificate> loadTrustCerts() throws Exception {
+        if (StringUtils.isNotBlank(policy.trustStorePath())) {
+            return TlsKeyStoreLoader.extractTrustCerts(TlsKeyStoreLoader.loadKeyStore(policy.trustStoreType(),
+                    policy.trustStorePath(), policy.trustStorePassword()));
+        }
+        if (StringUtils.isNotBlank(policy.trustCertsFilePath())) {
+            X509Certificate[] certs = PemReader.loadCertificatesFromPemFile(policy.trustCertsFilePath());
+            return certs == null ? List.of() : List.of(certs);
+        }
+        return List.of();
+    }
+
+    private PrivateKey loadPrivateKey() throws Exception {
+        if (StringUtils.isNotBlank(policy.keyStorePath())) {
+            return TlsKeyStoreLoader.extractPrivateKey(TlsKeyStoreLoader.loadKeyStore(policy.keyStoreType(),
+                    policy.keyStorePath(), policy.keyStorePassword()), policy.keyStorePassword());
+        }
+        if (StringUtils.isNotBlank(policy.keyFilePath())) {
+            return PemReader.loadPrivateKeyFromPemFile(policy.keyFilePath());
+        }
+        return null;
+    }
+
+    private List<X509Certificate> loadCertificateChain() throws Exception {
+        if (StringUtils.isNotBlank(policy.keyStorePath())) {
+            return TlsKeyStoreLoader.extractCertificateChain(TlsKeyStoreLoader.loadKeyStore(policy.keyStoreType(),
+                    policy.keyStorePath(), policy.keyStorePassword()));
+        }
+        if (StringUtils.isNotBlank(policy.certificateFilePath())) {
+            X509Certificate[] certs = PemReader.loadCertificatesFromPemFile(policy.certificateFilePath());
+            return certs == null ? List.of() : List.of(certs);
+        }
+        return List.of();
+    }
+
+    private Map<String, FileTime> snapshotModificationTimes() {
+        Map<String, FileTime> snapshot = new LinkedHashMap<>();
+        for (String path : watchedPaths) {
+            FileTime mtime;
+            try {
+                mtime = Files.getLastModifiedTime(Paths.get(path));
+            } catch (Exception e) {
+                mtime = MISSING;
+            }
+            snapshot.put(path, mtime);
+        }
+        return snapshot;
+    }
+
+    private static List<String> watchedPathsFor(TlsPolicy policy) {
+        List<String> paths = new ArrayList<>(5);
+        addIfPresent(paths, policy.trustCertsFilePath());
+        addIfPresent(paths, policy.certificateFilePath());
+        addIfPresent(paths, policy.keyFilePath());
+        addIfPresent(paths, policy.keyStorePath());
+        addIfPresent(paths, policy.trustStorePath());
+        return List.copyOf(paths);
+    }
+
+    private static void addIfPresent(List<String> paths, String path) {
+        if (StringUtils.isNotBlank(path)) {
+            paths.add(path);
+        }
+    }
+}

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/tls/impl/TlsReloadMetrics.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/tls/impl/TlsReloadMetrics.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.tls.impl;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.api.metrics.ObservableLongGauge;
+import java.time.Clock;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.pulsar.common.tls.TlsPurpose;
+
+/**
+ * The OpenTelemetry TLS-reload instruments emitted by the default {@link FileBasedTlsFactory} (PIP-478,
+ * the Metrics section). The factory obtains its {@link OpenTelemetry} handle from
+ * {@code TlsFactoryInitContext.openTelemetry()} and records one attempt per <em>actual</em> material
+ * (re)load — the initial load of a purpose, and each rotation where the on-disk material changed and was
+ * rebuilt. A steady poll that finds no change is not a reload and is not counted, so the counter reflects
+ * real (re)load events and the last-success gauge stops advancing exactly when rotation silently fails or
+ * silently stops happening — the signal the Monitoring section alerts on.
+ *
+ * <ul>
+ *   <li>{@value #RELOAD_COUNTER} — counter {@code {purpose, result=success|failure}}: TLS material
+ *       load/reload attempts per purpose, client and server side;</li>
+ *   <li>{@value #LAST_RELOAD_SUCCESS_GAUGE} — gauge (unix seconds) {@code {purpose}}: time of the last
+ *       successful load/reload, so alerts can catch silently-failing rotation long before a certificate
+ *       expires.</li>
+ * </ul>
+ *
+ * <p>With a {@link OpenTelemetry#noop() no-op} telemetry root (the framework default for components that
+ * do not wire a real one) every instrument is a no-op, so recording is always safe and cheap. The
+ * instance is thread-safe: {@link #recordLoad} runs on the factory's blocking-executor / poll threads
+ * while the gauge callback runs on the OpenTelemetry collection thread.
+ */
+final class TlsReloadMetrics implements AutoCloseable {
+
+    static final String INSTRUMENTATION_SCOPE_NAME = "org.apache.pulsar.tls";
+    static final String RELOAD_COUNTER = "pulsar.tls.reload";
+    static final String LAST_RELOAD_SUCCESS_GAUGE = "pulsar.tls.last_reload_success";
+
+    private static final AttributeKey<String> PURPOSE_KEY = AttributeKey.stringKey("purpose");
+    private static final AttributeKey<String> RESULT_KEY = AttributeKey.stringKey("result");
+    private static final String RESULT_SUCCESS = "success";
+    private static final String RESULT_FAILURE = "failure";
+
+    private final Clock clock;
+    private final LongCounter reloadCounter;
+    private final ObservableLongGauge lastReloadSuccessGauge;
+    // Purpose name -> unix seconds of the last successful load/reload; read by the gauge callback.
+    private final Map<String, Long> lastSuccessEpochSeconds = new ConcurrentHashMap<>();
+
+    private TlsReloadMetrics(OpenTelemetry openTelemetry, Clock clock) {
+        this.clock = clock == null ? Clock.systemUTC() : clock;
+        Meter meter = openTelemetry.getMeter(INSTRUMENTATION_SCOPE_NAME);
+        this.reloadCounter = meter.counterBuilder(RELOAD_COUNTER)
+                .setDescription("TLS material load/reload attempts per purpose, client and server side")
+                .build();
+        this.lastReloadSuccessGauge = meter.gaugeBuilder(LAST_RELOAD_SUCCESS_GAUGE)
+                .setUnit("s")
+                .setDescription("Time (unix seconds) of the last successful TLS material load/reload per purpose")
+                .ofLongs()
+                .buildWithCallback(measurement -> lastSuccessEpochSeconds.forEach(
+                        (purpose, seconds) -> measurement.record(seconds, Attributes.of(PURPOSE_KEY, purpose))));
+    }
+
+    /**
+     * Create the instruments over the given telemetry root. A {@code null} root maps to
+     * {@link OpenTelemetry#noop()}, which yields no-op instruments.
+     */
+    static TlsReloadMetrics create(OpenTelemetry openTelemetry, Clock clock) {
+        return new TlsReloadMetrics(openTelemetry == null ? OpenTelemetry.noop() : openTelemetry, clock);
+    }
+
+    /**
+     * Record a single material load/reload attempt for a purpose. On success, advances the purpose's
+     * last-successful-load timestamp.
+     *
+     * @param purpose the purpose whose material was (re)loaded
+     * @param success whether the load/reload succeeded
+     */
+    void recordLoad(TlsPurpose purpose, boolean success) {
+        String purposeName = Objects.requireNonNull(purpose, "purpose").name();
+        reloadCounter.add(1, Attributes.of(PURPOSE_KEY, purposeName,
+                RESULT_KEY, success ? RESULT_SUCCESS : RESULT_FAILURE));
+        if (success) {
+            lastSuccessEpochSeconds.put(purposeName, clock.instant().getEpochSecond());
+        }
+    }
+
+    @Override
+    public void close() {
+        lastReloadSuccessGauge.close();
+    }
+}

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/tls/impl/TlsSynthesisSpec.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/tls/impl/TlsSynthesisSpec.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.tls.impl;
+
+/**
+ * The per-consumer settings the framework bakes into a Netty {@code io.netty.handler.ssl.SslContext} when it
+ * synthesizes one from a factory's {@code javax.net.ssl.SSLContext} fallback (PIP-478).
+ *
+ * <p>Synthesis happens only when a <em>custom</em> factory returns {@code Optional.empty()} for the Netty
+ * class but supplies the JDK {@code SSLContext}. In that case the framework does not know the factory's
+ * internal {@code TlsPolicy}, so the consumer must supply the two role-specific settings its configuration
+ * dictates:
+ * <ul>
+ *   <li><b>Client purposes</b> — {@code enableHostnameVerification}: whether the produced engines verify the
+ *       peer hostname ({@code endpointIdentificationAlgorithm = "HTTPS"}). Threaded from the consumer's own
+ *       hostname-verification flag ({@code tlsHostnameVerificationEnable} on the client;
+ *       {@code tlsHostnameVerificationEnabled} on the proxy&rarr;broker path).</li>
+ *   <li><b>Server purposes</b> — {@code requireTrustedClientCert}: whether client auth is required
+ *       ({@code ClientAuth.REQUIRE}) or merely requested ({@code ClientAuth.OPTIONAL}). Threaded from
+ *       {@code tlsRequireTrustedClientCertOnConnect}.</li>
+ * </ul>
+ * The acquisition helper selects which field applies from the purpose's {@link
+ * org.apache.pulsar.common.tls.TlsPurpose#role() role}, so a caller passes only the setting relevant to the
+ * purpose it is acquiring via {@link #client(boolean)} or {@link #server(boolean)}.
+ *
+ * @param enableHostnameVerification client-purpose hostname verification (ignored for server purposes)
+ * @param requireTrustedClientCert   server-purpose client-auth requirement (ignored for client purposes)
+ */
+public record TlsSynthesisSpec(boolean enableHostnameVerification, boolean requireTrustedClientCert) {
+
+    /**
+     * A client-purpose synthesis spec.
+     *
+     * @param enableHostnameVerification whether the synthesized client engines verify the peer hostname
+     * @return the spec
+     */
+    public static TlsSynthesisSpec client(boolean enableHostnameVerification) {
+        return new TlsSynthesisSpec(enableHostnameVerification, false);
+    }
+
+    /**
+     * A server-purpose synthesis spec.
+     *
+     * @param requireTrustedClientCert whether the synthesized server context requires a trusted client cert
+     * @return the spec
+     */
+    public static TlsSynthesisSpec server(boolean requireTrustedClientCert) {
+        return new TlsSynthesisSpec(false, requireTrustedClientCert);
+    }
+}

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/tls/impl/package-info.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/tls/impl/package-info.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * The default, file-based implementation of the PIP-478 TLS SPI
+ * ({@link org.apache.pulsar.common.tls.PulsarTlsFactory}).
+ *
+ * <p>This package lives in {@code pulsar-common} rather than the dependency-light SPI module
+ * {@code pulsar-common-api}: it needs {@code netty-handler} and the {@code netty-tcnative} OpenSSL
+ * binding to build native contexts, both already present here. The distinct {@code .impl} package name
+ * keeps the SPI package ({@code org.apache.pulsar.common.tls}) single-owner.
+ *
+ * <ul>
+ *   <li>{@link org.apache.pulsar.common.tls.impl.FileBasedTlsFactory} — the factory: purpose registry,
+ *       single-level fallback resolution, one-shot and subscribing handles, and the rotation
+ *       reload fan-out.</li>
+ *   <li>{@code TlsMaterialSource} / {@code TlsMaterial} — load, watch, cache one material set with a
+ *       fixed mtime baseline and value-equality change suppression.</li>
+ *   <li>{@link org.apache.pulsar.common.tls.impl.TlsContexts} — build the Netty/JDK contexts and
+ *       synthesize a Netty context from a JDK {@code SSLContext}.</li>
+ *   <li>{@link org.apache.pulsar.common.tls.impl.TlsFactoryProbe} — fail-fast boot-time probing.</li>
+ * </ul>
+ */
+package org.apache.pulsar.common.tls.impl;

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/tls/JcaProviders.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/tls/JcaProviders.java
@@ -1,0 +1,230 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.util.tls;
+
+import java.lang.reflect.Method;
+import java.security.NoSuchAlgorithmException;
+import java.security.Provider;
+import java.security.Security;
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import lombok.CustomLog;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.pulsar.common.tls.TlsHostnameVerifier;
+
+/**
+ * Resolves the JCA/JCE security providers Pulsar relies on: the Bouncy Castle provider (FIPS or non-FIPS)
+ * and the optional Conscrypt (OpenSSL) provider. This is the single provider-resolution primitive extracted
+ * from the former {@code SecurityUtility} grab-bag (PIP-478); loading either provider (as a side effect of
+ * class initialization, via {@link #BC_PROVIDER} / {@link #CONSCRYPT_PROVIDER}) calls
+ * {@code Security.addProvider} so the provider is installed process-wide.
+ */
+@CustomLog
+public final class JcaProviders {
+
+    public static final Provider BC_PROVIDER = getProvider();
+    public static final String BC_FIPS_PROVIDER_CLASS = "org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider";
+    public static final String BC_NON_FIPS_PROVIDER_CLASS = "org.bouncycastle.jce.provider.BouncyCastleProvider";
+    public static final String CONSCRYPT_PROVIDER_CLASS = "org.conscrypt.OpenSSLProvider";
+    public static final Provider CONSCRYPT_PROVIDER = loadConscryptProvider();
+
+    // Security.getProvider("BC") / Security.getProvider("BCFIPS").
+    // also used to get Factories. e.g. CertificateFactory.getInstance("X.509", "BCFIPS")
+    public static final String BC_FIPS = "BCFIPS";
+    public static final String BC = "BC";
+
+    private JcaProviders() {
+    }
+
+    public static boolean isBCFIPS() {
+        return BC_PROVIDER.getClass().getCanonicalName().equals(BC_FIPS_PROVIDER_CLASS);
+    }
+
+    /**
+     * Get Bouncy Castle provider, and call Security.addProvider(provider) if success.
+     *  1. try get from classpath.
+     *  2. try get from Nar.
+     */
+    public static Provider getProvider() {
+        boolean isProviderInstalled =
+                Security.getProvider(BC) != null || Security.getProvider(BC_FIPS) != null;
+
+        if (isProviderInstalled) {
+            Provider provider = Security.getProvider(BC) != null
+                    ? Security.getProvider(BC)
+                    : Security.getProvider(BC_FIPS);
+            log.debug().attr("provider", provider.getName()).log("Already instantiated Bouncy Castle provider");
+            return provider;
+        }
+
+        // Not installed, try load from class path
+        try {
+            return getBCProviderFromClassPath();
+        } catch (Exception e) {
+            log.warn().exception(e)
+                    .log("Not able to get Bouncy Castle provider for both FIPS and Non-FIPS from class path");
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static Provider loadConscryptProvider() {
+        Class<?> conscryptClazz;
+
+        try {
+            conscryptClazz = Class.forName("org.conscrypt.Conscrypt");
+            conscryptClazz.getMethod("checkAvailability").invoke(null);
+        } catch (Throwable e) {
+            if (e instanceof ClassNotFoundException) {
+                log.debug("Conscrypt isn't available in the classpath. Using JDK default security provider.");
+            } else if (e.getCause() instanceof UnsatisfiedLinkError) {
+                log.debug().attr("os", System.getProperty("os.name")).attr("arch", System.getProperty("os.arch"))
+                        .log("Conscrypt isn't available. Using JDK default security provider");
+            } else {
+                log.debug().attr("cause", e.getCause()).attr("reason", e.getMessage())
+                        .log("Conscrypt isn't available. Using JDK default security provider");
+            }
+            return null;
+        }
+
+        Provider provider;
+        try {
+            provider = (Provider) Class.forName(CONSCRYPT_PROVIDER_CLASS).getDeclaredConstructor().newInstance();
+        } catch (ReflectiveOperationException e) {
+            log.debug().attr("class", CONSCRYPT_PROVIDER_CLASS).exception(e)
+                    .log("Unable to get security provider");
+            return null;
+        }
+
+        // Configure Conscrypt's default hostname verifier to use Pulsar's TlsHostnameVerifier which
+        // is more relaxed than the Conscrypt HostnameVerifier checking for RFC 2818 conformity.
+        //
+        // Certificates used in Pulsar docs and examples aren't strictly RFC 2818 compliant since they use the
+        // deprecated way of specifying the hostname in the CN field of the subject DN of the certificate.
+        // RFC 2818 recommends the use of SAN (subjectAltName) extension for specifying the hostname in the dNSName
+        // field of the subjectAltName extension.
+        //
+        // Conscrypt's default HostnameVerifier has dropped support for the deprecated method of specifying the hostname
+        // in the CN field. Pulsar's TlsHostnameVerifier continues to support the CN field.
+        //
+        // more details of Conscrypt's hostname verification:
+        // https://github.com/google/conscrypt/blob/master/IMPLEMENTATION_NOTES.md#hostname-verification
+        // there's a bug in Conscrypt while setting a custom HostnameVerifier,
+        // https://github.com/google/conscrypt/issues/1015 and therefore this solution alone
+        // isn't sufficient to configure Conscrypt's hostname verifier. The method processConscryptTrustManager
+        // contains the workaround.
+        try {
+            HostnameVerifier hostnameVerifier = new TlsHostnameVerifier();
+            Object wrappedHostnameVerifier = conscryptClazz
+                    .getMethod("wrapHostnameVerifier",
+                            new Class<?>[]{HostnameVerifier.class}).invoke(null, hostnameVerifier);
+            Method setDefaultHostnameVerifierMethod =
+                    conscryptClazz
+                            .getMethod("setDefaultHostnameVerifier",
+                                    new Class<?>[]{Class.forName("org.conscrypt.ConscryptHostnameVerifier")});
+            setDefaultHostnameVerifierMethod.invoke(null, wrappedHostnameVerifier);
+        } catch (Exception e) {
+            log.warn().exception(e).log("Unable to set default hostname verifier for Conscrypt");
+        }
+
+        Security.addProvider(provider);
+        log.debug().attr("provider", provider.getName()).attr("class", CONSCRYPT_PROVIDER_CLASS)
+                .log("Added security provider");
+        return provider;
+    }
+
+    /**
+     * Get Bouncy Castle provider from classpath, and call Security.addProvider.
+     * Throw Exception if failed.
+     */
+    private static Provider getBCProviderFromClassPath() throws Exception {
+        Class<?> clazz;
+        try {
+            // prefer non FIPS, for backward compatibility concern.
+            clazz = Class.forName(BC_NON_FIPS_PROVIDER_CLASS);
+        } catch (ClassNotFoundException cnf) {
+            log.warn().attr("nonFipsClass", BC_NON_FIPS_PROVIDER_CLASS).attr("fipsClass", BC_FIPS_PROVIDER_CLASS)
+                    .log("Not able to get Bouncy Castle provider, try to get FIPS provider");
+            // attempt to use the FIPS provider.
+            clazz = Class.forName(BC_FIPS_PROVIDER_CLASS);
+        }
+
+        Provider provider = (Provider) clazz.getDeclaredConstructor().newInstance();
+        Security.addProvider(provider);
+        log.debug().attr("provider", provider.getName())
+                .log("Found and Instantiated Bouncy Castle provider in classpath");
+        return provider;
+    }
+
+    /**
+     * Resolve a security {@link Provider} by name, falling back to the default {@code TLS}
+     * {@code SSLContext} provider when the name is blank or unknown.
+     */
+    static Provider resolveProvider(String providerName) throws NoSuchAlgorithmException {
+        Provider provider = null;
+        if (!StringUtils.isEmpty(providerName)) {
+            provider = Security.getProvider(providerName);
+        }
+
+        if (provider == null) {
+            provider = SSLContext.getDefault().getProvider();
+        }
+
+        return provider;
+    }
+
+    /**
+     * Conscrypt {@link TrustManager} instances are configured to use Pulsar's
+     * {@link TlsHostnameVerifier}. This is a workaround for https://github.com/google/conscrypt/issues/1015
+     * when Conscrypt / OpenSSL is used as the TLS security provider.
+     *
+     * @param trustManagers the array of TrustManager instances to process.
+     * @return same instance passed as parameter
+     */
+    static TrustManager[] processConscryptTrustManagers(TrustManager[] trustManagers) {
+        for (TrustManager trustManager : trustManagers) {
+            processConscryptTrustManager(trustManager);
+        }
+        return trustManagers;
+    }
+
+    // workaround https://github.com/google/conscrypt/issues/1015
+    private static void processConscryptTrustManager(TrustManager trustManager) {
+        if (trustManager.getClass().getName().equals("org.conscrypt.TrustManagerImpl")) {
+            try {
+                Class<?> conscryptClazz = Class.forName("org.conscrypt.Conscrypt");
+                Object hostnameVerifier = conscryptClazz.getMethod("getHostnameVerifier",
+                        new Class<?>[]{TrustManager.class}).invoke(null, trustManager);
+                if (hostnameVerifier == null) {
+                    Object defaultHostnameVerifier = conscryptClazz.getMethod("getDefaultHostnameVerifier",
+                            new Class<?>[]{TrustManager.class}).invoke(null, trustManager);
+                    if (defaultHostnameVerifier != null) {
+                        conscryptClazz.getMethod("setHostnameVerifier", new Class<?>[]{
+                                TrustManager.class,
+                                Class.forName("org.conscrypt.ConscryptHostnameVerifier")
+                        }).invoke(null, trustManager, defaultHostnameVerifier);
+                    }
+                }
+            } catch (ReflectiveOperationException e) {
+                log.warn().exception(e)
+                        .log("Unable to set hostname verifier for Conscrypt TrustManager implementation");
+            }
+        }
+    }
+}

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/tls/JdkSslContexts.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/tls/JdkSslContexts.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.util.tls;
+
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import java.security.GeneralSecurityException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.Provider;
+import java.security.SecureRandom;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import org.apache.pulsar.common.util.KeyStoreHolder;
+
+/**
+ * Assembles JDK {@link SSLContext} instances from loaded certificate/key material, resolving the security
+ * provider through {@link JcaProviders} and parsing PEM inputs through {@link PemReader}. This is the JDK
+ * {@code SSLContext} assembly primitive extracted from the former {@code SecurityUtility} grab-bag (PIP-478);
+ * the default file-based TLS factory ({@code TlsContexts}) builds its JDK fallback context here, and TLS
+ * tests reuse it to construct JDK contexts from PEM material.
+ */
+public final class JdkSslContexts {
+
+    private JdkSslContexts() {
+    }
+
+    public static SSLContext createSslContext(boolean allowInsecureConnection, Certificate[] trustCertificates,
+                                              String providerName)
+            throws GeneralSecurityException {
+        return createSslContext(allowInsecureConnection, trustCertificates, null, null, providerName);
+    }
+
+    public static SSLContext createSslContext(boolean allowInsecureConnection, String trustCertsFilePath,
+            String certFilePath, String keyFilePath, String providerName) throws GeneralSecurityException {
+        X509Certificate[] trustCertificates = PemReader.loadCertificatesFromPemFile(trustCertsFilePath);
+        X509Certificate[] certificates = PemReader.loadCertificatesFromPemFile(certFilePath);
+        PrivateKey privateKey = PemReader.loadPrivateKeyFromPemFile(keyFilePath);
+        return createSslContext(allowInsecureConnection, trustCertificates, certificates, privateKey, providerName);
+    }
+
+    public static SSLContext createSslContext(boolean allowInsecureConnection, Certificate[] trustCertficates,
+                                              Certificate[] certificates, PrivateKey privateKey)
+            throws GeneralSecurityException {
+        return createSslContext(allowInsecureConnection, trustCertficates, certificates, privateKey, null);
+    }
+
+    public static SSLContext createSslContext(boolean allowInsecureConnection, Certificate[] trustCertficates,
+                                              Certificate[] certificates, PrivateKey privateKey, String providerName)
+            throws GeneralSecurityException {
+        KeyStoreHolder ksh = new KeyStoreHolder();
+        Provider provider = JcaProviders.resolveProvider(providerName);
+
+        TrustManager[] trustManagers = setupTrustCerts(ksh, allowInsecureConnection, trustCertficates, provider);
+        KeyManager[] keyManagers = setupKeyManager(ksh, privateKey, certificates);
+
+        SSLContext sslCtx = provider != null ? SSLContext.getInstance("TLS", provider)
+                : SSLContext.getInstance("TLS");
+        sslCtx.init(keyManagers, trustManagers, new SecureRandom());
+        return sslCtx;
+    }
+
+    private static KeyManager[] setupKeyManager(KeyStoreHolder ksh, PrivateKey privateKey, Certificate[] certificates)
+            throws KeyStoreException, NoSuchAlgorithmException, UnrecoverableKeyException {
+        KeyManager[] keyManagers = null;
+        if (certificates != null && privateKey != null) {
+            ksh.setPrivateKey("private", privateKey, certificates);
+            KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+            kmf.init(ksh.getKeyStore(), "".toCharArray());
+            keyManagers = kmf.getKeyManagers();
+        }
+        return keyManagers;
+    }
+
+    private static TrustManager[] setupTrustCerts(KeyStoreHolder ksh, boolean allowInsecureConnection,
+                                                  Certificate[] trustCertficates, Provider securityProvider)
+            throws NoSuchAlgorithmException, KeyStoreException {
+        TrustManager[] trustManagers;
+        if (allowInsecureConnection) {
+            trustManagers = InsecureTrustManagerFactory.INSTANCE.getTrustManagers();
+        } else {
+            TrustManagerFactory tmf = securityProvider != null
+                    ? TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm(), securityProvider)
+                    : TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+
+            if (trustCertficates == null || trustCertficates.length == 0) {
+                tmf.init((KeyStore) null);
+            } else {
+                for (int i = 0; i < trustCertficates.length; i++) {
+                    ksh.setCertificate("trust" + i, trustCertficates[i]);
+                }
+                tmf.init(ksh.getKeyStore());
+            }
+
+            trustManagers = JcaProviders.processConscryptTrustManagers(tmf.getTrustManagers());
+        }
+        return trustManagers;
+    }
+}

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/tls/PemReader.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/tls/PemReader.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.util.tls;
+
+import java.io.BufferedReader;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.security.KeyFactory;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.KeySpec;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.List;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Parses PEM-encoded X.509 certificates and PKCS#8 private keys from files and streams. This is the single
+ * shared PEM-parsing primitive extracted from the former {@code SecurityUtility} grab-bag (PIP-478): it holds
+ * no TLS-context assembly or security-provider concerns, only the file/stream-to-material parsing that several
+ * callers (the file-based TLS material sources and {@code AuthenticationDataTls}) reuse.
+ */
+public final class PemReader {
+
+    private static final List<String> KEY_FACTORY_ALGORITHMS = List.of("RSA", "EC");
+
+    private PemReader() {
+    }
+
+    public static X509Certificate[] loadCertificatesFromPemFile(String certFilePath) throws KeyManagementException {
+        X509Certificate[] certificates = null;
+
+        if (certFilePath == null || certFilePath.isEmpty()) {
+            return certificates;
+        }
+
+        try (FileInputStream input = new FileInputStream(certFilePath)) {
+            certificates = loadCertificatesFromPemStream(input);
+        } catch (GeneralSecurityException | IOException e) {
+            throw new KeyManagementException("Certificate loading error", e);
+        }
+
+        return certificates;
+    }
+
+    public static X509Certificate[] loadCertificatesFromPemStream(InputStream inStream) throws KeyManagementException  {
+        if (inStream == null) {
+            return null;
+        }
+        CertificateFactory cf;
+        try {
+            if (inStream.markSupported()) {
+                inStream.reset();
+            }
+            cf = CertificateFactory.getInstance("X.509");
+            @SuppressWarnings("unchecked") // CertificateFactory.getInstance("X.509") returns X509Certificate instances
+            Collection<X509Certificate> collection = (Collection<X509Certificate>) cf.generateCertificates(inStream);
+            return collection.toArray(new X509Certificate[collection.size()]);
+        } catch (CertificateException | IOException e) {
+            throw new KeyManagementException("Certificate loading error", e);
+        }
+    }
+
+    public static PrivateKey loadPrivateKeyFromPemFile(String keyFilePath) throws KeyManagementException {
+        if (keyFilePath == null || keyFilePath.isEmpty()) {
+            return null;
+        }
+
+        PrivateKey privateKey;
+
+        try (FileInputStream input = new FileInputStream(keyFilePath)) {
+            privateKey = loadPrivateKeyFromPemStream(input);
+        } catch (IOException e) {
+            throw new KeyManagementException("Private key loading error", e);
+        }
+
+        return privateKey;
+    }
+
+    public static PrivateKey loadPrivateKeyFromPemStream(InputStream inStream) throws KeyManagementException {
+        if (inStream == null) {
+            return null;
+        }
+
+        PrivateKey privateKey;
+
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(inStream, StandardCharsets.UTF_8))) {
+            if (inStream.markSupported()) {
+                inStream.reset();
+            }
+            StringBuilder sb = new StringBuilder();
+            String currentLine = null;
+
+            // Jump to the first line after -----BEGIN [RSA] PRIVATE KEY-----
+            while ((currentLine = reader.readLine()) != null && !currentLine.startsWith("-----BEGIN")) {
+                reader.readLine();
+            }
+
+            // Stop (and skip) at the last line that has, say, -----END [RSA] PRIVATE KEY-----
+            while ((currentLine = reader.readLine()) != null && !currentLine.startsWith("-----END")) {
+                sb.append(currentLine);
+            }
+            final KeySpec keySpec = new PKCS8EncodedKeySpec(Base64.getDecoder().decode(sb.toString()));
+            final List<String> failedAlgorithm = new ArrayList<>(KEY_FACTORY_ALGORITHMS.size());
+            for (String algorithm : KEY_FACTORY_ALGORITHMS) {
+                try {
+                    return KeyFactory.getInstance(algorithm).generatePrivate(keySpec);
+                } catch (InvalidKeySpecException | NoSuchAlgorithmException ex) {
+                    failedAlgorithm.add(algorithm);
+                }
+            }
+            throw new KeyManagementException("The private key algorithm is not supported. attempted: "
+                    + StringUtils.join(failedAlgorithm, ","));
+        } catch (IOException e) {
+            throw new KeyManagementException("Private key loading error", e);
+        }
+
+    }
+}

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/tls/package-info.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/tls/package-info.java
@@ -16,31 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pulsar.bcloader;
-
-import static org.apache.pulsar.common.util.tls.JcaProviders.BC;
-import java.security.Provider;
-import java.security.Security;
-import lombok.CustomLog;
-import org.apache.pulsar.common.util.BCLoader;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
 /**
- * This is a Bouncy Castle provider Loader.
+ * Cohesive, single-concern TLS utility containers (PIP-478). Each class holds one concern rather than the
+ * former {@code SecurityUtility} grab-bag: {@link org.apache.pulsar.common.util.tls.PemReader} parses PEM
+ * certificates and keys, {@link org.apache.pulsar.common.util.tls.JcaProviders} resolves JCA/JCE security
+ * providers, and {@link org.apache.pulsar.common.util.tls.JdkSslContexts} assembles JDK
+ * {@code javax.net.ssl.SSLContext} instances from loaded material.
  */
-@CustomLog
-public class BouncyCastleLoader implements BCLoader {
-    public static Provider provider;
-    static {
-        if (Security.getProvider(BC) == null) {
-            Security.addProvider(new BouncyCastleProvider());
-        }
-        provider = Security.getProvider(BC);
-        log.info().attr("provider", provider).log("BouncyCastle Provider BC loaded");
-    }
-
-    @Override
-    public Provider getProvider() {
-        return Security.getProvider(BC);
-    }
-}
+package org.apache.pulsar.common.util.tls;

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/tls/TlsPolicyValidationTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/tls/TlsPolicyValidationTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.tls;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import org.testng.annotations.Test;
+
+/**
+ * PIP-478 A-L1: {@link TlsPolicy.Builder#build()} fails loud when a configured field is inconsistent with the
+ * chosen {@link TlsPolicy.Format}, rather than silently ignoring it.
+ */
+public class TlsPolicyValidationTest {
+
+    @Test
+    public void pemPolicyRejectsKeystoreFields() {
+        assertThatThrownBy(() -> TlsPolicy.builder()
+                .format(TlsPolicy.Format.PEM)
+                .trustCertsFilePath("/ca.pem")
+                .keyStorePath("/key.p12")
+                .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("keyStorePath");
+
+        assertThatThrownBy(() -> TlsPolicy.builder()
+                .format(TlsPolicy.Format.PEM)
+                .keyStoreType("PKCS12")
+                .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("keyStoreType");
+    }
+
+    @Test
+    public void keystorePolicyRejectsPemFields() {
+        assertThatThrownBy(() -> TlsPolicy.builder()
+                .format(TlsPolicy.Format.KEYSTORE)
+                .keyStorePath("/key.p12")
+                .certificateFilePath("/cert.pem")
+                .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("certificateFilePath");
+    }
+
+    @Test
+    public void consistentPoliciesBuild() {
+        assertThatCode(() -> TlsPolicy.pem("/ca.pem", "/cert.pem", "/key.pem"))
+                .doesNotThrowAnyException();
+        assertThatCode(() -> TlsPolicy.keyStore("/trust.jks", "pw", "/key.jks", "pw", "JKS"))
+                .doesNotThrowAnyException();
+        // Mixed store TYPES are consistent with KEYSTORE format (only cross-format fields are rejected).
+        assertThatCode(() -> TlsPolicy.builder().format(TlsPolicy.Format.KEYSTORE)
+                .keyStorePath("/key.p12").keyStoreType("PKCS12")
+                .trustStorePath("/trust.jks").trustStoreType("JKS")
+                .build()).doesNotThrowAnyException();
+        // Flag-only policies (system default / insecure) build cleanly.
+        assertThat(TlsPolicy.builder().build().format()).isEqualTo(TlsPolicy.Format.PEM);
+        assertThat(TlsPolicy.insecure().allowInsecureConnection()).isTrue();
+    }
+}

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/tls/TlsPurposeTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/tls/TlsPurposeTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.tls;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import java.util.HashMap;
+import java.util.Map;
+import org.testng.annotations.Test;
+
+/**
+ * Locks the freeze-forever {@link TlsPurpose} identity contract (PIP-478 A-M2): equality is over
+ * {@code (role, name)} only, with the fallback treated as resolution metadata, so a purpose resolves to
+ * the same purpose→policy map slot regardless of the fallback the caller minted it with. Also covers the
+ * A-M4 {@code server(name, fallback)} overload.
+ */
+public class TlsPurposeTest {
+
+    @Test
+    public void equalsAndHashCodeIgnoreFallback() {
+        TlsPurpose noFallback = TlsPurpose.client("x");
+        TlsPurpose withFallback = TlsPurpose.client("x", TlsPurpose.CLIENT_DEFAULT);
+        TlsPurpose withOtherFallback = TlsPurpose.client("x", TlsPurpose.CLIENT_OAUTH2);
+
+        assertThat(withFallback).isEqualTo(noFallback).isEqualTo(withOtherFallback);
+        assertThat(withFallback.hashCode()).isEqualTo(noFallback.hashCode());
+    }
+
+    @Test
+    public void purposeToPolicyMapResolvesSameSlotRegardlessOfFallback() {
+        // The exact defect A-M2 guards against: minting with a fallback must NOT split one config entry
+        // into two distinct map keys and cause silent lookup misses.
+        Map<TlsPurpose, String> map = new HashMap<>();
+        map.put(TlsPurpose.client("x"), "policy");
+
+        assertThat(map).containsKey(TlsPurpose.client("x", TlsPurpose.CLIENT_DEFAULT));
+        assertThat(map.get(TlsPurpose.client("x", TlsPurpose.CLIENT_OAUTH2))).isEqualTo("policy");
+    }
+
+    @Test
+    public void roleAndNameStillDistinguish() {
+        assertThat(TlsPurpose.client("x")).isNotEqualTo(TlsPurpose.server("x"));
+        assertThat(TlsPurpose.client("x")).isNotEqualTo(TlsPurpose.client("y"));
+    }
+
+    @Test
+    public void serverWithFallbackKeepsFallbackAsMetadataNotIdentity() {
+        TlsPurpose internal = TlsPurpose.server("broker.internal", TlsPurpose.BROKER);
+        assertThat(internal.role()).isEqualTo(TlsPurpose.Role.SERVER);
+        assertThat(internal.name()).isEqualTo("broker.internal");
+        assertThat(internal.fallback()).contains(TlsPurpose.BROKER);
+        // Same identity as the fallback-less server purpose of the same name.
+        assertThat(internal).isEqualTo(TlsPurpose.server("broker.internal"));
+    }
+}

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/tls/impl/AuthProvidedMaterialFoldTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/tls/impl/AuthProvidedMaterialFoldTest.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.tls.impl;
+
+import static org.apache.pulsar.common.tls.impl.TlsTestSupport.resource;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import java.security.cert.X509Certificate;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.pulsar.client.api.AuthenticationDataProvider;
+import org.apache.pulsar.common.tls.TlsPolicy;
+import org.apache.pulsar.common.util.tls.PemReader;
+import org.testng.annotations.Test;
+
+/**
+ * Verifies the PIP-478 server-side {@code BROKER_CLIENT} authentication-material fold at the material level:
+ * when a broker-client {@code Authentication} plugin supplies TLS material, its in-memory cert/key override
+ * the {@code brokerClient*} file policy (auth-cert-wins) — the flip-CI blocker — while the base file trust is
+ * retained, and rotation of the auth material is detected independently of the files. The end-to-end TLS
+ * handshake proof lives in {@code AuthedAdminProxyHandlerNewTlsPathTest} with real client certificates.
+ */
+public class AuthProvidedMaterialFoldTest {
+
+    private static final String RSA_CA = resource("certificate-authority/certs/ca.cert.pem");
+    private static final String BROKER_CERT = resource("certificate-authority/server-keys/broker.cert.pem");
+    private static final String BROKER_KEY = resource("certificate-authority/server-keys/broker.key-pk8.pem");
+    private static final String PROXY_CERT = resource("certificate-authority/server-keys/proxy.cert.pem");
+    private static final String PROXY_KEY = resource("certificate-authority/server-keys/proxy.key-pk8.pem");
+
+    private static AuthProvidedMaterialSource overlay(TlsPolicy basePolicy,
+            AtomicReference<AuthenticationDataProvider> authData) {
+        return new AuthProvidedMaterialSource(new TlsMaterialSource(basePolicy), authData::get);
+    }
+
+    private static AuthenticationDataProvider tlsAuthData(String certFile, String keyFile) throws Exception {
+        AuthenticationDataProvider authData = mock(AuthenticationDataProvider.class);
+        when(authData.hasDataForTls()).thenReturn(true);
+        when(authData.getTlsCertificates()).thenReturn(PemReader.loadCertificatesFromPemFile(certFile));
+        when(authData.getTlsPrivateKey()).thenReturn(PemReader.loadPrivateKeyFromPemFile(keyFile));
+        return authData;
+    }
+
+    private static List<X509Certificate> certs(String certFile) throws Exception {
+        return List.of(PemReader.loadCertificatesFromPemFile(certFile));
+    }
+
+    @Test
+    public void authCertOverridesTheFilePolicyKeyMaterial() throws Exception {
+        // Base file policy points at the BROKER cert/key; the auth plugin supplies the PROXY cert/key.
+        AuthProvidedMaterialSource overlay = overlay(TlsPolicy.pem(RSA_CA, BROKER_CERT, BROKER_KEY),
+                new AtomicReference<>(tlsAuthData(PROXY_CERT, PROXY_KEY)));
+
+        TlsMaterial material = overlay.refresh().material();
+        assertThat(material.hasKeyMaterial()).isTrue();
+        assertThat(material.keyCertChain()).as("auth cert wins over the file-policy cert")
+                .isEqualTo(certs(PROXY_CERT));
+        assertThat(material.privateKey()).isEqualTo(PemReader.loadPrivateKeyFromPemFile(PROXY_KEY));
+        assertThat(material.trustCerts()).as("base file trust (CA) is retained").isNotEmpty();
+    }
+
+    @Test
+    public void blankFilePolicyUsesAuthKeyMaterial() throws Exception {
+        // The flip-CI case: no brokerClient*FilePath cert/key, only the auth plugin supplies the identity.
+        AuthProvidedMaterialSource overlay = overlay(TlsPolicy.builder().trustCertsFilePath(RSA_CA).build(),
+                new AtomicReference<>(tlsAuthData(PROXY_CERT, PROXY_KEY)));
+
+        TlsMaterial material = overlay.refresh().material();
+        assertThat(material.hasKeyMaterial()).as("without the fold there would be no client cert → 401").isTrue();
+        assertThat(material.keyCertChain()).isEqualTo(certs(PROXY_CERT));
+    }
+
+    @Test
+    public void noAuthTlsMaterialFallsBackToTheFilePolicy() throws Exception {
+        AuthenticationDataProvider noTls = mock(AuthenticationDataProvider.class);
+        when(noTls.hasDataForTls()).thenReturn(false);
+        AuthProvidedMaterialSource overlay = overlay(TlsPolicy.pem(RSA_CA, BROKER_CERT, BROKER_KEY),
+                new AtomicReference<>(noTls));
+
+        TlsMaterial material = overlay.refresh().material();
+        assertThat(material.keyCertChain()).as("no auth TLS material → keep the file-policy cert")
+                .isEqualTo(certs(BROKER_CERT));
+    }
+
+    @Test
+    public void refreshDetectsAuthMaterialRotationIndependentlyOfFiles() throws Exception {
+        // The base policy has no watched cert/key files, so any change must come from the auth material.
+        AtomicReference<AuthenticationDataProvider> current =
+                new AtomicReference<>(tlsAuthData(PROXY_CERT, PROXY_KEY));
+        AuthProvidedMaterialSource overlay = overlay(TlsPolicy.builder().trustCertsFilePath(RSA_CA).build(), current);
+
+        assertThat(overlay.refresh().changed()).as("first load counts as a change").isTrue();
+        assertThat(overlay.refresh().changed()).as("same auth material → no change").isFalse();
+
+        current.set(tlsAuthData(BROKER_CERT, BROKER_KEY));
+        assertThat(overlay.refresh().changed()).as("rotated auth cert is detected").isTrue();
+    }
+}

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/tls/impl/FileBasedTlsFactoryTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/tls/impl/FileBasedTlsFactoryTest.java
@@ -1,0 +1,817 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.tls.impl;
+
+import static org.apache.pulsar.common.tls.impl.TlsTestSupport.handshake;
+import static org.apache.pulsar.common.tls.impl.TlsTestSupport.initContext;
+import static org.apache.pulsar.common.tls.impl.TlsTestSupport.resource;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.handler.ssl.OpenSsl;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.SslProvider;
+import io.netty.util.ReferenceCountUtil;
+import io.netty.util.ReferenceCounted;
+import java.net.Socket;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.FileTime;
+import java.security.KeyStore;
+import java.security.Principal;
+import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509ExtendedKeyManager;
+import org.apache.commons.io.FileUtils;
+import org.apache.pulsar.common.tls.TlsHandle;
+import org.apache.pulsar.common.tls.TlsPolicy;
+import org.apache.pulsar.common.tls.TlsPurpose;
+import org.apache.pulsar.common.util.tls.PemReader;
+import org.awaitility.Awaitility;
+import org.testng.SkipException;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class FileBasedTlsFactoryTest {
+
+    private static final String RSA_CA = resource("certificate-authority/certs/ca.cert.pem");
+    private static final String BROKER_CERT = resource("certificate-authority/server-keys/broker.cert.pem");
+    private static final String BROKER_KEY = resource("certificate-authority/server-keys/broker.key-pk8.pem");
+    private static final String PROXY_CERT = resource("certificate-authority/server-keys/proxy.cert.pem");
+    private static final String PROXY_KEY = resource("certificate-authority/server-keys/proxy.key-pk8.pem");
+    // EC identity is signed by the EC CA — untrusted by the RSA CA the server above trusts.
+    private static final String EC_CLIENT_CERT = resource("certificate-authority/ec/client.cert.pem");
+    private static final String EC_CLIENT_KEY = resource("certificate-authority/ec/client.key-pk8.pem");
+
+    private static final String KEYSTORE = resource("certificate-authority/jks/broker.keystore.jks");
+    private static final String TRUSTSTORE = resource("certificate-authority/jks/broker.truststore.jks");
+    private static final String STORE_PW = "111111";
+
+    private ScheduledExecutorService scheduler;
+    private final Executor directExecutor = Runnable::run;
+    private Path tempDir;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        scheduler = Executors.newSingleThreadScheduledExecutor();
+        tempDir = Files.createTempDirectory("pip478-tls-");
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void tearDown() throws Exception {
+        scheduler.shutdownNow();
+        if (tempDir != null) {
+            FileUtils.deleteDirectory(tempDir.toFile());
+        }
+    }
+
+    private FileBasedTlsFactory factory(Map<TlsPurpose, TlsPolicy> policies, FileBasedTlsFactorySettings settings) {
+        FileBasedTlsFactory factory = new FileBasedTlsFactory(policies, settings);
+        factory.initialize(initContext(scheduler, directExecutor)).join();
+        return factory;
+    }
+
+    @Test
+    public void buildsNettyAndJdkContextsFromPem() throws Exception {
+        FileBasedTlsFactory factory = factory(
+                Map.of(TlsPurpose.BROKER, TlsPolicy.pem(RSA_CA, BROKER_CERT, BROKER_KEY)),
+                FileBasedTlsFactorySettings.defaults());
+
+        Optional<TlsHandle<SslContext>> netty = factory.createInstance(TlsPurpose.BROKER, SslContext.class).join();
+        Optional<TlsHandle<SSLContext>> jdk = factory.createInstance(TlsPurpose.BROKER, SSLContext.class).join();
+
+        assertThat(netty).isPresent();
+        assertThat(netty.get().get()).isNotNull();
+        assertThat(jdk).isPresent();
+        assertThat(jdk.get().get()).isNotNull();
+        netty.get().dispose();
+        jdk.get().dispose();
+        factory.close();
+    }
+
+    @Test
+    public void buildsContextsFromKeystore() throws Exception {
+        FileBasedTlsFactory factory = factory(
+                Map.of(TlsPurpose.BROKER, TlsPolicy.keyStore(TRUSTSTORE, STORE_PW, KEYSTORE, STORE_PW, "JKS")),
+                FileBasedTlsFactorySettings.defaults());
+
+        Optional<TlsHandle<SslContext>> netty = factory.createInstance(TlsPurpose.BROKER, SslContext.class).join();
+        assertThat(netty).isPresent();
+        assertThat(netty.get().get()).isNotNull();
+        factory.close();
+    }
+
+    @Test
+    public void resolutionFollowsSingleLevelFallbackChain() throws Exception {
+        FileBasedTlsFactory factory = factory(
+                Map.of(TlsPurpose.CLIENT_DEFAULT, TlsPolicy.pem(RSA_CA, null, null)),
+                FileBasedTlsFactorySettings.defaults());
+
+        TlsPurpose minted = TlsPurpose.client("oauth2.myPlugin", TlsPurpose.CLIENT_DEFAULT);
+        Optional<TlsHandle<SslContext>> resolved = factory.createInstance(minted, SslContext.class).join();
+        assertThat(resolved).as("minted purpose resolves via fallback to CLIENT_DEFAULT").isPresent();
+        factory.close();
+    }
+
+    @Test
+    public void oauth2ResolvesToSystemDefaultNotEmptyNotError() throws Exception {
+        FileBasedTlsFactory factory = factory(
+                Map.of(TlsPurpose.CLIENT_DEFAULT, TlsPolicy.pem(RSA_CA, null, null)),
+                FileBasedTlsFactorySettings.defaults());
+
+        Optional<TlsHandle<SslContext>> handle =
+                factory.createInstance(TlsPurpose.CLIENT_OAUTH2, SslContext.class).join();
+        assertThat(handle).as("CLIENT_OAUTH2 empty fallback resolves to the system default").isPresent();
+
+        // The system default verifies hostnames (secure defaults) — proven by the baked HTTPS algorithm.
+        SSLEngine engine = ((SslContext) handle.get().get()).newEngine(ByteBufAllocator.DEFAULT);
+        assertThat(engine.getSSLParameters().getEndpointIdentificationAlgorithm()).isEqualTo("HTTPS");
+        factory.close();
+    }
+
+    @Test
+    public void unconfiguredServerPurposeFailsExceptionally() {
+        FileBasedTlsFactory factory = factory(
+                Map.of(TlsPurpose.BROKER, TlsPolicy.pem(RSA_CA, BROKER_CERT, BROKER_KEY)),
+                FileBasedTlsFactorySettings.defaults());
+
+        // PROXY (server role, no fallback) is not configured: this is an error, not empty().
+        assertThatThrownBy(() -> factory.createInstance(TlsPurpose.PROXY, SslContext.class).join())
+                .hasCauseInstanceOf(FileBasedTlsFactory.TlsMaterialUnavailableException.class);
+        factory.close();
+    }
+
+    @Test
+    public void unsupportedClassReturnsEmpty() {
+        FileBasedTlsFactory factory = factory(
+                Map.of(TlsPurpose.BROKER, TlsPolicy.pem(RSA_CA, BROKER_CERT, BROKER_KEY)),
+                FileBasedTlsFactorySettings.defaults());
+
+        // A class the factory cannot build natively (stands in for Jetty's SslContextFactory.Server,
+        // which pulsar-common cannot reference) yields empty(), which the framework synthesizes.
+        Optional<TlsHandle<String>> handle = factory.createInstance(TlsPurpose.BROKER, String.class).join();
+        assertThat(handle).isEmpty();
+        factory.close();
+    }
+
+    @Test
+    public void resolvedButUnbuildableFailsExceptionallyNeverEmpty() {
+        FileBasedTlsFactory factory = factory(
+                Map.of(TlsPurpose.BROKER, TlsPolicy.pem(RSA_CA,
+                        tempDir.resolve("missing-cert.pem").toString(),
+                        tempDir.resolve("missing-key.pem").toString())),
+                FileBasedTlsFactorySettings.defaults());
+
+        assertThatThrownBy(() -> factory.createInstance(TlsPurpose.BROKER, SslContext.class).join())
+                .isInstanceOf(Exception.class);
+        factory.close();
+    }
+
+    @Test
+    public void clientHostnameVerificationIsBakedIntoTheContext() throws Exception {
+        FileBasedTlsFactory verifying = factory(
+                Map.of(TlsPurpose.CLIENT_DEFAULT, TlsPolicy.builder()
+                        .trustCertsFilePath(RSA_CA).enableHostnameVerification(true).build()),
+                FileBasedTlsFactorySettings.defaults());
+        FileBasedTlsFactory notVerifying = factory(
+                Map.of(TlsPurpose.CLIENT_DEFAULT, TlsPolicy.builder()
+                        .trustCertsFilePath(RSA_CA).enableHostnameVerification(false).build()),
+                FileBasedTlsFactorySettings.defaults());
+
+        SSLEngine verifyingEngine = ((SslContext) verifying.createInstance(TlsPurpose.CLIENT_DEFAULT, SslContext.class)
+                .join().get().get()).newEngine(ByteBufAllocator.DEFAULT);
+        SSLEngine plainEngine = ((SslContext) notVerifying.createInstance(TlsPurpose.CLIENT_DEFAULT, SslContext.class)
+                .join().get().get()).newEngine(ByteBufAllocator.DEFAULT);
+
+        assertThat(verifyingEngine.getSSLParameters().getEndpointIdentificationAlgorithm()).isEqualTo("HTTPS");
+        assertThat(plainEngine.getSSLParameters().getEndpointIdentificationAlgorithm()).isNullOrEmpty();
+        verifying.close();
+        notVerifying.close();
+    }
+
+    @Test
+    public void insecureServerAcceptsUntrustedClientAndCapturesItsCert() throws Exception {
+        // D3: insecure server installs InsecureTrustManagerFactory but keeps ClientAuth OPTIONAL,
+        // so an untrusted (cross-CA) client certificate still completes the handshake and is captured.
+        FileBasedTlsFactory server = factory(
+                Map.of(TlsPurpose.BROKER, TlsPolicy.builder()
+                        .trustCertsFilePath(RSA_CA).certificateFilePath(BROKER_CERT).keyFilePath(BROKER_KEY)
+                        .allowInsecureConnection(true).build()),
+                FileBasedTlsFactorySettings.builder().requireTrustedClientCert(false).build());
+        FileBasedTlsFactory client = factory(
+                Map.of(TlsPurpose.CLIENT_DEFAULT, TlsPolicy.builder()
+                        .trustCertsFilePath(RSA_CA).certificateFilePath(EC_CLIENT_CERT).keyFilePath(EC_CLIENT_KEY)
+                        .enableHostnameVerification(false).build()),
+                FileBasedTlsFactorySettings.defaults());
+
+        SSLEngine serverEngine = serverEngine(server);
+        SSLEngine clientEngine = clientEngine(client);
+        handshake(clientEngine, serverEngine);
+
+        assertThat(serverEngine.getSession().getPeerCertificates())
+                .as("insecure server captured the untrusted client certificate").isNotEmpty();
+        server.close();
+        client.close();
+    }
+
+    @Test
+    public void secureServerDoesNotCaptureUntrustedClientCert() throws Exception {
+        // The contrast to the D3 case: a SECURE server (real trust manager) advertises only its trusted
+        // CA (RSA) in the CertificateRequest, so the client withholds its cross-CA (EC) certificate and
+        // the handshake completes anonymously — the server captures no client certificate.
+        FileBasedTlsFactory server = factory(
+                Map.of(TlsPurpose.BROKER, TlsPolicy.builder()
+                        .trustCertsFilePath(RSA_CA).certificateFilePath(BROKER_CERT).keyFilePath(BROKER_KEY)
+                        .allowInsecureConnection(false).build()),
+                FileBasedTlsFactorySettings.defaults());
+        FileBasedTlsFactory client = factory(
+                Map.of(TlsPurpose.CLIENT_DEFAULT, TlsPolicy.builder()
+                        .trustCertsFilePath(RSA_CA).certificateFilePath(EC_CLIENT_CERT).keyFilePath(EC_CLIENT_KEY)
+                        .enableHostnameVerification(false).build()),
+                FileBasedTlsFactorySettings.defaults());
+
+        SSLEngine serverEngine = serverEngine(server);
+        SSLEngine clientEngine = clientEngine(client);
+        handshake(clientEngine, serverEngine);
+        assertThatThrownBy(() -> serverEngine.getSession().getPeerCertificates())
+                .as("secure server did not capture the untrusted client certificate")
+                .isInstanceOf(SSLPeerUnverifiedException.class);
+        server.close();
+        client.close();
+    }
+
+    // ---- T1: forced-untrusted-cert Netty rejection (a real negative, not mere non-capture). ----
+    // The two tests above depend on the client's default JSSE key manager silently WITHHOLDING its cross-CA
+    // certificate when the server advertises only its own trusted CA — so they never prove the server would
+    // reject a cert that is actually presented. These force the client to present the untrusted (EC, cross-CA)
+    // certificate via a ForcingKeyManager and assert the server-side decision directly: a secure server (real
+    // trust manager) REJECTS the handshake, an insecure server (InsecureTrustManagerFactory) accepts it and
+    // captures the cert (the D3 behavior TLS authentication relies on). Mirrors JettyTlsFactoryTest's
+    // optionalClientAuthScopesTrustAllToInsecureFlag on the Netty engine.
+
+    @Test
+    public void forcedUntrustedClientCertRejectedBySecureServer() throws Exception {
+        FileBasedTlsFactory server = factory(
+                Map.of(TlsPurpose.BROKER, TlsPolicy.builder()
+                        .trustCertsFilePath(RSA_CA).certificateFilePath(BROKER_CERT).keyFilePath(BROKER_KEY)
+                        .allowInsecureConnection(false).build()),
+                FileBasedTlsFactorySettings.builder().requireTrustedClientCert(true).build());
+
+        SSLEngine serverEngine = tls12(serverEngine(server));
+        SSLEngine clientEngine = tls12(forcingUntrustedClientEngine());
+        // The forced EC certificate is actually sent; the secure server's real (RSA) trust manager rejects it
+        // and aborts the handshake — the security-critical negative.
+        assertThatThrownBy(() -> handshake(clientEngine, serverEngine))
+                .as("secure server rejects the forced untrusted client certificate")
+                .isInstanceOf(SSLException.class);
+        server.close();
+    }
+
+    @Test
+    public void forcedUntrustedClientCertAcceptedAndCapturedByInsecureServer() throws Exception {
+        FileBasedTlsFactory server = factory(
+                Map.of(TlsPurpose.BROKER, TlsPolicy.builder()
+                        .trustCertsFilePath(RSA_CA).certificateFilePath(BROKER_CERT).keyFilePath(BROKER_KEY)
+                        .allowInsecureConnection(true).build()),
+                FileBasedTlsFactorySettings.builder().requireTrustedClientCert(false).build());
+
+        SSLEngine serverEngine = tls12(serverEngine(server));
+        SSLEngine clientEngine = tls12(forcingUntrustedClientEngine());
+        handshake(clientEngine, serverEngine);
+        assertThat(serverEngine.getSession().getPeerCertificates())
+                .as("insecure server captured the forced untrusted client certificate").isNotEmpty();
+        server.close();
+    }
+
+    @Test
+    public void rotationDeliversRebuiltInstanceToSubscriber() throws Exception {
+        TlsPolicy policy = copyServerCertsToTemp(BROKER_CERT, BROKER_KEY);
+        FileBasedTlsFactory factory = factory(Map.of(TlsPurpose.BROKER, policy),
+                FileBasedTlsFactorySettings.builder().refreshIntervalSeconds(1).build());
+
+        List<SslContext> deliveries = new CopyOnWriteArrayList<>();
+        factory.createInstance(TlsPurpose.BROKER, SslContext.class, deliveries::add).join();
+        assertThat(deliveries).as("initial delivery").hasSize(1);
+
+        overwriteServerCerts(PROXY_CERT, PROXY_KEY);
+        Awaitility.await().atMost(Duration.ofSeconds(15)).until(() -> deliveries.size() == 2);
+        assertThat(deliveries.get(1)).as("rebuilt on rotation").isNotSameAs(deliveries.get(0));
+        factory.close();
+    }
+
+    @Test
+    public void touchWithoutContentChangeSuppressesReload() throws Exception {
+        TlsPolicy policy = copyServerCertsToTemp(BROKER_CERT, BROKER_KEY);
+        FileBasedTlsFactory factory = factory(Map.of(TlsPurpose.BROKER, policy),
+                FileBasedTlsFactorySettings.builder().refreshIntervalSeconds(1).build());
+
+        AtomicInteger deliveries = new AtomicInteger();
+        factory.createInstance(TlsPurpose.BROKER, SslContext.class, ctx -> deliveries.incrementAndGet()).join();
+        assertThat(deliveries.get()).isEqualTo(1);
+
+        // Touch the cert file (advance mtime) without changing its content.
+        Files.setLastModifiedTime(tempDir.resolve("cert.pem"), FileTime.fromMillis(System.currentTimeMillis() + 5000));
+        Awaitility.await().during(Duration.ofSeconds(3)).atMost(Duration.ofSeconds(4))
+                .until(() -> deliveries.get() == 1);
+        factory.close();
+    }
+
+    @Test
+    public void failedRotationKeepsLastGoodThenRecovers() throws Exception {
+        TlsPolicy policy = copyServerCertsToTemp(BROKER_CERT, BROKER_KEY);
+        FileBasedTlsFactory factory = factory(Map.of(TlsPurpose.BROKER, policy),
+                FileBasedTlsFactorySettings.builder().refreshIntervalSeconds(1).build());
+
+        List<SslContext> deliveries = new CopyOnWriteArrayList<>();
+        factory.createInstance(TlsPurpose.BROKER, SslContext.class, deliveries::add).join();
+        assertThat(deliveries).hasSize(1);
+
+        // Corrupt the cert file: the rebuild fails, the subscriber keeps the last-good instance.
+        Files.writeString(tempDir.resolve("cert.pem"), "-----BEGIN CERTIFICATE-----\nnot a cert\n");
+        Files.setLastModifiedTime(tempDir.resolve("cert.pem"), FileTime.fromMillis(System.currentTimeMillis() + 5000));
+        Awaitility.await().during(Duration.ofSeconds(3)).atMost(Duration.ofSeconds(4))
+                .until(() -> deliveries.size() == 1);
+
+        // A subsequent good change is picked up (retry-on-next-change).
+        overwriteServerCerts(PROXY_CERT, PROXY_KEY);
+        Awaitility.await().atMost(Duration.ofSeconds(15)).until(() -> deliveries.size() == 2);
+        factory.close();
+    }
+
+    @Test
+    public void oneShotServesLastGoodWhenReloadFails() throws Exception {
+        // PIP-478 F4: a one-shot acquisition during a non-atomic rotation window (cert briefly unreadable)
+        // must serve the last-good cached context rather than failing, mirroring the subscription poll's
+        // keep-last-good semantics.
+        TlsPolicy policy = copyServerCertsToTemp(BROKER_CERT, BROKER_KEY);
+        FileBasedTlsFactory factory = factory(Map.of(TlsPurpose.BROKER, policy),
+                FileBasedTlsFactorySettings.defaults());
+
+        TlsHandle<SslContext> firstHandle =
+                factory.createInstance(TlsPurpose.BROKER, SslContext.class).join().get();
+        SslContext first = firstHandle.get();
+        assertThat(first).isNotNull();
+
+        // Corrupt the cert file so a fresh load fails, and advance mtime so the source attempts a reload.
+        Files.writeString(tempDir.resolve("cert.pem"), "-----BEGIN CERTIFICATE-----\nnot a cert\n");
+        Files.setLastModifiedTime(tempDir.resolve("cert.pem"),
+                FileTime.fromMillis(System.currentTimeMillis() + 5000));
+
+        Optional<TlsHandle<SslContext>> retry =
+                factory.createInstance(TlsPurpose.BROKER, SslContext.class).join();
+        assertThat(retry).as("keep-last-good instead of failing the acquisition").isPresent();
+        assertThat(retry.get().get()).as("served the last-good context").isSameAs(first);
+
+        retry.get().dispose();
+        firstHandle.dispose();
+        factory.close();
+    }
+
+    @Test
+    public void oneShotFailsWhenNoLastGoodExists() throws Exception {
+        // With no prior successful load there is nothing to fall back on: the acquisition fails (fail-fast).
+        Files.copy(Paths.get(RSA_CA), tempDir.resolve("ca.pem"), StandardCopyOption.REPLACE_EXISTING);
+        Files.writeString(tempDir.resolve("cert.pem"), "-----BEGIN CERTIFICATE-----\nnot a cert\n");
+        Files.copy(Paths.get(BROKER_KEY), tempDir.resolve("key.pem"), StandardCopyOption.REPLACE_EXISTING);
+        TlsPolicy policy = TlsPolicy.pem(tempDir.resolve("ca.pem").toString(),
+                tempDir.resolve("cert.pem").toString(), tempDir.resolve("key.pem").toString());
+        FileBasedTlsFactory factory = factory(Map.of(TlsPurpose.BROKER, policy),
+                FileBasedTlsFactorySettings.defaults());
+
+        assertThatThrownBy(() -> factory.createInstance(TlsPurpose.BROKER, SslContext.class).join())
+                .hasCauseInstanceOf(Exception.class);
+        factory.close();
+    }
+
+    @Test
+    public void subscriberCallbackExceptionDoesNotKillSubscription() throws Exception {
+        TlsPolicy policy = copyServerCertsToTemp(BROKER_CERT, BROKER_KEY);
+        FileBasedTlsFactory factory = factory(Map.of(TlsPurpose.BROKER, policy),
+                FileBasedTlsFactorySettings.builder().refreshIntervalSeconds(1).build());
+
+        AtomicInteger deliveries = new AtomicInteger();
+        factory.createInstance(TlsPurpose.BROKER, SslContext.class, ctx -> {
+            deliveries.incrementAndGet();
+            throw new RuntimeException("boom");
+        }).join();
+        assertThat(deliveries.get()).as("initial delivery still happened despite throwing callback").isEqualTo(1);
+
+        overwriteServerCerts(PROXY_CERT, PROXY_KEY);
+        Awaitility.await().atMost(Duration.ofSeconds(15)).until(() -> deliveries.get() == 2);
+        factory.close();
+    }
+
+    // ---- PIP-478 F1: OpenSSL rotation use-after-free guard (deferred release + per-use pinning). ----
+    // These exercise the OpenSSL engine specifically: on the JDK engine SslContext ref-counting is a no-op, so
+    // CI's default JDK provider can never surface the use-after-free the review flagged. On OpenSSL the native
+    // SSL_CTX is freed when a context's refcount reaches zero.
+
+    @Test
+    public void openSslRotationKeepsSupersededContextUsableWhileBorrowed() throws Exception {
+        assumeOpenSslAvailable();
+        TlsPolicy policy = copyServerCertsToTemp(BROKER_CERT, BROKER_KEY);
+        FileBasedTlsFactory factory = factory(Map.of(TlsPurpose.BROKER, policy),
+                FileBasedTlsFactorySettings.builder().engineProvider(SslProvider.OPENSSL)
+                        .refreshIntervalSeconds(1).build());
+
+        List<SslContext> deliveries = new CopyOnWriteArrayList<>();
+        factory.createInstance(TlsPurpose.BROKER, SslContext.class, deliveries::add).join();
+        assertThat(deliveries).hasSize(1);
+        SslContext borrowed = deliveries.get(0);
+        assertThat(borrowed).as("OpenSSL contexts are reference-counted").isInstanceOf(ReferenceCounted.class);
+
+        // A consumer read the borrow off its volatile and is about to build a handler/engine from it; interleave
+        // a rotation that supersedes it on the poll thread.
+        overwriteServerCerts(PROXY_CERT, PROXY_KEY);
+        Awaitility.await().atMost(Duration.ofSeconds(15)).until(() -> deliveries.size() == 2);
+
+        // Deferred release (F1): the just-superseded borrow was NOT released to refcount 0 on the poll thread,
+        // so the in-flight consumer can still build an engine from it. Pre-fix, its native SSL_CTX was freed the
+        // instant the new context was published, and this newEngine would use freed memory.
+        assertThat(((ReferenceCounted) borrowed).refCnt()).as("superseded borrow kept alive").isPositive();
+        SSLEngine engine = borrowed.newEngine(ByteBufAllocator.DEFAULT);
+        assertThat(engine).isNotNull();
+        ReferenceCountUtil.release(engine);
+        factory.close();
+    }
+
+    @Test
+    public void openSslRotationReleasesSupersededContextOneGenerationLater() throws Exception {
+        assumeOpenSslAvailable();
+        TlsPolicy policy = copyServerCertsToTemp(BROKER_CERT, BROKER_KEY);
+        FileBasedTlsFactory factory = factory(Map.of(TlsPurpose.BROKER, policy),
+                FileBasedTlsFactorySettings.builder().engineProvider(SslProvider.OPENSSL)
+                        .refreshIntervalSeconds(1).build());
+
+        List<SslContext> deliveries = new CopyOnWriteArrayList<>();
+        factory.createInstance(TlsPurpose.BROKER, SslContext.class, deliveries::add).join();
+        SslContext gen0 = deliveries.get(0);
+
+        // One rotation: gen0 is superseded but kept alive one extra generation.
+        overwriteServerCerts(PROXY_CERT, PROXY_KEY);
+        Awaitility.await().atMost(Duration.ofSeconds(15)).until(() -> deliveries.size() == 2);
+        assertThat(((ReferenceCounted) gen0).refCnt()).as("survives one generation").isPositive();
+
+        // A second rotation makes gen0 the N-1 instance, released on this (N+1th) delivery — the deferral is
+        // bounded, so nothing leaks.
+        overwriteServerCerts(BROKER_CERT, BROKER_KEY);
+        Awaitility.await().atMost(Duration.ofSeconds(15)).until(() -> deliveries.size() == 3);
+        Awaitility.await().atMost(Duration.ofSeconds(5)).untilAsserted(() ->
+                assertThat(((ReferenceCounted) gen0).refCnt()).as("released one generation later").isZero());
+        factory.close();
+    }
+
+    @Test
+    public void withPinnedContextReReadsWhenBorrowWasFreed() throws Exception {
+        assumeOpenSslAvailable();
+        // Two independent OpenSSL contexts: the first is freed, standing in for a borrow that a rotation
+        // released between the volatile read and the pin; the second is the live current context.
+        SslContext dead = SslContextBuilder.forClient().sslProvider(SslProvider.OPENSSL).build();
+        SslContext live = SslContextBuilder.forClient().sslProvider(SslProvider.OPENSSL).build();
+        ReferenceCountUtil.release(dead);
+        assertThat(((ReferenceCounted) dead).refCnt()).as("freed borrow").isZero();
+
+        AtomicInteger reads = new AtomicInteger();
+        Supplier<SslContext> source = () -> reads.getAndIncrement() == 0 ? dead : live;
+        int liveBefore = ((ReferenceCounted) live).refCnt();
+
+        // retain() on the freed borrow throws IllegalReferenceCountException; the helper must re-read the source
+        // and pin the live context instead.
+        SslContext used = TlsContextAcquisition.withPinnedContext(source, ctx -> ctx);
+
+        assertThat(used).as("re-read past the freed borrow").isSameAs(live);
+        assertThat(reads.get()).as("read at least twice").isGreaterThanOrEqualTo(2);
+        assertThat(((ReferenceCounted) live).refCnt()).as("pin is balanced (nets to zero)").isEqualTo(liveBefore);
+        ReferenceCountUtil.release(live);
+    }
+
+    @Test
+    public void createInstanceAfterCloseFailsWithoutRebuilding() {
+        // PIP-478 F9: a closed factory must not rebuild/cache a context (which would leak, since close()
+        // already released the memos). createInstance completes exceptionally instead.
+        FileBasedTlsFactory factory = factory(
+                Map.of(TlsPurpose.BROKER, TlsPolicy.pem(RSA_CA, BROKER_CERT, BROKER_KEY)),
+                FileBasedTlsFactorySettings.defaults());
+        factory.close();
+
+        assertThatThrownBy(() -> factory.createInstance(TlsPurpose.BROKER, SslContext.class).join())
+                .hasCauseInstanceOf(IllegalStateException.class);
+        assertThatThrownBy(() ->
+                factory.createInstance(TlsPurpose.BROKER, SslContext.class, ctx -> { }).join())
+                .hasCauseInstanceOf(IllegalStateException.class);
+    }
+
+    private static void assumeOpenSslAvailable() {
+        if (!OpenSsl.isAvailable()) {
+            throw new SkipException("Native OpenSSL (netty-tcnative) not available in this environment");
+        }
+    }
+
+    @Test
+    public void initialDeliveryHappensBeforeFutureCompletes() throws Exception {
+        FileBasedTlsFactory factory = factory(
+                Map.of(TlsPurpose.BROKER, TlsPolicy.pem(RSA_CA, BROKER_CERT, BROKER_KEY)),
+                FileBasedTlsFactorySettings.defaults());
+
+        AtomicInteger deliveries = new AtomicInteger();
+        // No await: by the time join() returns, the initial delivery must already have run.
+        factory.createInstance(TlsPurpose.BROKER, SslContext.class, ctx -> deliveries.incrementAndGet()).join();
+        assertThat(deliveries.get()).isEqualTo(1);
+        factory.close();
+    }
+
+    @Test
+    public void synthesizeNettyFromJdkWrapsTheJdkContext() throws Exception {
+        FileBasedTlsFactory factory = factory(
+                Map.of(TlsPurpose.BROKER, TlsPolicy.pem(RSA_CA, BROKER_CERT, BROKER_KEY)),
+                FileBasedTlsFactorySettings.defaults());
+        SSLContext jdk = (SSLContext) factory.createInstance(TlsPurpose.BROKER, SSLContext.class)
+                .join().get().get();
+
+        SslContext synthesized = TlsContexts.synthesizeNettyFromJdk(jdk, false, true);
+        assertThat(synthesized).isNotNull();
+        assertThat(synthesized.isServer()).isTrue();
+        assertThat(synthesized.newEngine(ByteBufAllocator.DEFAULT)).isNotNull();
+        factory.close();
+    }
+
+    @Test
+    public void returnsEmptyForSslParametersCompanion() {
+        // PIP-478: the default file-based factory bakes engine policy natively into its Netty/JDK contexts,
+        // so it exposes no SSLParameters companion for the framework to overlay -> empty() for every form.
+        FileBasedTlsFactory factory = factory(
+                Map.of(TlsPurpose.BROKER, TlsPolicy.pem(RSA_CA, BROKER_CERT, BROKER_KEY)),
+                FileBasedTlsFactorySettings.defaults());
+
+        assertThat(factory.createInstance(TlsPurpose.BROKER, SSLParameters.class).join()).isEmpty();
+        assertThat(factory.createInstance(TlsPurpose.BROKER, SSLParameters.class, p -> { }).join()).isEmpty();
+        factory.close();
+    }
+
+    @Test
+    public void probeRetainsInitialInstanceAndFailsFastOnBootError() {
+        FileBasedTlsFactory ok = factory(
+                Map.of(TlsPurpose.BROKER, TlsPolicy.pem(RSA_CA, BROKER_CERT, BROKER_KEY)),
+                FileBasedTlsFactorySettings.defaults());
+        TlsHandle<SslContext> handle = TlsFactoryProbe.probe(ok, TlsPurpose.BROKER, SslContext.class);
+        assertThat(handle.get()).isNotNull();
+        ok.close();
+
+        FileBasedTlsFactory broken = factory(
+                Map.of(TlsPurpose.BROKER, TlsPolicy.pem(RSA_CA,
+                        tempDir.resolve("nope-cert.pem").toString(), tempDir.resolve("nope-key.pem").toString())),
+                FileBasedTlsFactorySettings.defaults());
+        assertThatThrownBy(() -> TlsFactoryProbe.probe(broken, TlsPurpose.BROKER, SslContext.class))
+                .isInstanceOf(IllegalStateException.class);
+        broken.close();
+    }
+
+    // ---- PIP-478 stage 4c: ports the removed SslContextTest matrix (SslProvider x ciphers x keystore/PEM) ----
+    // onto the new FileBasedTlsFactory. OpenSSL rejects the JDK-named TLS 1.2 ciphers used here (matching the
+    // removed test's assertion); the JDK engine accepts them, and keystore-format material builds regardless.
+
+    private static final List<String> MATRIX_CIPHERS = List.of(
+            "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384",
+            "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+            "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+            "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+            "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384");
+
+    @DataProvider(name = "engineAndCiphers")
+    public static Object[][] engineAndCiphers() {
+        return new Object[][] {
+                {SslProvider.JDK, MATRIX_CIPHERS},
+                {SslProvider.JDK, null},
+                {SslProvider.OPENSSL, MATRIX_CIPHERS},
+                {SslProvider.OPENSSL, null},
+        };
+    }
+
+    @Test(dataProvider = "engineAndCiphers")
+    public void serverPemContextAcrossEngineAndCiphers(SslProvider provider, List<String> ciphers) {
+        FileBasedTlsFactory factory = factory(
+                Map.of(TlsPurpose.BROKER, TlsPolicy.builder()
+                        .trustCertsFilePath(RSA_CA).certificateFilePath(BROKER_CERT).keyFilePath(BROKER_KEY)
+                        .ciphers(ciphers).build()),
+                FileBasedTlsFactorySettings.builder().engineProvider(provider)
+                        .requireTrustedClientCert(true).build());
+        assertNettyContextBuildsUnlessOpenSslWithCiphers(factory, TlsPurpose.BROKER, provider, ciphers);
+        factory.close();
+    }
+
+    @Test(dataProvider = "engineAndCiphers")
+    public void clientPemContextAcrossEngineAndCiphers(SslProvider provider, List<String> ciphers) {
+        FileBasedTlsFactory factory = factory(
+                Map.of(TlsPurpose.CLIENT_DEFAULT, TlsPolicy.builder()
+                        .trustCertsFilePath(RSA_CA).allowInsecureConnection(true)
+                        .ciphers(ciphers).build()),
+                FileBasedTlsFactorySettings.builder().engineProvider(provider).build());
+        assertNettyContextBuildsUnlessOpenSslWithCiphers(factory, TlsPurpose.CLIENT_DEFAULT, provider, ciphers);
+        factory.close();
+    }
+
+    @Test
+    public void serverKeystoreContextBuildsWithCiphers() {
+        FileBasedTlsFactory factory = factory(
+                Map.of(TlsPurpose.BROKER, TlsPolicy.builder()
+                        .format(TlsPolicy.Format.KEYSTORE).keyStoreType("JKS").trustStoreType("JKS")
+                        .trustStorePath(TRUSTSTORE).trustStorePassword(STORE_PW)
+                        .keyStorePath(KEYSTORE).keyStorePassword(STORE_PW)
+                        .ciphers(MATRIX_CIPHERS).build()),
+                FileBasedTlsFactorySettings.builder().requireTrustedClientCert(true).build());
+        Optional<TlsHandle<SslContext>> handle = factory.createInstance(TlsPurpose.BROKER, SslContext.class).join();
+        assertThat(handle).isPresent();
+        assertThat(handle.get().get()).isNotNull();
+        handle.get().dispose();
+        factory.close();
+    }
+
+    @Test
+    public void clientKeystoreContextBuildsWithCiphers() {
+        FileBasedTlsFactory factory = factory(
+                Map.of(TlsPurpose.CLIENT_DEFAULT, TlsPolicy.builder()
+                        .format(TlsPolicy.Format.KEYSTORE).keyStoreType("JKS").trustStoreType("JKS")
+                        .trustStorePath(TRUSTSTORE).trustStorePassword(STORE_PW)
+                        .ciphers(MATRIX_CIPHERS).build()),
+                FileBasedTlsFactorySettings.defaults());
+        Optional<TlsHandle<SslContext>> handle =
+                factory.createInstance(TlsPurpose.CLIENT_DEFAULT, SslContext.class).join();
+        assertThat(handle).isPresent();
+        assertThat(handle.get().get()).isNotNull();
+        handle.get().dispose();
+        factory.close();
+    }
+
+    @Test
+    public void defaultProtocolsAppliedWhenPolicyLeavesThemUnset() {
+        FileBasedTlsFactory factory = factory(
+                Map.of(TlsPurpose.BROKER, TlsPolicy.pem(RSA_CA, BROKER_CERT, BROKER_KEY),
+                        TlsPurpose.CLIENT_DEFAULT, TlsPolicy.builder().trustCertsFilePath(RSA_CA).build()),
+                FileBasedTlsFactorySettings.defaults());
+        // B3: with no protocols configured the {TLSv1.3, TLSv1.2} floor is enabled on both the server and the
+        // client context (the set the removed DefaultPulsarSslFactory forced), not the provider default — so an
+        // upgrade to the PIP-478 TLS path does not silently change the enabled protocol set.
+        assertThat(serverEngine(factory).getEnabledProtocols()).containsExactlyInAnyOrder("TLSv1.3", "TLSv1.2");
+        assertThat(clientEngine(factory).getEnabledProtocols()).containsExactlyInAnyOrder("TLSv1.3", "TLSv1.2");
+        factory.close();
+    }
+
+    private static void assertNettyContextBuildsUnlessOpenSslWithCiphers(FileBasedTlsFactory factory,
+            TlsPurpose purpose, SslProvider provider, List<String> ciphers) {
+        if (ciphers != null && provider == SslProvider.OPENSSL) {
+            // OpenSSL does not support these JDK-named TLS 1.2 ciphers (as the removed SslContextTest asserted).
+            assertThatThrownBy(() -> factory.createInstance(purpose, SslContext.class).join())
+                    .hasCauseInstanceOf(SSLException.class);
+            return;
+        }
+        Optional<TlsHandle<SslContext>> handle = factory.createInstance(purpose, SslContext.class).join();
+        assertThat(handle).isPresent();
+        assertThat(handle.get().get()).isNotNull();
+        handle.get().dispose();
+    }
+
+    private SSLEngine serverEngine(FileBasedTlsFactory factory) {
+        SslContext ctx = (SslContext) factory.createInstance(TlsPurpose.BROKER, SslContext.class).join().get().get();
+        SSLEngine engine = ctx.newEngine(ByteBufAllocator.DEFAULT);
+        engine.setUseClientMode(false);
+        return engine;
+    }
+
+    private SSLEngine clientEngine(FileBasedTlsFactory factory) {
+        SslContext ctx = (SslContext) factory.createInstance(TlsPurpose.CLIENT_DEFAULT, SslContext.class)
+                .join().get().get();
+        SSLEngine engine = ctx.newEngine(ByteBufAllocator.DEFAULT);
+        engine.setUseClientMode(true);
+        return engine;
+    }
+
+    // Pin TLSv1.2 so an untrusted-cert rejection surfaces synchronously within the in-memory handshake pump
+    // rather than as a TLS 1.3 post-handshake alert (client auth completes symmetrically within the handshake).
+    private static SSLEngine tls12(SSLEngine engine) {
+        engine.setEnabledProtocols(new String[] {"TLSv1.2"});
+        return engine;
+    }
+
+    // A JDK client engine whose key manager is FORCED to present the untrusted (EC, cross-CA) certificate
+    // regardless of the server's advertised acceptable-CA list, so the certificate is actually sent (and can
+    // therefore be rejected) rather than silently withheld by the default JSSE key manager. Trusts the RSA CA
+    // so the client accepts the server certificate.
+    private static SSLEngine forcingUntrustedClientEngine() throws Exception {
+        X509Certificate[] chain = PemReader.loadCertificatesFromPemFile(EC_CLIENT_CERT);
+        PrivateKey key = PemReader.loadPrivateKeyFromPemFile(EC_CLIENT_KEY);
+        KeyStore trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
+        trustStore.load(null, null);
+        X509Certificate[] ca = PemReader.loadCertificatesFromPemFile(RSA_CA);
+        for (int i = 0; i < ca.length; i++) {
+            trustStore.setCertificateEntry("ca-" + i, ca[i]);
+        }
+        TrustManagerFactory tmf = TrustManagerFactory.getInstance("PKIX");
+        tmf.init(trustStore);
+        SSLContext context = SSLContext.getInstance("TLS");
+        context.init(new KeyManager[] {new ForcingKeyManager(chain, key)}, tmf.getTrustManagers(), null);
+        SSLEngine engine = context.createSSLEngine();
+        engine.setUseClientMode(true);
+        return engine;
+    }
+
+    /** A key manager that always presents a fixed certificate chain, ignoring the server's CA hints. */
+    private static final class ForcingKeyManager extends X509ExtendedKeyManager {
+        private static final String ALIAS = "client";
+        private final X509Certificate[] chain;
+        private final PrivateKey key;
+
+        ForcingKeyManager(X509Certificate[] chain, PrivateKey key) {
+            this.chain = chain;
+            this.key = key;
+        }
+
+        @Override
+        public String[] getClientAliases(String keyType, Principal[] issuers) {
+            return new String[] {ALIAS};
+        }
+
+        @Override
+        public String chooseClientAlias(String[] keyType, Principal[] issuers, Socket socket) {
+            return ALIAS;
+        }
+
+        @Override
+        public String chooseEngineClientAlias(String[] keyType, Principal[] issuers, SSLEngine engine) {
+            return ALIAS;
+        }
+
+        @Override
+        public String[] getServerAliases(String keyType, Principal[] issuers) {
+            return null;
+        }
+
+        @Override
+        public String chooseServerAlias(String keyType, Principal[] issuers, Socket socket) {
+            return null;
+        }
+
+        @Override
+        public X509Certificate[] getCertificateChain(String alias) {
+            return chain;
+        }
+
+        @Override
+        public PrivateKey getPrivateKey(String alias) {
+            return key;
+        }
+    }
+
+    private TlsPolicy copyServerCertsToTemp(String certSrc, String keySrc) throws Exception {
+        Files.copy(Paths.get(RSA_CA), tempDir.resolve("ca.pem"), StandardCopyOption.REPLACE_EXISTING);
+        Files.copy(Paths.get(certSrc), tempDir.resolve("cert.pem"), StandardCopyOption.REPLACE_EXISTING);
+        Files.copy(Paths.get(keySrc), tempDir.resolve("key.pem"), StandardCopyOption.REPLACE_EXISTING);
+        return TlsPolicy.pem(tempDir.resolve("ca.pem").toString(),
+                tempDir.resolve("cert.pem").toString(), tempDir.resolve("key.pem").toString());
+    }
+
+    private void overwriteServerCerts(String certSrc, String keySrc) throws Exception {
+        Files.copy(Paths.get(certSrc), tempDir.resolve("cert.pem"), StandardCopyOption.REPLACE_EXISTING);
+        Files.copy(Paths.get(keySrc), tempDir.resolve("key.pem"), StandardCopyOption.REPLACE_EXISTING);
+        long later = System.currentTimeMillis() + 5000;
+        Files.setLastModifiedTime(tempDir.resolve("cert.pem"), FileTime.fromMillis(later));
+        Files.setLastModifiedTime(tempDir.resolve("key.pem"), FileTime.fromMillis(later));
+    }
+}

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/tls/impl/SslParametersSynthesisTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/tls/impl/SslParametersSynthesisTest.java
@@ -1,0 +1,383 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.tls.impl;
+
+import static org.apache.pulsar.common.tls.impl.TlsTestSupport.handshake;
+import static org.apache.pulsar.common.tls.impl.TlsTestSupport.resource;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.handler.ssl.SslContext;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLParameters;
+import org.apache.pulsar.common.tls.PulsarTlsFactory;
+import org.apache.pulsar.common.tls.TlsFactoryInitContext;
+import org.apache.pulsar.common.tls.TlsHandle;
+import org.apache.pulsar.common.tls.TlsPurpose;
+import org.apache.pulsar.common.util.tls.JdkSslContexts;
+import org.apache.pulsar.common.util.tls.PemReader;
+import org.testng.annotations.Test;
+
+/**
+ * PIP-478: a factory that supplies only a JDK {@code SSLContext} may accompany it with a
+ * {@code javax.net.ssl.SSLParameters} companion carrying the engine-level baseline a bare {@code SSLContext}
+ * cannot express (protocols, cipher suites, endpoint identification, server client-auth mode). This exercises
+ * the framework's composition of that companion into the synthesized Netty context — both directly through
+ * {@link TlsContexts} and end-to-end through {@link TlsContextAcquisition} — per the documented merge order.
+ */
+public class SslParametersSynthesisTest {
+
+    private static final String CA = resource("certificate-authority/certs/ca.cert.pem");
+    private static final String SERVER_CERT = resource("certificate-authority/server-keys/broker.cert.pem");
+    private static final String SERVER_KEY = resource("certificate-authority/server-keys/broker.key-pk8.pem");
+    // A client identity with the clientAuth EKU, trusted by the shared CA above.
+    private static final String CLIENT_CERT = resource("certificate-authority/client-keys/admin.cert.pem");
+    private static final String CLIENT_KEY = resource("certificate-authority/client-keys/admin.key-pk8.pem");
+
+    private static SSLContext serverJdkContext() throws Exception {
+        return JdkSslContexts.createSslContext(false, CA, SERVER_CERT, SERVER_KEY, null);
+    }
+
+    private static SSLContext clientJdkContextWithCert() throws Exception {
+        return JdkSslContexts.createSslContext(false, CA, CLIENT_CERT, CLIENT_KEY, null);
+    }
+
+    private static SSLContext clientJdkContextTrustOnly() throws Exception {
+        return JdkSslContexts.createSslContext(false, PemReader.loadCertificatesFromPemFile(CA), null);
+    }
+
+    // ---- (a) protocol restriction from the factory companion ----
+
+    @Test
+    public void factoryProtocolsRestrictSynthesizedClientEngine() throws Exception {
+        SSLParameters baseline = new SSLParameters();
+        baseline.setProtocols(new String[] {"TLSv1.2"});
+
+        SslContext context = TlsContexts.synthesizeNettyClientFromJdk(clientJdkContextTrustOnly(), false, baseline);
+        SSLEngine engine = context.newEngine(ByteBufAllocator.DEFAULT);
+
+        assertThat(engine.getEnabledProtocols()).containsExactly("TLSv1.2");
+    }
+
+    @Test
+    public void factoryProtocolRestrictionHonoredAtHandshake() throws Exception {
+        // Matching TLSv1.2-only baselines on both ends complete the handshake...
+        SslContext client = TlsContexts.synthesizeNettyClientFromJdk(
+                clientJdkContextTrustOnly(), false, protocols("TLSv1.2"));
+        SslContext server = TlsContexts.synthesizeNettyServerFromJdk(serverJdkContext(), false, protocols("TLSv1.2"));
+        handshake(client.newEngine(ByteBufAllocator.DEFAULT), server.newEngine(ByteBufAllocator.DEFAULT));
+
+        // ...but a TLSv1.3-only client against a TLSv1.2-only server has no shared protocol and fails.
+        SslContext client13 = TlsContexts.synthesizeNettyClientFromJdk(
+                clientJdkContextTrustOnly(), false, protocols("TLSv1.3"));
+        SslContext server12 = TlsContexts.synthesizeNettyServerFromJdk(serverJdkContext(), false, protocols("TLSv1.2"));
+        assertThatThrownBy(() -> handshake(client13.newEngine(ByteBufAllocator.DEFAULT),
+                server12.newEngine(ByteBufAllocator.DEFAULT)))
+                .isInstanceOf(SSLException.class);
+    }
+
+    // ---- default protocol floor (B3): unset -> {TLSv1.3, TLSv1.2}, not the provider default ----
+
+    @Test
+    public void synthesizedClientWithoutCompanionPinsDefaultProtocols() throws Exception {
+        SslContext context = TlsContexts.synthesizeNettyClientFromJdk(clientJdkContextTrustOnly(), false, null);
+        assertThat(context.newEngine(ByteBufAllocator.DEFAULT).getEnabledProtocols())
+                .containsExactlyInAnyOrder("TLSv1.3", "TLSv1.2");
+    }
+
+    @Test
+    public void synthesizedClientWithCompanionMissingProtocolsPinsDefault() throws Exception {
+        // A companion that sets other members but no protocols still gets the default floor.
+        SSLParameters companion = new SSLParameters();
+        companion.setEndpointIdentificationAlgorithm("HTTPS");
+        SslContext context = TlsContexts.synthesizeNettyClientFromJdk(clientJdkContextTrustOnly(), false, companion);
+        assertThat(context.newEngine(ByteBufAllocator.DEFAULT).getEnabledProtocols())
+                .containsExactlyInAnyOrder("TLSv1.3", "TLSv1.2");
+    }
+
+    @Test
+    public void synthesizedServerWithoutCompanionPinsDefaultProtocols() throws Exception {
+        SslContext context = TlsContexts.synthesizeNettyServerFromJdk(serverJdkContext(), false, null);
+        assertThat(context.newEngine(ByteBufAllocator.DEFAULT).getEnabledProtocols())
+                .containsExactlyInAnyOrder("TLSv1.3", "TLSv1.2");
+    }
+
+    // ---- (b) endpoint identification: factory value wins, else the consumer flag applies "HTTPS" ----
+
+    @Test
+    public void factoryEndpointIdentificationAlgorithmWinsOverConsumerFlag() throws Exception {
+        SSLParameters baseline = new SSLParameters();
+        baseline.setEndpointIdentificationAlgorithm("HTTPS");
+
+        // Consumer hostname verification disabled, but the factory pins HTTPS -> the factory wins.
+        SslContext context = TlsContexts.synthesizeNettyClientFromJdk(clientJdkContextTrustOnly(), false, baseline);
+        SSLEngine engine = context.newEngine(ByteBufAllocator.DEFAULT);
+        assertThat(engine.getSSLParameters().getEndpointIdentificationAlgorithm()).isEqualTo("HTTPS");
+    }
+
+    @Test
+    public void consumerFlagAppliesHttpsWhenFactoryLeavesAlgorithmNull() throws Exception {
+        // Companion present but with no endpoint-identification algorithm -> the consumer flag applies "HTTPS".
+        SslContext verifying = TlsContexts.synthesizeNettyClientFromJdk(
+                clientJdkContextTrustOnly(), true, new SSLParameters());
+        assertThat(verifying.newEngine(ByteBufAllocator.DEFAULT).getSSLParameters()
+                .getEndpointIdentificationAlgorithm()).isEqualTo("HTTPS");
+
+        // Companion present, algorithm null, consumer flag off -> no endpoint identification.
+        SslContext plain = TlsContexts.synthesizeNettyClientFromJdk(
+                clientJdkContextTrustOnly(), false, new SSLParameters());
+        assertThat(plain.newEngine(ByteBufAllocator.DEFAULT).getSSLParameters()
+                .getEndpointIdentificationAlgorithm()).isNull();
+
+        // No companion at all, consumer flag on -> "HTTPS" (unchanged pre-companion behavior).
+        SslContext noCompanion = TlsContexts.synthesizeNettyClientFromJdk(clientJdkContextTrustOnly(), true, null);
+        assertThat(noCompanion.newEngine(ByteBufAllocator.DEFAULT).getSSLParameters()
+                .getEndpointIdentificationAlgorithm()).isEqualTo("HTTPS");
+    }
+
+    // ---- (c) server client-auth mode: factory companion is authoritative (merge rule 4) ----
+
+    @Test
+    public void serverNeedClientAuthFromFactoryEnforcedAtHandshake() throws Exception {
+        // Consumer requests only OPTIONAL client auth (requireTrustedClientCert=false), but the factory
+        // companion sets needClientAuth -> the factory wins and the server requires a client certificate.
+        SSLParameters serverBaseline = protocols("TLSv1.2");
+        serverBaseline.setNeedClientAuth(true);
+        SslContext server = TlsContexts.synthesizeNettyServerFromJdk(serverJdkContext(), false, serverBaseline);
+        assertThat(server.newEngine(ByteBufAllocator.DEFAULT).getNeedClientAuth()).isTrue();
+
+        // A client that presents a trusted certificate completes the handshake.
+        SslContext clientWithCert = TlsContexts.synthesizeNettyClientFromJdk(
+                clientJdkContextWithCert(), false, protocols("TLSv1.2"));
+        handshake(clientWithCert.newEngine(ByteBufAllocator.DEFAULT),
+                TlsContexts.synthesizeNettyServerFromJdk(serverJdkContext(), false, needClientAuthTls12())
+                        .newEngine(ByteBufAllocator.DEFAULT));
+
+        // A client that presents no certificate is rejected by the client-auth-requiring server.
+        SslContext clientNoCert = TlsContexts.synthesizeNettyClientFromJdk(
+                clientJdkContextTrustOnly(), false, protocols("TLSv1.2"));
+        assertThatThrownBy(() -> handshake(clientNoCert.newEngine(ByteBufAllocator.DEFAULT),
+                TlsContexts.synthesizeNettyServerFromJdk(serverJdkContext(), false, needClientAuthTls12())
+                        .newEngine(ByteBufAllocator.DEFAULT)))
+                .isInstanceOf(SSLException.class);
+    }
+
+    @Test
+    public void factoryClientAuthOverridesConsumerRequireBothWays() throws Exception {
+        // Consumer would REQUIRE a trusted client cert, but the factory companion states NONE (need=want=false)
+        // -> the factory is authoritative and the server requests no client certificate.
+        SslContext server = TlsContexts.synthesizeNettyServerFromJdk(serverJdkContext(), true, new SSLParameters());
+        SSLEngine engine = server.newEngine(ByteBufAllocator.DEFAULT);
+        assertThat(engine.getNeedClientAuth()).isFalse();
+        assertThat(engine.getWantClientAuth()).isFalse();
+    }
+
+    // ---- (f) the factory companion is mutable: a later mutation must not affect an acquired context ----
+
+    @Test
+    public void mutationAfterSupplyDoesNotAffectAcquiredContext() throws Exception {
+        SSLParameters baseline = new SSLParameters();
+        baseline.setProtocols(new String[] {"TLSv1.2"});
+
+        SslContext context = TlsContexts.synthesizeNettyClientFromJdk(clientJdkContextTrustOnly(), false, baseline);
+
+        // Mutate the factory's original object after the context was synthesized.
+        baseline.setProtocols(new String[] {"TLSv1.3"});
+        baseline.setEndpointIdentificationAlgorithm("HTTPS");
+
+        // Engines produced after the mutation still reflect the snapshot taken at synthesis time.
+        SSLEngine engine = context.newEngine(ByteBufAllocator.DEFAULT);
+        assertThat(engine.getEnabledProtocols()).containsExactly("TLSv1.2");
+        assertThat(engine.getSSLParameters().getEndpointIdentificationAlgorithm()).isNull();
+    }
+
+    // ---- end-to-end: the acquisition helper requests and threads the companion ----
+
+    @Test
+    public void acquisitionThreadsFactorySuppliedCompanion() throws Exception {
+        SSLParameters companion = new SSLParameters();
+        companion.setProtocols(new String[] {"TLSv1.2"});
+        companion.setEndpointIdentificationAlgorithm("HTTPS");
+        CompanionFactory factory = new CompanionFactory(clientJdkContextTrustOnly(), companion);
+
+        TlsHandle<SslContext> handle = TlsContextAcquisition.acquireNettyContext(
+                factory, TlsPurpose.CLIENT_DEFAULT, TlsSynthesisSpec.client(false)).join().orElseThrow();
+
+        SSLEngine engine = handle.get().newEngine(ByteBufAllocator.DEFAULT);
+        assertThat(engine.getEnabledProtocols()).containsExactly("TLSv1.2");
+        assertThat(engine.getSSLParameters().getEndpointIdentificationAlgorithm()).isEqualTo("HTTPS");
+        assertThat(factory.companionRequests).as("the framework requested the SSLParameters companion").isPositive();
+        handle.dispose();
+    }
+
+    @Test
+    public void subscribingAcquisitionPreFetchesCompanionOnce() throws Exception {
+        SSLParameters companion = new SSLParameters();
+        companion.setProtocols(new String[] {"TLSv1.2"});
+        CompanionFactory factory = new CompanionFactory(serverJdkContext(), companion);
+
+        TlsHandle<SslContext> handle = TlsContextAcquisition.acquireNettyContext(
+                factory, TlsPurpose.BROKER, TlsSynthesisSpec.server(false), ctx -> { }).join().orElseThrow();
+
+        assertThat(handle.get().newEngine(ByteBufAllocator.DEFAULT).getEnabledProtocols()).containsExactly("TLSv1.2");
+        // F8: the companion is pre-fetched exactly once at subscribe time (not re-requested inside each delivery
+        // callback), so a custom factory that dispatches its creation to the same single-thread executor running
+        // the reload callback cannot self-deadlock. Material still rotates per delivery; engine policy snapshots.
+        assertThat(factory.companionRequests).as("companion pre-fetched once at subscribe").isEqualTo(1);
+        handle.dispose();
+    }
+
+    // ---- T4: LIVE handshakes driven through the full factory -> acquisition path (not the low-level
+    // synthesize helper, and not just getters): the factory-supplied companion actually decides a real
+    // handshake outcome after flowing through TlsContextAcquisition.acquireNettyContext. ----
+
+    @Test
+    public void acquiredCompanionProtocolRestrictionEnforcedAtHandshake() throws Exception {
+        // A companion pinning TLSv1.2 on contexts obtained through the acquisition path completes a matching
+        // TLSv1.2 handshake and rejects a TLSv1.3-only peer.
+        TlsHandle<SslContext> server = acquireServer(serverJdkContext(), protocols("TLSv1.2"));
+        TlsHandle<SslContext> okClient = acquireClient(clientJdkContextTrustOnly(), protocols("TLSv1.2"));
+        handshake(okClient.get().newEngine(ByteBufAllocator.DEFAULT),
+                server.get().newEngine(ByteBufAllocator.DEFAULT));
+
+        TlsHandle<SslContext> badClient = acquireClient(clientJdkContextTrustOnly(), protocols("TLSv1.3"));
+        assertThatThrownBy(() -> handshake(badClient.get().newEngine(ByteBufAllocator.DEFAULT),
+                server.get().newEngine(ByteBufAllocator.DEFAULT)))
+                .as("a TLSv1.3-only client cannot handshake with the companion-pinned TLSv1.2 server")
+                .isInstanceOf(SSLException.class);
+
+        server.dispose();
+        okClient.dispose();
+        badClient.dispose();
+    }
+
+    @Test
+    public void acquiredCompanionNeedClientAuthEnforcedAtHandshake() throws Exception {
+        // The consumer requests only OPTIONAL client auth (server(false)); the companion's needClientAuth is
+        // authoritative through the acquisition path — a client presenting a trusted certificate completes the
+        // handshake, a client presenting none is rejected.
+        TlsHandle<SslContext> server = acquireServer(serverJdkContext(), needClientAuthTls12());
+        TlsHandle<SslContext> clientWithCert = acquireClient(clientJdkContextWithCert(), protocols("TLSv1.2"));
+        handshake(clientWithCert.get().newEngine(ByteBufAllocator.DEFAULT),
+                server.get().newEngine(ByteBufAllocator.DEFAULT));
+
+        TlsHandle<SslContext> clientNoCert = acquireClient(clientJdkContextTrustOnly(), protocols("TLSv1.2"));
+        assertThatThrownBy(() -> handshake(clientNoCert.get().newEngine(ByteBufAllocator.DEFAULT),
+                server.get().newEngine(ByteBufAllocator.DEFAULT)))
+                .as("the companion's needClientAuth rejects a client presenting no certificate")
+                .isInstanceOf(SSLException.class);
+
+        server.dispose();
+        clientWithCert.dispose();
+        clientNoCert.dispose();
+    }
+
+    private static TlsHandle<SslContext> acquireServer(SSLContext jdkContext, SSLParameters companion)
+            throws Exception {
+        return TlsContextAcquisition.acquireNettyContext(new CompanionFactory(jdkContext, companion),
+                TlsPurpose.BROKER, TlsSynthesisSpec.server(false)).join().orElseThrow();
+    }
+
+    private static TlsHandle<SslContext> acquireClient(SSLContext jdkContext, SSLParameters companion)
+            throws Exception {
+        return TlsContextAcquisition.acquireNettyContext(new CompanionFactory(jdkContext, companion),
+                TlsPurpose.CLIENT_DEFAULT, TlsSynthesisSpec.client(false)).join().orElseThrow();
+    }
+
+    private static SSLParameters protocols(String... protocols) {
+        SSLParameters params = new SSLParameters();
+        params.setProtocols(protocols);
+        return params;
+    }
+
+    private static SSLParameters needClientAuthTls12() {
+        SSLParameters params = protocols("TLSv1.2");
+        params.setNeedClientAuth(true);
+        return params;
+    }
+
+    /**
+     * A minimal factory that supplies only the JDK {@code SSLContext} (returning {@code empty()} for the Netty
+     * class, forcing synthesis) plus a fixed {@code SSLParameters} companion, counting companion requests.
+     */
+    private static final class CompanionFactory implements PulsarTlsFactory {
+        private final SSLContext jdkContext;
+        private final SSLParameters companion;
+        private int companionRequests;
+
+        CompanionFactory(SSLContext jdkContext, SSLParameters companion) {
+            this.jdkContext = jdkContext;
+            this.companion = companion;
+        }
+
+        @Override
+        public CompletableFuture<Void> initialize(TlsFactoryInitContext context) {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        @Override
+        public <T> CompletableFuture<Optional<TlsHandle<T>>> createInstance(TlsPurpose purpose,
+                                                                            Class<T> instanceClass) {
+            return CompletableFuture.completedFuture(instanceFor(instanceClass));
+        }
+
+        @Override
+        public <T> CompletableFuture<Optional<TlsHandle<T>>> createInstance(
+                TlsPurpose purpose, Class<T> instanceClass, Consumer<T> onLoadOrReload) {
+            Optional<TlsHandle<T>> instance = instanceFor(instanceClass);
+            instance.ifPresent(handle -> onLoadOrReload.accept(handle.get()));
+            return CompletableFuture.completedFuture(instance);
+        }
+
+        @SuppressWarnings("unchecked")
+        private <T> Optional<TlsHandle<T>> instanceFor(Class<T> instanceClass) {
+            if (instanceClass == SSLContext.class) {
+                return Optional.of((TlsHandle<T>) handleOf(jdkContext));
+            }
+            if (instanceClass == SSLParameters.class) {
+                companionRequests++;
+                return Optional.of((TlsHandle<T>) handleOf(companion));
+            }
+            // Netty SslContext and anything else: unsupported -> the framework synthesizes from the SSLContext.
+            return Optional.empty();
+        }
+
+        private static <V> TlsHandle<V> handleOf(V value) {
+            return new TlsHandle<>() {
+                @Override
+                public V get() {
+                    return value;
+                }
+
+                @Override
+                public void dispose() {
+                }
+            };
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+}

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/tls/impl/TlsMaterialSourceTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/tls/impl/TlsMaterialSourceTest.java
@@ -1,0 +1,218 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.tls.impl;
+
+import static org.apache.pulsar.common.tls.impl.TlsTestSupport.resource;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.FileTime;
+import java.security.KeyStore;
+import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
+import org.apache.commons.io.FileUtils;
+import org.apache.pulsar.common.tls.TlsPolicy;
+import org.apache.pulsar.common.util.tls.PemReader;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class TlsMaterialSourceTest {
+
+    private static final String CA = resource("certificate-authority/certs/ca.cert.pem");
+    private static final String BROKER_CERT = resource("certificate-authority/server-keys/broker.cert.pem");
+    private static final String BROKER_KEY = resource("certificate-authority/server-keys/broker.key-pk8.pem");
+    private static final String PROXY_CERT = resource("certificate-authority/server-keys/proxy.cert.pem");
+    private static final String PROXY_KEY = resource("certificate-authority/server-keys/proxy.key-pk8.pem");
+
+    private static final char[] STORE_PW = "changeit".toCharArray();
+
+    private Path dir;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        dir = Files.createTempDirectory("pip478-src-");
+        Files.copy(Paths.get(CA), dir.resolve("ca.pem"), StandardCopyOption.REPLACE_EXISTING);
+        Files.copy(Paths.get(BROKER_CERT), dir.resolve("cert.pem"), StandardCopyOption.REPLACE_EXISTING);
+        Files.copy(Paths.get(BROKER_KEY), dir.resolve("key.pem"), StandardCopyOption.REPLACE_EXISTING);
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void tearDown() throws Exception {
+        if (dir != null) {
+            FileUtils.deleteDirectory(dir.toFile());
+        }
+    }
+
+    private TlsMaterialSource source() {
+        return new TlsMaterialSource(TlsPolicy.pem(dir.resolve("ca.pem").toString(),
+                dir.resolve("cert.pem").toString(), dir.resolve("key.pem").toString()));
+    }
+
+    private void bumpMtime(String name) throws Exception {
+        Files.setLastModifiedTime(dir.resolve(name), FileTime.fromMillis(System.currentTimeMillis() + 5000));
+    }
+
+    @Test
+    public void firstLoadIsAChangeThenStable() throws Exception {
+        TlsMaterialSource source = source();
+        TlsMaterialSource.RefreshOutcome first = source.refresh();
+        assertThat(first.changed()).isTrue();
+        assertThat(first.material().hasKeyMaterial()).isTrue();
+        assertThat(first.material().trustCerts()).isNotEmpty();
+
+        assertThat(source.refresh().changed()).as("no file change -> stable").isFalse();
+    }
+
+    @Test
+    public void touchWithSameContentDoesNotSignalChange() throws Exception {
+        TlsMaterialSource source = source();
+        TlsMaterial initial = source.refresh().material();
+
+        bumpMtime("cert.pem");
+        TlsMaterialSource.RefreshOutcome outcome = source.refresh();
+        assertThat(outcome.changed()).as("mtime advanced but content identical -> suppressed").isFalse();
+        assertThat(outcome.material()).isEqualTo(initial);
+    }
+
+    @Test
+    public void differentContentSignalsChange() throws Exception {
+        TlsMaterialSource source = source();
+        TlsMaterial initial = source.refresh().material();
+
+        Files.copy(Paths.get(PROXY_CERT), dir.resolve("cert.pem"), StandardCopyOption.REPLACE_EXISTING);
+        Files.copy(Paths.get(PROXY_KEY), dir.resolve("key.pem"), StandardCopyOption.REPLACE_EXISTING);
+        bumpMtime("cert.pem");
+        bumpMtime("key.pem");
+
+        TlsMaterialSource.RefreshOutcome outcome = source.refresh();
+        assertThat(outcome.changed()).isTrue();
+        assertThat(outcome.material()).isNotEqualTo(initial);
+    }
+
+    @Test
+    public void failedLoadKeepsBaselineSoNextPollRetries() throws Exception {
+        TlsMaterialSource source = source();
+        TlsMaterial good = source.refresh().material();
+
+        // Corrupt the cert: the load throws and neither the baseline nor the cached material advance.
+        Files.writeString(dir.resolve("cert.pem"), "-----BEGIN CERTIFICATE-----\ngarbage\n");
+        bumpMtime("cert.pem");
+        assertThatThrownBy(source::refresh).isInstanceOf(Exception.class);
+
+        // Because the baseline was NOT advanced on failure, a retry without any further mtime change
+        // still attempts the load again (the fix for the old advance-before-load sharp edge).
+        assertThatThrownBy(source::refresh).isInstanceOf(Exception.class);
+
+        // A subsequent good change recovers.
+        Files.copy(Paths.get(PROXY_CERT), dir.resolve("cert.pem"), StandardCopyOption.REPLACE_EXISTING);
+        Files.copy(Paths.get(PROXY_KEY), dir.resolve("key.pem"), StandardCopyOption.REPLACE_EXISTING);
+        bumpMtime("cert.pem");
+        bumpMtime("key.pem");
+        TlsMaterialSource.RefreshOutcome recovered = source.refresh();
+        assertThat(recovered.changed()).isTrue();
+        assertThat(recovered.material()).isNotEqualTo(good);
+    }
+
+    // ---- v4-parity: separate keystore/truststore types (PIP-478 P1) ----
+
+    /**
+     * A PKCS12 keystore paired with a JKS truststore must load — each store parsed with its OWN configured
+     * type. The pre-fix policy carried a single {@code storeType} applied to all three loads, which cannot
+     * express this mixed setup (and breaks outright with FIPS/BCFKS mixes or when {@code keystore.type.compat}
+     * is disabled).
+     */
+    @Test
+    public void mixedStoreTypesLoadEachWithItsOwnType() throws Exception {
+        Path pkcs12KeyStore = writePkcs12KeyStore();
+        Path jksTrustStore = writeJksTrustStore();
+
+        TlsMaterial material = new TlsMaterialSource(mixedPolicy(pkcs12KeyStore, "PKCS12", jksTrustStore, "JKS"))
+                .refresh().material();
+
+        assertThat(material.hasKeyMaterial()).as("PKCS12 keystore -> key + chain loaded").isTrue();
+        assertThat(material.trustCerts()).as("JKS truststore -> trust certs loaded").isNotEmpty();
+    }
+
+    /**
+     * The truststore must be loaded with {@code trustStoreType()}, not the keystore type. An invalid TRUST
+     * type fails the load even though the KEY type is valid — before the fix (single shared type) the good
+     * key type was used for the truststore and this would NOT have failed.
+     */
+    @Test
+    public void trustStoreTypeIsConsultedForTheTruststore() throws Exception {
+        Path pkcs12KeyStore = writePkcs12KeyStore();
+        Path jksTrustStore = writeJksTrustStore();
+        assertThatThrownBy(() ->
+                new TlsMaterialSource(mixedPolicy(pkcs12KeyStore, "PKCS12", jksTrustStore, "NOSUCHTYPE")).refresh())
+                .isInstanceOf(Exception.class);
+    }
+
+    /**
+     * Symmetrically, the keystore must be loaded with {@code keyStoreType()}: an invalid KEY type fails even
+     * though the TRUST type is valid.
+     */
+    @Test
+    public void keyStoreTypeIsConsultedForTheKeystore() throws Exception {
+        Path pkcs12KeyStore = writePkcs12KeyStore();
+        Path jksTrustStore = writeJksTrustStore();
+        assertThatThrownBy(() ->
+                new TlsMaterialSource(mixedPolicy(pkcs12KeyStore, "NOSUCHTYPE", jksTrustStore, "JKS")).refresh())
+                .isInstanceOf(Exception.class);
+    }
+
+    private static TlsPolicy mixedPolicy(Path keyStore, String keyStoreType, Path trustStore, String trustStoreType) {
+        return TlsPolicy.builder().format(TlsPolicy.Format.KEYSTORE)
+                .keyStorePath(keyStore.toString()).keyStorePassword(new String(STORE_PW)).keyStoreType(keyStoreType)
+                .trustStorePath(trustStore.toString()).trustStorePassword(new String(STORE_PW))
+                .trustStoreType(trustStoreType)
+                .build();
+    }
+
+    private Path writePkcs12KeyStore() throws Exception {
+        PrivateKey key = PemReader.loadPrivateKeyFromPemFile(BROKER_KEY);
+        X509Certificate[] chain = PemReader.loadCertificatesFromPemFile(BROKER_CERT);
+        KeyStore ks = KeyStore.getInstance("PKCS12");
+        ks.load(null, null);
+        ks.setKeyEntry("key", key, STORE_PW, chain);
+        Path path = dir.resolve("key.p12");
+        try (OutputStream out = Files.newOutputStream(path)) {
+            ks.store(out, STORE_PW);
+        }
+        return path;
+    }
+
+    private Path writeJksTrustStore() throws Exception {
+        X509Certificate[] cas = PemReader.loadCertificatesFromPemFile(CA);
+        KeyStore ks = KeyStore.getInstance("JKS");
+        ks.load(null, null);
+        for (int i = 0; i < cas.length; i++) {
+            ks.setCertificateEntry("ca" + i, cas[i]);
+        }
+        Path path = dir.resolve("trust.jks");
+        try (OutputStream out = Files.newOutputStream(path)) {
+            ks.store(out, STORE_PW);
+        }
+        return path;
+    }
+}

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/tls/impl/TlsReloadMetricsTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/tls/impl/TlsReloadMetricsTest.java
@@ -1,0 +1,202 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.tls.impl;
+
+import static org.apache.pulsar.common.tls.impl.TlsReloadMetrics.LAST_RELOAD_SUCCESS_GAUGE;
+import static org.apache.pulsar.common.tls.impl.TlsReloadMetrics.RELOAD_COUNTER;
+import static org.apache.pulsar.common.tls.impl.TlsTestSupport.resource;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import io.netty.handler.ssl.SslContext;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.data.LongPointData;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.FileTime;
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import org.apache.commons.io.FileUtils;
+import org.apache.pulsar.common.tls.TlsPolicy;
+import org.apache.pulsar.common.tls.TlsPurpose;
+import org.awaitility.Awaitility;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class TlsReloadMetricsTest {
+
+    private static final String RSA_CA = resource("certificate-authority/certs/ca.cert.pem");
+    private static final String BROKER_CERT = resource("certificate-authority/server-keys/broker.cert.pem");
+    private static final String BROKER_KEY = resource("certificate-authority/server-keys/broker.key-pk8.pem");
+    private static final String PROXY_CERT = resource("certificate-authority/server-keys/proxy.cert.pem");
+    private static final String PROXY_KEY = resource("certificate-authority/server-keys/proxy.key-pk8.pem");
+
+    private static final AttributeKey<String> PURPOSE = AttributeKey.stringKey("purpose");
+    private static final AttributeKey<String> RESULT = AttributeKey.stringKey("result");
+
+    private ScheduledExecutorService scheduler;
+    private final Executor directExecutor = Runnable::run;
+    private InMemoryMetricReader metricReader;
+    private OpenTelemetry openTelemetry;
+    private Path tempDir;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        scheduler = Executors.newSingleThreadScheduledExecutor();
+        metricReader = InMemoryMetricReader.create();
+        openTelemetry = OpenTelemetrySdk.builder()
+                .setMeterProvider(SdkMeterProvider.builder().registerMetricReader(metricReader).build())
+                .build();
+        tempDir = Files.createTempDirectory("pip478-tls-metrics-");
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void tearDown() throws Exception {
+        scheduler.shutdownNow();
+        if (tempDir != null) {
+            FileUtils.deleteDirectory(tempDir.toFile());
+        }
+    }
+
+    private FileBasedTlsFactory factory(Map<TlsPurpose, TlsPolicy> policies, FileBasedTlsFactorySettings settings) {
+        FileBasedTlsFactory factory = new FileBasedTlsFactory(policies, settings);
+        factory.initialize(TlsTestSupport.initContext(scheduler, directExecutor, openTelemetry)).join();
+        return factory;
+    }
+
+    @Test
+    public void initialLoadRecordsSuccessCounterAndGauge() throws Exception {
+        FileBasedTlsFactory factory = factory(
+                Map.of(TlsPurpose.BROKER, TlsPolicy.pem(RSA_CA, BROKER_CERT, BROKER_KEY)),
+                FileBasedTlsFactorySettings.defaults());
+
+        factory.createInstance(TlsPurpose.BROKER, SslContext.class).join().get().dispose();
+
+        Collection<MetricData> metrics = metricReader.collectAllMetrics();
+        assertThat(counter(metrics, "broker", "success")).isEqualTo(1L);
+        assertThat(counter(metrics, "broker", "failure")).isEqualTo(0L);
+        assertThat(gauge(metrics, "broker")).as("last_reload_success gauge is set on success").isPositive();
+        factory.close();
+    }
+
+    @Test
+    public void initialLoadFailureRecordsFailureCounterAndNoGauge() {
+        FileBasedTlsFactory factory = factory(
+                Map.of(TlsPurpose.BROKER, TlsPolicy.pem(RSA_CA,
+                        tempDir.resolve("missing-cert.pem").toString(),
+                        tempDir.resolve("missing-key.pem").toString())),
+                FileBasedTlsFactorySettings.defaults());
+
+        assertThatThrownBy(() -> factory.createInstance(TlsPurpose.BROKER, SslContext.class).join())
+                .isInstanceOf(Exception.class);
+
+        Collection<MetricData> metrics = metricReader.collectAllMetrics();
+        assertThat(counter(metrics, "broker", "failure")).isEqualTo(1L);
+        assertThat(counter(metrics, "broker", "success")).isEqualTo(0L);
+        assertThat(gauge(metrics, "broker")).as("no last_reload_success without a successful load").isEqualTo(-1L);
+        factory.close();
+    }
+
+    @Test
+    public void rotationRecordsSecondSuccessfulReload() throws Exception {
+        TlsPolicy policy = copyServerCertsToTemp(BROKER_CERT, BROKER_KEY);
+        FileBasedTlsFactory factory = factory(Map.of(TlsPurpose.BROKER, policy),
+                FileBasedTlsFactorySettings.builder().refreshIntervalSeconds(1).build());
+
+        factory.createInstance(TlsPurpose.BROKER, SslContext.class, new CopyOnWriteArrayList<SslContext>()::add).join();
+        assertThat(counter(metricReader.collectAllMetrics(), "broker", "success")).isEqualTo(1L);
+
+        overwriteServerCerts(PROXY_CERT, PROXY_KEY);
+        // The rotation poll delivers a rebuilt instance and records a second successful reload.
+        Awaitility.await().atMost(Duration.ofSeconds(15))
+                .untilAsserted(() -> assertThat(counter(metricReader.collectAllMetrics(), "broker", "success"))
+                        .isEqualTo(2L));
+        assertThat(counter(metricReader.collectAllMetrics(), "broker", "failure")).isEqualTo(0L);
+        factory.close();
+    }
+
+    @Test
+    public void failedRotationRecordsReloadFailure() throws Exception {
+        TlsPolicy policy = copyServerCertsToTemp(BROKER_CERT, BROKER_KEY);
+        FileBasedTlsFactory factory = factory(Map.of(TlsPurpose.BROKER, policy),
+                FileBasedTlsFactorySettings.builder().refreshIntervalSeconds(1).build());
+
+        factory.createInstance(TlsPurpose.BROKER, SslContext.class, new CopyOnWriteArrayList<SslContext>()::add).join();
+        assertThat(counter(metricReader.collectAllMetrics(), "broker", "success")).isEqualTo(1L);
+
+        // Corrupt the cert file (mtime advanced so the change is observed): the rebuild fails and is counted.
+        Files.writeString(tempDir.resolve("cert.pem"), "-----BEGIN CERTIFICATE-----\nnot a cert\n");
+        Files.setLastModifiedTime(tempDir.resolve("cert.pem"), FileTime.fromMillis(System.currentTimeMillis() + 5000));
+        Awaitility.await().atMost(Duration.ofSeconds(15))
+                .untilAsserted(() -> assertThat(counter(metricReader.collectAllMetrics(), "broker", "failure"))
+                        .isEqualTo(1L));
+        factory.close();
+    }
+
+    /** The reload counter value for a purpose+result, or 0 when the point is absent. */
+    private long counter(Collection<MetricData> metrics, String purpose, String result) {
+        return metrics.stream()
+                .filter(m -> m.getName().equals(RELOAD_COUNTER))
+                .flatMap(m -> m.getLongSumData().getPoints().stream())
+                .filter(p -> purpose.equals(p.getAttributes().get(PURPOSE))
+                        && result.equals(p.getAttributes().get(RESULT)))
+                .mapToLong(LongPointData::getValue)
+                .findFirst()
+                .orElse(0L);
+    }
+
+    /** The last-reload-success gauge (unix seconds) for a purpose, or -1 when the point is absent. */
+    private long gauge(Collection<MetricData> metrics, String purpose) {
+        return metrics.stream()
+                .filter(m -> m.getName().equals(LAST_RELOAD_SUCCESS_GAUGE))
+                .flatMap(m -> m.getLongGaugeData().getPoints().stream())
+                .filter(p -> purpose.equals(p.getAttributes().get(PURPOSE)))
+                .mapToLong(LongPointData::getValue)
+                .findFirst()
+                .orElse(-1L);
+    }
+
+    private TlsPolicy copyServerCertsToTemp(String certSrc, String keySrc) throws Exception {
+        Files.copy(Paths.get(RSA_CA), tempDir.resolve("ca.pem"), StandardCopyOption.REPLACE_EXISTING);
+        Files.copy(Paths.get(certSrc), tempDir.resolve("cert.pem"), StandardCopyOption.REPLACE_EXISTING);
+        Files.copy(Paths.get(keySrc), tempDir.resolve("key.pem"), StandardCopyOption.REPLACE_EXISTING);
+        return TlsPolicy.pem(tempDir.resolve("ca.pem").toString(),
+                tempDir.resolve("cert.pem").toString(), tempDir.resolve("key.pem").toString());
+    }
+
+    private void overwriteServerCerts(String certSrc, String keySrc) throws Exception {
+        Files.copy(Paths.get(certSrc), tempDir.resolve("cert.pem"), StandardCopyOption.REPLACE_EXISTING);
+        Files.copy(Paths.get(keySrc), tempDir.resolve("key.pem"), StandardCopyOption.REPLACE_EXISTING);
+        long later = System.currentTimeMillis() + 5000;
+        Files.setLastModifiedTime(tempDir.resolve("cert.pem"), FileTime.fromMillis(later));
+        Files.setLastModifiedTime(tempDir.resolve("key.pem"), FileTime.fromMillis(later));
+    }
+}

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/tls/impl/TlsTestSupport.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/tls/impl/TlsTestSupport.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.tls.impl;
+
+import com.google.common.io.Resources;
+import io.opentelemetry.api.OpenTelemetry;
+import java.io.File;
+import java.nio.ByteBuffer;
+import java.time.Clock;
+import java.util.Map;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledExecutorService;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLEngineResult;
+import org.apache.pulsar.common.tls.TlsFactoryInitContext;
+
+/**
+ * Shared helpers for the {@code FileBasedTlsFactory} tests: a test {@link TlsFactoryInitContext} and a
+ * self-contained in-memory {@link SSLEngine} handshake pump (no sockets, no event loops).
+ */
+final class TlsTestSupport {
+
+    private TlsTestSupport() {
+    }
+
+    static String resource(String name) {
+        return new File(Resources.getResource(name).getPath()).getAbsolutePath();
+    }
+
+    static TlsFactoryInitContext initContext(ScheduledExecutorService scheduler, Executor blockingExecutor) {
+        return initContext(scheduler, blockingExecutor, OpenTelemetry.noop());
+    }
+
+    static TlsFactoryInitContext initContext(ScheduledExecutorService scheduler, Executor blockingExecutor,
+            OpenTelemetry openTelemetry) {
+        return new TlsFactoryInitContext() {
+            @Override
+            public Map<String, String> params() {
+                return Map.of();
+            }
+
+            @Override
+            public ScheduledExecutorService scheduler() {
+                return scheduler;
+            }
+
+            @Override
+            public Executor blockingExecutor() {
+                return blockingExecutor;
+            }
+
+            @Override
+            public Clock clock() {
+                return Clock.systemUTC();
+            }
+
+            @Override
+            public OpenTelemetry openTelemetry() {
+                return openTelemetry;
+            }
+        };
+    }
+
+    /**
+     * Drive a full in-memory TLS handshake between two engines until both stop handshaking, or throw if
+     * it fails (e.g. an untrusted client certificate rejected by a secure server).
+     */
+    static void handshake(SSLEngine client, SSLEngine server) throws Exception {
+        ByteBuffer clientToServer = ByteBuffer.allocate(client.getSession().getPacketBufferSize());
+        ByteBuffer serverToClient = ByteBuffer.allocate(server.getSession().getPacketBufferSize());
+        ByteBuffer clientApp = ByteBuffer.allocate(client.getSession().getApplicationBufferSize() + 64);
+        ByteBuffer serverApp = ByteBuffer.allocate(server.getSession().getApplicationBufferSize() + 64);
+        ByteBuffer empty = ByteBuffer.allocate(0);
+
+        client.beginHandshake();
+        server.beginHandshake();
+
+        for (int i = 0; i < 200; i++) {
+            if (isDone(client) && isDone(server)) {
+                return;
+            }
+            runTasks(client.wrap(empty, clientToServer), client);
+            runTasks(server.wrap(empty, serverToClient), server);
+            clientToServer.flip();
+            serverToClient.flip();
+            runTasks(client.unwrap(serverToClient, clientApp), client);
+            runTasks(server.unwrap(clientToServer, serverApp), server);
+            clientToServer.compact();
+            serverToClient.compact();
+        }
+        throw new IllegalStateException("TLS handshake did not complete within the iteration budget");
+    }
+
+    private static boolean isDone(SSLEngine engine) {
+        SSLEngineResult.HandshakeStatus status = engine.getHandshakeStatus();
+        return status == SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING
+                || status == SSLEngineResult.HandshakeStatus.FINISHED;
+    }
+
+    private static void runTasks(SSLEngineResult result, SSLEngine engine) {
+        if (result.getHandshakeStatus() == SSLEngineResult.HandshakeStatus.NEED_TASK) {
+            Runnable task;
+            while ((task = engine.getDelegatedTask()) != null) {
+                task.run();
+            }
+        }
+    }
+}

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/FileModifiedTimeUpdaterTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/FileModifiedTimeUpdaterTest.java
@@ -18,15 +18,12 @@
  */
 package org.apache.pulsar.common.util;
 
-import static org.testng.Assert.assertTrue;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.FileTime;
-import java.util.concurrent.TimeUnit;
 import org.apache.pulsar.client.api.AuthenticationDataProvider;
-import org.awaitility.Awaitility;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -101,27 +98,6 @@ public class FileModifiedTimeUpdaterTest {
         FileTime fileTime = fileModifiedTimeUpdater.getLastModifiedTime();
         Assert.assertFalse(fileModifiedTimeUpdater.checkAndRefresh());
         Assert.assertEquals(fileTime, fileModifiedTimeUpdater.getLastModifiedTime());
-    }
-
-    @Test
-    @SuppressWarnings("try")
-    public void testNettyClientSslContextRefresher() throws Exception {
-        BasicAuthenticationData provider = new BasicAuthenticationData(null);
-        String certFile = "/tmp/cert.txt";
-        createFile(Paths.get(certFile));
-        provider.certFilePath = certFile;
-        provider.keyFilePath = certFile;
-        PulsarSslConfiguration pulsarSslConfiguration = PulsarSslConfiguration.builder()
-                .allowInsecureConnection(false).tlsTrustCertsFilePath(certFile).authData(provider).build();
-        try (PulsarSslFactory pulsarSslFactory = new DefaultPulsarSslFactory()) {
-            pulsarSslFactory.initialize(pulsarSslConfiguration);
-            Thread.sleep(5000);
-            Paths.get(certFile).toFile().delete();
-            // update the file
-            createFile(Paths.get(certFile));
-            Awaitility.await().atMost(30, TimeUnit.SECONDS).until(pulsarSslFactory::needsUpdate);
-            assertTrue(pulsarSslFactory.needsUpdate());
-        }
     }
 
 }


### PR DESCRIPTION
PR 3/7 of the PIP-478 stacked series (stacks on #235).

### Motivation

PIP-478 replaces the PIP-337 `PulsarSslFactory`/`SecurityUtility` TLS stack with a neutral SPI (added in PR 2/7) plus a default, file-based implementation. This PR adds that default implementation and its supporting primitives. It is purely **additive**: the existing PIP-337 factory (`PulsarSslFactory`, `DefaultPulsarSslFactory`, `JettySslContextFactory`, `SecurityUtility`, `KeyStoreSSLContext`) still exists and remains wired; the new code is exercised only by its own unit tests here and is wired into the client/server in later PRs (4a/4b/5). The old classes are removed in PR 6/7.

### Modifications

`pulsar-common` — `common/tls/impl/*` default TLS factory:
- `FileBasedTlsFactory` + `FileBasedTlsFactorySettings`: the default `PulsarTlsFactory` built from PEM/keystore file material.
- `TlsMaterialSource` / `MaterialSource` / `AuthProvidedMaterialSource` / `TlsMaterial`: material loading and rotation with keep-last-good semantics, rebuild-not-mutate on reload, and OpenSSL-safe pin discipline (contexts are rebuilt, never mutated in place, so a native OpenSSL engine never observes a torn context).
- `TlsContexts` / `TlsContextAcquisition` / `SynthesizedEngineSslContext` / `TlsSynthesisSpec`: SSL context assembly and per-acquisition read of the current context, plus SSLParameters companion synthesis.
- `TlsKeyStoreLoader`, `TlsFactoryProbe`, `TlsReloadMetrics`, `package-info`.

`pulsar-common` — `common/util/tls/*` primitive containers:
- `PemReader` (PEM parsing), `JcaProviders` (BouncyCastle provider accessors, new home of the `BC` constant), `JdkSslContexts` (JDK SSLContext assembly), `package-info`.

`pulsar-broker-common`:
- `broker/tls/DefaultBrokerTlsFactory` + `TlsFactorySupport`: default broker-side TLS factory composed from the existing base `tls*` fields of `ServiceConfiguration` (no new config keys — those arrive in PR 5/7).
- `jetty/tls/JettyTlsFactory`: framework Jetty reload driver built on the new factory.

`bouncy-castle`:
- `BouncyCastleLoader` / `BouncyCastleFipsLoader`: switch the static `BC` provider import from `SecurityUtility.BC` to `JcaProviders.BC`.

### Verifications

Unit-tested with real in-memory TLS handshakes and rotation (no broker, no sockets), including an OpenSSL-provider path. Key suites: `FileBasedTlsFactoryTest`, `TlsMaterialSourceTest`, `SslParametersSynthesisTest`, `TlsReloadMetricsTest`, `AuthProvidedMaterialFoldTest`, `TlsPolicyValidationTest`, `TlsPurposeTest`, `DefaultBrokerTlsFactoryTest`, `TlsFactorySupportTest`, `JettyTlsFactoryTest`.

`./gradlew :pulsar-common:build :pulsar-broker-common:build` passes (full check incl. checkstyle/spotless/license + the new unit tests).