### PR TITLE
[feat][client] PIP-478: v5 migration of the Athenz and SASL auth plugins

### DIFF
--- a/pulsar-client-auth-athenz/src/main/java/org/apache/pulsar/client/impl/auth/AuthenticationAthenz.java
+++ b/pulsar-client-auth-athenz/src/main/java/org/apache/pulsar/client/impl/auth/AuthenticationAthenz.java
@@ -51,14 +51,33 @@ import org.apache.pulsar.client.api.AuthenticationDataProvider;
 import org.apache.pulsar.client.api.EncodedAuthenticationParameterSupport;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.PulsarClientException.GettingAuthenticationDataException;
+import org.apache.pulsar.client.api.internal.AsyncAuthenticationDriver;
+import org.apache.pulsar.client.api.internal.AsyncAuthenticationDriver.AuthenticationExchange;
 import org.apache.pulsar.client.api.url.URL;
+import org.apache.pulsar.client.api.v5.internal.ClientAuthenticationServices;
+import org.apache.pulsar.client.api.v5.internal.ClientAuthenticationServicesAware;
 import org.apache.pulsar.client.impl.AuthenticationUtil;
+import org.apache.pulsar.client.impl.auth.v5.AthenzAuthenticationV5;
+import org.apache.pulsar.client.impl.auth.v5.V5BinaryAuthenticationDriver;
 
-public class AuthenticationAthenz implements Authentication, EncodedAuthenticationParameterSupport {
+/**
+ * Athenz authentication provider.
+ *
+ * <p>The verbatim v4 synchronous surface ({@link #getAuthData()} / {@link AuthenticationDataAthenz}) is
+ * preserved; PIP-478 additionally exposes {@link AsyncAuthenticationDriver} so {@code ClientCnx} can drive
+ * the role-token credential over the non-blocking binary path via the v5-native
+ * {@link AthenzAuthenticationV5}. The ZTS role-token cache stays on this shim.
+ */
+public class AuthenticationAthenz
+        implements Authentication, EncodedAuthenticationParameterSupport, AsyncAuthenticationDriver,
+        ClientAuthenticationServicesAware {
 
     private static final long serialVersionUID = 1L;
 
     private static final String APPLICATION_X_PEM_FILE = "application/x-pem-file";
+
+    // PIP-478: the client's framework services, late-bound before start(); null until then.
+    private transient volatile ClientAuthenticationServices authServices;
 
     private transient KeyRefresher keyRefresher = null;
     private transient ZTSClient ztsClient = null;
@@ -133,6 +152,53 @@ public class AuthenticationAthenz implements Authentication, EncodedAuthenticati
         // Ensure we refresh the Athenz role token every 90 minutes to avoid using an expired
         // role token
         return (System.nanoTime() - cachedRoleTokenTimestamp) < TimeUnit.MINUTES.toNanos(cacheDurationInMinutes);
+    }
+
+    @Override
+    public void bindClientAuthenticationServices(ClientAuthenticationServices services) {
+        this.authServices = services;
+    }
+
+    @Override
+    public AuthenticationExchange newAuthenticationExchange(String brokerHostName) {
+        // PIP-478: drive the v5-native Athenz body on the async binary path. The ZTS role-token cache stays
+        // on this shim; the body reads the current role token through getAuthData(), so a broker-pushed
+        // REFRESH re-acquires an expired token here exactly as the synchronous path does. The bound blocking
+        // executor off-loads that (ZTS-blocking) fetch so it never runs on the Netty event loop.
+        return new V5BinaryAuthenticationDriver(new AthenzAuthenticationV5(new ShimRoleTokenProvider(this)),
+                authServices).newAuthenticationExchange(brokerHostName);
+    }
+
+    @SuppressWarnings("deprecation")
+    private String currentRoleToken() {
+        try {
+            return getAuthData().getCommandData();
+        } catch (PulsarClientException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private String currentRoleHeaderName() {
+        return isNotBlank(roleHeader) ? roleHeader : ZTSClient.getHeader();
+    }
+
+    private static final class ShimRoleTokenProvider implements AthenzAuthenticationV5.RoleTokenProvider {
+        private static final long serialVersionUID = 1L;
+        private final AuthenticationAthenz shim;
+
+        ShimRoleTokenProvider(AuthenticationAthenz shim) {
+            this.shim = shim;
+        }
+
+        @Override
+        public String roleToken() {
+            return shim.currentRoleToken();
+        }
+
+        @Override
+        public String roleHeaderName() {
+            return shim.currentRoleHeaderName();
+        }
     }
 
     @Override

--- a/pulsar-client-auth-athenz/src/main/java/org/apache/pulsar/client/impl/auth/v5/AthenzAuthenticationV5.java
+++ b/pulsar-client-auth-athenz/src/main/java/org/apache/pulsar/client/impl/auth/v5/AthenzAuthenticationV5.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl.auth.v5;
+
+import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import org.apache.pulsar.client.api.v5.auth.AuthenticationCallContext;
+import org.apache.pulsar.client.api.v5.auth.AuthenticationInitContext;
+import org.apache.pulsar.client.api.v5.auth.BinaryAuthData;
+import org.apache.pulsar.client.api.v5.auth.HttpAuthCallContext;
+import org.apache.pulsar.client.api.v5.auth.HttpAuthHeaders;
+import org.apache.pulsar.client.api.v5.auth.SinglePassAuthentication;
+
+/**
+ * v5-native Athenz authentication (PIP-478). A single-pass credential served over both transports: the
+ * binary protocol sends the current ZTS role token as {@code auth_data}, and HTTP sends the role token
+ * under the configured Athenz role header. The built-in v4 {@code AuthenticationAthenz} drives this body
+ * on the async binary path; the ZTS role-token acquisition and the 90-minute role-token cache remain on
+ * the v4 shim, which supplies the current role token and the HTTP role header to this body via the
+ * role-token provider.
+ *
+ * <p>Role-token acquisition performs network I/O. As with the existing v4 Athenz code, the provider may
+ * block on the ZTS client; off-loading the blocking call belongs to the framework layer, so
+ * this body introduces no threading of its own.
+ *
+ * <p>Although the v5 {@code Authentication} SPI deliberately does not extend {@link Serializable}, this
+ * concrete built-in body is serializable so the v4 {@code AuthenticationAthenz} shim (whose interface
+ * requires {@code Serializable}, for Functions/connector frameworks) round-trips. The role-token provider
+ * is itself serializable.
+ */
+public class AthenzAuthenticationV5 implements SinglePassAuthentication, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    /** The stable auth-method name. */
+    public static final String AUTH_METHOD_NAME = "athenz";
+
+    private final RoleTokenProvider roleTokenProvider;
+
+    // Late-bound at initializeAsync(...): the client's bounded blocking executor, onto which the
+    // (ZTS-blocking) role-token fetch is off-loaded so it never runs on the Netty event loop
+    // (PIP-478). Null when used outside a client, in which case the fetch runs inline.
+    private transient volatile Executor blockingExecutor;
+
+    /**
+     * @param roleTokenProvider supplies the current role token and its HTTP header name on each call
+     */
+    public AthenzAuthenticationV5(RoleTokenProvider roleTokenProvider) {
+        this.roleTokenProvider = roleTokenProvider;
+    }
+
+    @Override
+    public String authMethodName() {
+        return AUTH_METHOD_NAME;
+    }
+
+    @Override
+    public CompletableFuture<Void> initializeAsync(AuthenticationInitContext ctx) {
+        this.blockingExecutor = ctx.blockingExecutor();
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletableFuture<BinaryAuthData> getAuthDataAsync(AuthenticationCallContext ctx) {
+        return V5AuthContexts.supplyBlocking(blockingExecutor,
+                () -> new BinaryAuthData(roleTokenProvider.roleToken().getBytes(StandardCharsets.UTF_8)));
+    }
+
+    @Override
+    public CompletableFuture<HttpAuthHeaders> getHttpHeadersAsync(HttpAuthCallContext ctx) {
+        return V5AuthContexts.supplyBlocking(blockingExecutor, () -> {
+            Map<String, String> headers = new LinkedHashMap<>();
+            headers.put(roleTokenProvider.roleHeaderName(), roleTokenProvider.roleToken());
+            return HttpAuthHeaders.of(headers);
+        });
+    }
+
+    @Override
+    public void close() {
+    }
+
+    /**
+     * Supplies the current Athenz role token (acquiring/refreshing as needed) and the HTTP header name
+     * under which it is sent. Implementations must be serializable.
+     */
+    public interface RoleTokenProvider extends Serializable {
+        /**
+         * @return the current ZTS role token
+         */
+        String roleToken();
+
+        /**
+         * @return the HTTP header name carrying the role token
+         */
+        String roleHeaderName();
+    }
+}

--- a/pulsar-client-auth-athenz/src/main/java/org/apache/pulsar/client/impl/auth/v5/package-info.java
+++ b/pulsar-client-auth-athenz/src/main/java/org/apache/pulsar/client/impl/auth/v5/package-info.java
@@ -16,20 +16,10 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
-plugins {
-    id("pulsar.public-java-library-conventions")
-}
-
-dependencies {
-    implementation(libs.slog)
-    compileOnly(project(":pulsar-client-original"))
-    implementation(project(":pulsar-common"))
-    implementation(libs.guava)
-    implementation(libs.commons.lang3)
-    implementation(libs.jakarta.ws.rs.api)
-    implementation(libs.jersey.client)
-    // PIP-478 stage 3d: the SASL-over-HTTP conversation test drives the real SaslAuthenticationV5 body
-    // through the framework HttpAuthenticationDriver (both live in pulsar-client-original).
-    testImplementation(project(":pulsar-client-original"))
-}
+/**
+ * v5-native implementation of the built-in Athenz authentication plugin (PIP-478). The v4
+ * {@code AuthenticationAthenz} class in the parent package is a thin shim that keeps its verbatim
+ * synchronous surface and drives {@link org.apache.pulsar.client.impl.auth.v5.AthenzAuthenticationV5} on
+ * the async binary path via the shared {@code V5BinaryAuthenticationDriver}.
+ */
+package org.apache.pulsar.client.impl.auth.v5;

--- a/pulsar-client-auth-sasl/src/main/java/org/apache/pulsar/client/impl/auth/AuthenticationSasl.java
+++ b/pulsar-client-auth-sasl/src/main/java/org/apache/pulsar/client/impl/auth/AuthenticationSasl.java
@@ -38,10 +38,14 @@ import static org.apache.pulsar.common.sasl.SaslConstants.SASL_STATE_SERVER_CHEC
 import static org.apache.pulsar.common.sasl.SaslConstants.SASL_TYPE_VALUE;
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.net.URI;
+import java.time.Duration;
 import java.util.Base64;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import javax.security.auth.login.LoginException;
@@ -58,8 +62,18 @@ import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.AuthenticationDataProvider;
 import org.apache.pulsar.client.api.EncodedAuthenticationParameterSupport;
 import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.internal.AsyncAuthenticationDriver;
+import org.apache.pulsar.client.api.internal.AsyncAuthenticationDriver.AuthenticationExchange;
+import org.apache.pulsar.client.api.v5.auth.HttpAuthHeaders;
+import org.apache.pulsar.client.api.v5.internal.ClientAuthenticationServices;
+import org.apache.pulsar.client.api.v5.internal.ClientAuthenticationServicesAware;
 import org.apache.pulsar.client.impl.AuthenticationUtil;
 import org.apache.pulsar.client.impl.auth.PulsarSaslClient.ClientCallbackHandler;
+import org.apache.pulsar.client.impl.auth.v5.AsyncHttpAuthenticationProvider;
+import org.apache.pulsar.client.impl.auth.v5.HttpAuthenticationDriver;
+import org.apache.pulsar.client.impl.auth.v5.HttpChallengeTransport;
+import org.apache.pulsar.client.impl.auth.v5.SaslAuthenticationV5;
+import org.apache.pulsar.client.impl.auth.v5.V5BinaryAuthenticationDriver;
 import org.apache.pulsar.common.api.AuthData;
 import org.apache.pulsar.common.sasl.JAASCredentialsContainer;
 
@@ -71,7 +85,9 @@ import org.apache.pulsar.common.sasl.JAASCredentialsContainer;
  *   for Kerberos a krb5.conf, which is set by `-Djava.security.krb5.conf=/dir/krb5.conf`
  */
 @CustomLog
-public class AuthenticationSasl implements Authentication, EncodedAuthenticationParameterSupport {
+public class AuthenticationSasl
+        implements Authentication, EncodedAuthenticationParameterSupport, AsyncAuthenticationDriver,
+        AsyncHttpAuthenticationProvider, ClientAuthenticationServicesAware {
     private static final long serialVersionUID = 1L;
     // this is a static object that shares amongst client.
     private static JAASCredentialsContainer jaasCredentialsContainer;
@@ -80,6 +96,12 @@ public class AuthenticationSasl implements Authentication, EncodedAuthentication
     private Map<String, String> configuration;
     private String loginContextName;
     private String serverType = null;
+    // PIP-478: the client's framework services, late-bound before start(); null until then.
+    private transient volatile ClientAuthenticationServices authServices;
+    // PIP-478: the framework HTTP auth driver for the SASL-over-HTTP flow, created lazily on the
+    // first HTTP request after start(). Its default transport is this plugin's own JAX-RS client (the
+    // faithful admin-path transport; the lookup path supplies its shared AsyncHttpClient instead).
+    private transient volatile HttpAuthenticationDriver httpAuthenticationDriver;
 
     public AuthenticationSasl() {
     }
@@ -99,6 +121,101 @@ public class AuthenticationSasl implements Authentication, EncodedAuthentication
         } catch (Throwable t) {
             log.error().exception(t).log("Failed create sasl client");
             throw new PulsarClientException(t);
+        }
+    }
+
+    @Override
+    public void bindClientAuthenticationServices(ClientAuthenticationServices services) {
+        this.authServices = services;
+    }
+
+    @Override
+    public AuthenticationExchange newAuthenticationExchange(String brokerHostName) {
+        // PIP-478: drive the v5-native SASL body on the async binary path. Each connection attempt gets a
+        // fresh exchange whose call-context state slot holds the per-broker PulsarSaslClient across the
+        // multi-round handshake; the SASL-over-HTTP loop stays on this shim.
+        return new V5BinaryAuthenticationDriver(new SaslAuthenticationV5(new ShimSaslProviderFactory(this)),
+                authServices).newAuthenticationExchange(brokerHostName);
+    }
+
+    @Override
+    public Optional<HttpAuthenticationDriver> httpAuthenticationDriver() {
+        // PIP-478: expose the v5-native SASL-over-HTTP body to the framework HTTP auth driver so the
+        // HTTP callers route the 401->resubmit->200 exchange through the shared state machine instead of the
+        // deprecated authenticationStage(...) hook (which stays for third-party v4 plugins). The default
+        // transport is this plugin's own JAX-RS client — exactly what authenticationStage(...) uses today.
+        HttpAuthenticationDriver driver = httpAuthenticationDriver;
+        if (driver == null) {
+            synchronized (this) {
+                driver = httpAuthenticationDriver;
+                if (driver == null) {
+                    driver = new HttpAuthenticationDriver(
+                            new SaslAuthenticationV5(new ShimSaslProviderFactory(this)),
+                            authServices, new JaxRsChallengeTransport());
+                    httpAuthenticationDriver = driver;
+                }
+            }
+        }
+        return Optional.of(driver);
+    }
+
+    /**
+     * A {@link HttpChallengeTransport} backed by this plugin's own JAX-RS {@link Client} (created in
+     * {@link #start()}) — the faithful transport for the admin-path SASL warmup, matching what
+     * {@code authenticationStage(...)} does today. Each round is a bodiless {@code GET} to the original URI.
+     * The per-request {@code timeout} is not applied to the JAX-RS request (the driver's overall
+     * timeout-budget guard bounds the exchange between rounds); the client's own connect/read timeouts apply.
+     */
+    private final class JaxRsChallengeTransport implements HttpChallengeTransport {
+        @Override
+        public CompletableFuture<Result> get(URI uri, HttpAuthHeaders requestHeaders, Duration timeout) {
+            CompletableFuture<Result> future = new CompletableFuture<>();
+            try {
+                Client c = client;
+                if (c == null) {
+                    throw new IllegalStateException("SASL authentication HTTP client is not started");
+                }
+                Builder builder = c.target(uri).request(MediaType.APPLICATION_JSON);
+                requestHeaders.asMap().forEach(builder::header);
+                builder.async().get(new InvocationCallback<Response>() {
+                    @Override
+                    public void completed(Response response) {
+                        future.complete(new Result(response.getStatus(), toHeaders(response)));
+                    }
+
+                    @Override
+                    public void failed(Throwable throwable) {
+                        future.completeExceptionally(throwable);
+                    }
+                });
+            } catch (Throwable t) {
+                future.completeExceptionally(t);
+            }
+            return future;
+        }
+
+        private HttpAuthHeaders toHeaders(Response response) {
+            Map<String, String> headers = new LinkedHashMap<>();
+            response.getStringHeaders().forEach((name, values) -> {
+                if (values != null && !values.isEmpty() && values.get(0) != null) {
+                    headers.put(name, values.get(0));
+                }
+            });
+            return HttpAuthHeaders.of(headers);
+        }
+    }
+
+    private static final class ShimSaslProviderFactory implements SaslAuthenticationV5.SaslProviderFactory {
+        private static final long serialVersionUID = 1L;
+        private final AuthenticationSasl shim;
+
+        ShimSaslProviderFactory(AuthenticationSasl shim) {
+            this.shim = shim;
+        }
+
+        @Override
+        public AuthenticationDataProvider create(String brokerHost) throws Exception {
+            return shim.getAuthData(brokerHost);
         }
     }
 
@@ -167,6 +284,8 @@ public class AuthenticationSasl implements Authentication, EncodedAuthentication
             client.close();
             client = null;
         }
+        // Drop the cached HTTP driver; its default transport captured the now-closed JAX-RS client.
+        httpAuthenticationDriver = null;
         if (jaasCredentialsContainer != null) {
             jaasCredentialsContainer.close();
             jaasCredentialsContainer = null;

--- a/pulsar-client-auth-sasl/src/main/java/org/apache/pulsar/client/impl/auth/v5/SaslAuthenticationV5.java
+++ b/pulsar-client-auth-sasl/src/main/java/org/apache/pulsar/client/impl/auth/v5/SaslAuthenticationV5.java
@@ -1,0 +1,275 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl.auth.v5;
+
+import static org.apache.pulsar.common.sasl.SaslConstants.SASL_AUTH_ROLE_TOKEN;
+import static org.apache.pulsar.common.sasl.SaslConstants.SASL_AUTH_ROLE_TOKEN_EXPIRED;
+import static org.apache.pulsar.common.sasl.SaslConstants.SASL_AUTH_TOKEN;
+import static org.apache.pulsar.common.sasl.SaslConstants.SASL_HEADER_STATE;
+import static org.apache.pulsar.common.sasl.SaslConstants.SASL_HEADER_TYPE;
+import static org.apache.pulsar.common.sasl.SaslConstants.SASL_STATE_CLIENT_INIT;
+import static org.apache.pulsar.common.sasl.SaslConstants.SASL_STATE_COMPLETE;
+import static org.apache.pulsar.common.sasl.SaslConstants.SASL_STATE_NEGOTIATE;
+import static org.apache.pulsar.common.sasl.SaslConstants.SASL_STATE_SERVER;
+import static org.apache.pulsar.common.sasl.SaslConstants.SASL_STATE_SERVER_CHECK_TOKEN;
+import static org.apache.pulsar.common.sasl.SaslConstants.SASL_TYPE_VALUE;
+import java.io.Serializable;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import org.apache.pulsar.client.api.AuthenticationDataProvider;
+import org.apache.pulsar.client.api.v5.PulsarClientException;
+import org.apache.pulsar.client.api.v5.auth.AuthChallenge;
+import org.apache.pulsar.client.api.v5.auth.Authentication;
+import org.apache.pulsar.client.api.v5.auth.AuthenticationCallContext;
+import org.apache.pulsar.client.api.v5.auth.AuthenticationInitContext;
+import org.apache.pulsar.client.api.v5.auth.BinaryAuthChallengeHandler;
+import org.apache.pulsar.client.api.v5.auth.BinaryAuthData;
+import org.apache.pulsar.client.api.v5.auth.BinaryAuthDataProvider;
+import org.apache.pulsar.client.api.v5.auth.ChallengeResponse;
+import org.apache.pulsar.client.api.v5.auth.HttpAuthCallContext;
+import org.apache.pulsar.client.api.v5.auth.HttpAuthChallengeHandler;
+import org.apache.pulsar.client.api.v5.auth.HttpAuthHeaders;
+import org.apache.pulsar.client.api.v5.auth.HttpAuthHeadersProvider;
+import org.apache.pulsar.common.api.AuthData;
+import org.apache.pulsar.common.sasl.SaslConstants;
+
+/**
+ * v5-native SASL authentication for the Pulsar binary protocol (PIP-478). SASL is a multi-round
+ * challenge/response handshake, so this body implements {@link BinaryAuthDataProvider} for the initial
+ * {@code CommandConnect} credential and {@link BinaryAuthChallengeHandler} for each subsequent
+ * {@code CommandAuthChallenge}. The per-exchange SASL conversation state (an
+ * {@link AuthenticationDataProvider} wrapping a {@code PulsarSaslClient}) is created on the initial call
+ * and kept in the call-context state slot so each broker handshake stays isolated.
+ *
+ * <p>The same body also serves the SASL-over-HTTP flow: it implements {@link HttpAuthChallengeHandler}
+ * (the SASL-style {@code 401}-carrying-custom-headers multi-round exchange) and {@link HttpAuthHeadersProvider}
+ * (the validated role-token replay onto the real request). The framework HTTP auth driver runs the
+ * {@code 401}→resubmit→{@code 200} loop; this body only computes each round's headers, porting the v4
+ * {@code AuthenticationSasl.newRequestHeader} / {@code getHeaders} state machine. Its per-exchange
+ * conversation (the {@code PulsarSaslClient} wrapper plus the captured role token) lives in the HTTP
+ * call-context state slot, so concurrent HTTP handshakes stay isolated. A fresh per-exchange SASL provider
+ * is obtained through the serializable {@link SaslProviderFactory} supplied by the shim (it reads the
+ * shim's JAAS subject and server type).
+ *
+ * <p>Although the v5 {@code Authentication} SPI deliberately does not extend {@link Serializable}, this
+ * concrete built-in body is serializable so the v4 {@code AuthenticationSasl} shim (whose interface
+ * requires {@code Serializable}, for Functions/connector frameworks) round-trips. The provider factory is
+ * itself serializable.
+ */
+public class SaslAuthenticationV5 implements Authentication, BinaryAuthDataProvider,
+        BinaryAuthChallengeHandler, HttpAuthChallengeHandler, HttpAuthHeadersProvider, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    /** The stable auth-method name. */
+    public static final String AUTH_METHOD_NAME = SaslConstants.AUTH_METHOD_NAME;
+
+    private final SaslProviderFactory providerFactory;
+
+    /**
+     * @param providerFactory creates a fresh per-exchange SASL data provider for a broker host
+     */
+    public SaslAuthenticationV5(SaslProviderFactory providerFactory) {
+        this.providerFactory = providerFactory;
+    }
+
+    @Override
+    public String authMethodName() {
+        return AUTH_METHOD_NAME;
+    }
+
+    @Override
+    public CompletableFuture<Void> initializeAsync(AuthenticationInitContext ctx) {
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletableFuture<BinaryAuthData> getAuthDataAsync(AuthenticationCallContext ctx) {
+        try {
+            AuthenticationDataProvider provider = providerFactory.create(ctx.brokerHost());
+            ctx.setStateObject(AuthenticationDataProvider.class, provider);
+            AuthData initData = provider.authenticate(AuthData.INIT_AUTH_DATA);
+            return CompletableFuture.completedFuture(new BinaryAuthData(initData.getBytes()));
+        } catch (Throwable t) {
+            return CompletableFuture.failedFuture(t);
+        }
+    }
+
+    @Override
+    public CompletableFuture<ChallengeResponse> respondToChallengeAsync(AuthenticationCallContext ctx,
+                                                                        AuthChallenge authChallenge) {
+        try {
+            AuthenticationDataProvider provider = ctx.getStateObject(AuthenticationDataProvider.class).orElse(null);
+            if (provider == null) {
+                // No prior state (e.g. a broker-pushed challenge without a preceding connect call on this
+                // context); start a fresh SASL exchange.
+                provider = providerFactory.create(ctx.brokerHost());
+                ctx.setStateObject(AuthenticationDataProvider.class, provider);
+            }
+            AuthData response = provider.authenticate(AuthData.of(authChallenge.bytes()));
+            return CompletableFuture.completedFuture(new ChallengeResponse(response.getBytes()));
+        } catch (Throwable t) {
+            return CompletableFuture.failedFuture(t);
+        }
+    }
+
+    // ---- SASL-over-HTTP: HttpAuthChallengeHandler + HttpAuthHeadersProvider (PIP-478) ----
+    //
+    // Ports AuthenticationSasl.newRequestHeader / getHeaders. The framework driver runs the
+    // 401->resubmit->200 loop (bodiless GET to the original URI); respondToHttpChallengeAsync computes each
+    // round's request headers from the server's prior response, and getHttpHeadersAsync produces the real
+    // request's headers (the validated role token). Cross-round state (the PulsarSaslClient conversation
+    // plus the role token) lives in the call-context state slot, keyed by SaslHttpConversation.
+
+    /**
+     * The per-exchange SASL-over-HTTP conversation held in the HTTP call-context state slot: the
+     * {@link AuthenticationDataProvider} wrapping this exchange's {@code PulsarSaslClient}, and the role
+     * token once the server has issued it.
+     */
+    private static final class SaslHttpConversation {
+        private AuthenticationDataProvider provider;
+        private String roleToken;
+    }
+
+    @Override
+    public CompletableFuture<HttpAuthHeaders> respondToHttpChallengeAsync(HttpAuthCallContext ctx) {
+        try {
+            SaslHttpConversation conv = conversation(ctx);
+            // The server carries its prior response's SASL headers here (empty on the first round).
+            boolean hasPrevious = ctx.serverChallengeHeaders().isPresent();
+            // Capture the role token if the server has issued it (the terminal 200 also carries it).
+            String issuedRoleToken = header(ctx, SASL_AUTH_ROLE_TOKEN);
+            if (issuedRoleToken != null) {
+                conv.roleToken = issuedRoleToken;
+            }
+
+            Map<String, String> headers = new LinkedHashMap<>();
+            // The SASL data provider's HTTP headers (SASL-Type: Kerberos), on every request.
+            conv.provider.getHttpHeaders().forEach(e -> headers.put(e.getKey(), e.getValue()));
+
+            // Role token exists but the server reported it expired: drop it and restart the SASL exchange.
+            if (isRoleTokenExpired(conv, ctx)) {
+                hasPrevious = false;
+                conv.roleToken = null;
+                conv.provider = providerFactory.create(host(ctx));
+            }
+
+            // Role token in hand: replay it, asking the server to check / negotiate / complete.
+            if (conv.roleToken != null) {
+                headers.put(SASL_AUTH_ROLE_TOKEN, conv.roleToken);
+                if (!hasPrevious) {
+                    headers.put(SASL_HEADER_STATE, SASL_STATE_SERVER_CHECK_TOKEN);
+                } else if (SASL_STATE_COMPLETE.equalsIgnoreCase(header(ctx, SASL_HEADER_STATE))) {
+                    headers.put(SASL_HEADER_STATE, SASL_STATE_COMPLETE);
+                } else {
+                    headers.put(SASL_HEADER_STATE, SASL_STATE_NEGOTIATE);
+                }
+                return CompletableFuture.completedFuture(HttpAuthHeaders.of(headers));
+            }
+
+            // No role token yet: run the SASL negotiation.
+            if (!hasPrevious) {
+                headers.put(SASL_HEADER_STATE, SASL_STATE_CLIENT_INIT);
+                AuthData initData = conv.provider.authenticate(AuthData.INIT_AUTH_DATA);
+                headers.put(SASL_AUTH_TOKEN, Base64.getEncoder().encodeToString(initData.getBytes()));
+            } else {
+                AuthData brokerData = AuthData.of(Base64.getDecoder().decode(header(ctx, SASL_AUTH_TOKEN)));
+                AuthData clientData = conv.provider.authenticate(brokerData);
+                headers.put(SASL_STATE_SERVER, header(ctx, SASL_STATE_SERVER));
+                headers.put(SASL_HEADER_TYPE, SASL_TYPE_VALUE);
+                headers.put(SASL_HEADER_STATE, SASL_STATE_NEGOTIATE);
+                headers.put(SASL_AUTH_TOKEN, Base64.getEncoder().encodeToString(clientData.getBytes()));
+            }
+            return CompletableFuture.completedFuture(HttpAuthHeaders.of(headers));
+        } catch (Throwable t) {
+            return CompletableFuture.failedFuture(t);
+        }
+    }
+
+    @Override
+    public CompletableFuture<HttpAuthHeaders> getHttpHeadersAsync(HttpAuthCallContext ctx) {
+        try {
+            SaslHttpConversation conv = ctx.getStateObject(SaslHttpConversation.class).orElse(null);
+            // The role token arrives on the terminal 200 response; fall back to any captured during rounds.
+            String roleToken = header(ctx, SASL_AUTH_ROLE_TOKEN);
+            if (roleToken == null && conv != null) {
+                roleToken = conv.roleToken;
+            }
+            if (roleToken == null) {
+                return CompletableFuture.failedFuture(new PulsarClientException.AuthenticationException(
+                        "SASL over HTTP exchange completed without issuing a role token"));
+            }
+            if (conv != null) {
+                conv.roleToken = roleToken;
+            }
+            Map<String, String> headers = new LinkedHashMap<>();
+            headers.put(SASL_HEADER_TYPE, SASL_TYPE_VALUE);
+            headers.put(SASL_AUTH_ROLE_TOKEN, roleToken);
+            headers.put(SASL_HEADER_STATE, SASL_STATE_COMPLETE);
+            return CompletableFuture.completedFuture(HttpAuthHeaders.of(headers));
+        } catch (Throwable t) {
+            return CompletableFuture.failedFuture(t);
+        }
+    }
+
+    private SaslHttpConversation conversation(HttpAuthCallContext ctx) throws Exception {
+        SaslHttpConversation conv = ctx.getStateObject(SaslHttpConversation.class).orElse(null);
+        if (conv == null) {
+            conv = new SaslHttpConversation();
+            conv.provider = providerFactory.create(host(ctx));
+            ctx.setStateObject(SaslHttpConversation.class, conv);
+        }
+        return conv;
+    }
+
+    // Mirrors AuthenticationSasl.isRoleTokenExpired: a role token exists and the server's prior response
+    // is a Kerberos SASL response whose State reports the role token expired.
+    private static boolean isRoleTokenExpired(SaslHttpConversation conv, HttpAuthCallContext ctx) {
+        return conv.roleToken != null
+                && SASL_TYPE_VALUE.equalsIgnoreCase(header(ctx, SASL_HEADER_TYPE))
+                && SASL_AUTH_ROLE_TOKEN_EXPIRED.equalsIgnoreCase(header(ctx, SASL_HEADER_STATE));
+    }
+
+    private static String header(HttpAuthCallContext ctx, String name) {
+        return ctx.serverChallengeHeaders().flatMap(h -> h.get(name)).orElse(null);
+    }
+
+    private static String host(HttpAuthCallContext ctx) {
+        return ctx.requestUri() == null ? null : ctx.requestUri().getHost();
+    }
+
+    @Override
+    public void close() {
+    }
+
+    /**
+     * Creates a fresh per-exchange SASL {@link AuthenticationDataProvider} (wrapping a new
+     * {@code PulsarSaslClient}) for a given broker host. Implementations must be serializable.
+     */
+    public interface SaslProviderFactory extends Serializable {
+        /**
+         * @param brokerHost the broker host the SASL client authenticates against
+         * @return a fresh SASL data provider for this exchange
+         * @throws Exception if the SASL client could not be created
+         */
+        AuthenticationDataProvider create(String brokerHost) throws Exception;
+    }
+}

--- a/pulsar-client-auth-sasl/src/main/java/org/apache/pulsar/client/impl/auth/v5/package-info.java
+++ b/pulsar-client-auth-sasl/src/main/java/org/apache/pulsar/client/impl/auth/v5/package-info.java
@@ -16,20 +16,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
-plugins {
-    id("pulsar.public-java-library-conventions")
-}
-
-dependencies {
-    implementation(libs.slog)
-    compileOnly(project(":pulsar-client-original"))
-    implementation(project(":pulsar-common"))
-    implementation(libs.guava)
-    implementation(libs.commons.lang3)
-    implementation(libs.jakarta.ws.rs.api)
-    implementation(libs.jersey.client)
-    // PIP-478 stage 3d: the SASL-over-HTTP conversation test drives the real SaslAuthenticationV5 body
-    // through the framework HttpAuthenticationDriver (both live in pulsar-client-original).
-    testImplementation(project(":pulsar-client-original"))
-}
+/**
+ * v5-native binary-protocol implementation of the built-in SASL authentication plugin (PIP-478). The v4
+ * {@code AuthenticationSasl} class in the parent package is a shim that keeps its verbatim synchronous
+ * surface (including the SASL-over-HTTP loop) and drives
+ * {@link org.apache.pulsar.client.impl.auth.v5.SaslAuthenticationV5} on the async binary path via the
+ * shared {@code V5BinaryAuthenticationDriver}.
+ */
+package org.apache.pulsar.client.impl.auth.v5;

--- a/pulsar-client-auth-sasl/src/test/java/org/apache/pulsar/client/impl/auth/v5/SaslAuthenticationV5HttpTest.java
+++ b/pulsar-client-auth-sasl/src/test/java/org/apache/pulsar/client/impl/auth/v5/SaslAuthenticationV5HttpTest.java
@@ -1,0 +1,192 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl.auth.v5;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.pulsar.common.sasl.SaslConstants.SASL_AUTH_ROLE_TOKEN;
+import static org.apache.pulsar.common.sasl.SaslConstants.SASL_AUTH_TOKEN;
+import static org.apache.pulsar.common.sasl.SaslConstants.SASL_HEADER_STATE;
+import static org.apache.pulsar.common.sasl.SaslConstants.SASL_HEADER_TYPE;
+import static org.apache.pulsar.common.sasl.SaslConstants.SASL_STATE_CLIENT_INIT;
+import static org.apache.pulsar.common.sasl.SaslConstants.SASL_STATE_COMPLETE;
+import static org.apache.pulsar.common.sasl.SaslConstants.SASL_STATE_NEGOTIATE;
+import static org.apache.pulsar.common.sasl.SaslConstants.SASL_STATE_SERVER;
+import static org.apache.pulsar.common.sasl.SaslConstants.SASL_TYPE_VALUE;
+import static org.assertj.core.api.Assertions.assertThat;
+import java.net.URI;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import org.apache.pulsar.client.api.AuthenticationDataProvider;
+import org.apache.pulsar.client.api.v5.auth.HttpAuthHeaders;
+import org.apache.pulsar.common.api.AuthData;
+import org.testng.annotations.Test;
+
+/**
+ * PIP-478 stage 3d: drive the real {@link SaslAuthenticationV5} SASL-over-HTTP body through the real
+ * {@link HttpAuthenticationDriver}, backed by a fake client-side SASL provider and a fake server transport
+ * that mimics {@code AuthenticationProviderSasl.authenticateHttpRequest}. This exercises the ported header
+ * state machine ({@code Init} → {@code ING} → {@code Done}, {@code SASL-Token} / {@code SASL-Server-ID} /
+ * role token) and, crucially, the state-slot persistence: one {@code PulsarSaslClient} conversation must
+ * span every round of one exchange and survive into the final role-token replay — no Kerberos or network.
+ */
+public class SaslAuthenticationV5HttpTest {
+
+    private static final URI ADMIN_URI = URI.create("https://broker.example:8443/admin/v2/tenants/x");
+
+    @Test
+    public void twoRoundExchangeReplaysRoleToken() throws Exception {
+        CountingFactory factory = new CountingFactory();
+        FakeSaslServer server = new FakeSaslServer(2, "role-token-abc");
+        HttpAuthenticationDriver driver =
+                new HttpAuthenticationDriver(new SaslAuthenticationV5(factory), null, server);
+
+        HttpAuthHeaders realRequestHeaders = driver.authenticateAsync(ADMIN_URI, null, Duration.ofSeconds(30)).get();
+
+        // The real request replays the validated role token with State=Done and the SASL type header.
+        assertThat(realRequestHeaders.get(SASL_AUTH_ROLE_TOKEN)).hasValue("role-token-abc");
+        assertThat(realRequestHeaders.get(SASL_HEADER_STATE)).hasValue(SASL_STATE_COMPLETE);
+        assertThat(realRequestHeaders.get(SASL_HEADER_TYPE)).hasValue(SASL_TYPE_VALUE);
+
+        // Exactly one PulsarSaslClient conversation was created for the whole exchange (state-slot persistence)
+        // and it advanced twice — the INIT frame plus one negotiation round.
+        assertThat(factory.createCalls).isEqualTo(1);
+        assertThat(factory.created.get(0).authenticateCalls).isEqualTo(2);
+
+        // The two warmup rounds were bodiless GETs to the original URI, carrying Init then ING.
+        assertThat(server.uris).hasSize(2).allMatch(ADMIN_URI::equals);
+        assertThat(server.requestStates).containsExactly(SASL_STATE_CLIENT_INIT, SASL_STATE_NEGOTIATE);
+
+        // Round 1 carried the initial SASL token; round 2 echoed the server id and carried the next token.
+        assertThat(server.requests.get(0).get(SASL_AUTH_TOKEN)).isPresent();
+        assertThat(server.requests.get(0).get(SASL_HEADER_TYPE)).hasValue(SASL_TYPE_VALUE);
+        assertThat(server.requests.get(1).get(SASL_STATE_SERVER)).hasValue("1");
+        assertThat(server.requests.get(1).get(SASL_AUTH_TOKEN)).isPresent();
+    }
+
+    @Test
+    public void singleRoundExchangeCompletesImmediately() throws Exception {
+        CountingFactory factory = new CountingFactory();
+        FakeSaslServer server = new FakeSaslServer(1, "rt-1");
+        HttpAuthenticationDriver driver =
+                new HttpAuthenticationDriver(new SaslAuthenticationV5(factory), null, server);
+
+        HttpAuthHeaders realRequestHeaders = driver.authenticateAsync(ADMIN_URI, null, Duration.ofSeconds(30)).get();
+
+        assertThat(realRequestHeaders.get(SASL_AUTH_ROLE_TOKEN)).hasValue("rt-1");
+        assertThat(realRequestHeaders.get(SASL_HEADER_STATE)).hasValue(SASL_STATE_COMPLETE);
+        assertThat(factory.createCalls).isEqualTo(1);
+        assertThat(factory.created.get(0).authenticateCalls).isEqualTo(1);
+        assertThat(server.requestStates).containsExactly(SASL_STATE_CLIENT_INIT);
+    }
+
+    // ---- fakes ----
+
+    /** The client-side SASL data provider: deterministic tokens, no Kerberos; counts advances. */
+    private static final class FakeSaslClient implements AuthenticationDataProvider {
+        private static final long serialVersionUID = 1L;
+        int authenticateCalls;
+
+        @Override
+        public boolean hasDataForHttp() {
+            return true;
+        }
+
+        @Override
+        public Set<Entry<String, String>> getHttpHeaders() {
+            return Collections.singletonMap(SASL_HEADER_TYPE, SASL_TYPE_VALUE).entrySet();
+        }
+
+        @Override
+        public AuthData authenticate(AuthData commandData) {
+            authenticateCalls++;
+            return AuthData.of(("client-token-" + authenticateCalls).getBytes(UTF_8));
+        }
+    }
+
+    private static final class CountingFactory implements SaslAuthenticationV5.SaslProviderFactory {
+        private static final long serialVersionUID = 1L;
+        int createCalls;
+        final List<FakeSaslClient> created = new ArrayList<>();
+
+        @Override
+        public AuthenticationDataProvider create(String brokerHost) {
+            createCalls++;
+            FakeSaslClient client = new FakeSaslClient();
+            created.add(client);
+            return client;
+        }
+    }
+
+    /**
+     * A fake transport that mimics the broker's SASL-over-HTTP servlet: it {@code 401}s with a NEGOTIATE
+     * challenge until {@code roundsToComplete} client tokens have arrived, then {@code 200}s with a role
+     * token. Only the warmup rounds pass through here — the driver's final role-token request goes back to
+     * the caller, not the transport.
+     */
+    private static final class FakeSaslServer implements HttpChallengeTransport {
+        private final int roundsToComplete;
+        private final String issuedRoleToken;
+        private int serverStep;
+        final List<URI> uris = new ArrayList<>();
+        final List<String> requestStates = new ArrayList<>();
+        final List<HttpAuthHeaders> requests = new ArrayList<>();
+
+        FakeSaslServer(int roundsToComplete, String issuedRoleToken) {
+            this.roundsToComplete = roundsToComplete;
+            this.issuedRoleToken = issuedRoleToken;
+        }
+
+        @Override
+        public CompletableFuture<Result> get(URI uri, HttpAuthHeaders requestHeaders, Duration timeout) {
+            uris.add(uri);
+            requests.add(requestHeaders);
+            String state = requestHeaders.get(SASL_HEADER_STATE).orElse(null);
+            requestStates.add(state);
+            if (SASL_STATE_CLIENT_INIT.equalsIgnoreCase(state)) {
+                serverStep = 1;
+            } else if (SASL_STATE_NEGOTIATE.equalsIgnoreCase(state)) {
+                serverStep++;
+            } else {
+                return CompletableFuture.completedFuture(new Result(400, HttpAuthHeaders.empty()));
+            }
+            if (serverStep >= roundsToComplete) {
+                Map<String, String> headers = new LinkedHashMap<>();
+                headers.put(SASL_HEADER_TYPE, SASL_TYPE_VALUE);
+                headers.put(SASL_HEADER_STATE, SASL_STATE_COMPLETE);
+                headers.put(SASL_STATE_SERVER, "1");
+                headers.put(SASL_AUTH_ROLE_TOKEN, issuedRoleToken);
+                return CompletableFuture.completedFuture(new Result(200, HttpAuthHeaders.of(headers)));
+            }
+            Map<String, String> headers = new LinkedHashMap<>();
+            headers.put(SASL_HEADER_TYPE, SASL_TYPE_VALUE);
+            headers.put(SASL_HEADER_STATE, SASL_STATE_NEGOTIATE);
+            headers.put(SASL_STATE_SERVER, "1");
+            headers.put(SASL_AUTH_TOKEN, Base64.getEncoder().encodeToString(("server-" + serverStep).getBytes(UTF_8)));
+            return CompletableFuture.completedFuture(new Result(401, HttpAuthHeaders.of(headers)));
+        }
+    }
+}


### PR DESCRIPTION
PIP: [PIP-478](https://github.com/apache/pulsar/blob/master/pip/pip-478.md)

> **Stacked PR series (PIP-478).** Base of this PR is `lh-pip-478-04-client` (the core client engine chunk). Review only the top commit here.

### Motivation

The Athenz and SASL client authentication plugins are downstream modules that depend on `pulsar-client` but are **not referenced by the core client engine at compile time** — the engine loads plugins by class name via `V5AuthenticationLoader` (`Class.forName(...)`). This was verified while building the core chunk: it compiles standalone without these two modules. They therefore migrate to the asynchronous v5 authentication SPI in their own PR, stacked on the core engine.

### Modifications

- **`pulsar-client-auth-athenz`**: `AthenzAuthenticationV5` implementing the v5 `Authentication` SPI (async credential retrieval on the binary path); `AuthenticationAthenz` adjusted for the shared v5 primitives.
- **`pulsar-client-auth-sasl`**: `SaslAuthenticationV5` driving the shared HTTP-SASL challenge exchange through the framework HTTP client; `AuthenticationSasl` adjusted; build wiring for the v5 auth API.

### Verifying this change

This change added tests and can be verified as follows:

- `:pulsar-client-auth-athenz:build` and `:pulsar-client-auth-sasl:build` green (tests + spotless + checkstyle): `SaslAuthenticationV5HttpTest` 2/2, `AuthenticationAthenzTest` 8/8.

### Does this pull request potentially affect one of the following parts:

- [x] The public API — adds v5-SPI implementations of the Athenz and SASL plugins (additive).

### Documentation

- [x] `doc-not-needed`

<sub>Assisted-by: Claude Code (Opus 4.8)</sub>
