### PR TITLE
[feat][broker] PIP-478: server-side TLS factory integration and default switch to the new SPI

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -844,6 +844,16 @@ authenticateOriginalAuthData=false
 # Tls cert refresh duration in seconds (set 0 to check on every new connection)
 tlsCertRefreshCheckDurationSec=300
 
+# PIP-478 TLS factory (PulsarTlsFactory) class name for the broker's server-side TLS (binary listener and
+# web server; purposes BROKER/PROXY/WEB). An empty value or the literal 'default' selects the built-in
+# DefaultBrokerTlsFactory composed from these tls* settings, otherwise the named class is instantiated via
+# its public no-arg constructor. This is the only server TLS path; the removed PIP-337 sslFactoryPlugin
+# keys are rejected at startup when set to a non-default value.
+tlsFactoryClassName=
+
+# PIP-478 configuration parameters for tlsFactoryClassName (JSON object or comma-separated key=value list)
+tlsFactoryConfig=
+
 # Path for the TLS certificate file
 tlsCertificateFilePath=
 
@@ -973,6 +983,16 @@ brokerClientTlsCiphers=
 # Example:
 # brokerClientTlsProtocols=TLSv1.3,TLSv1.2
 brokerClientTlsProtocols=
+
+# PIP-478 TLS factory (PulsarTlsFactory) class name for the broker's own outbound (broker-to-broker) client
+# connections (purpose BROKER_CLIENT). An empty value or the literal 'default' selects the built-in
+# default factory composed from the brokerClient tls* settings, otherwise the named class is instantiated
+# via its public no-arg constructor. This is the only outbound-client TLS path; the removed PIP-337
+# brokerClientSslFactoryPlugin keys are rejected at startup when set to a non-default value.
+brokerClientTlsFactoryClassName=
+
+# PIP-478 configuration parameters for brokerClientTlsFactoryClassName (JSON object or key=value list)
+brokerClientTlsFactoryConfig=
 
 # You can add extra configuration options for the Pulsar Client and the Pulsar Admin Client
 # by prefixing them with "brokerClient_". These configurations are applied after hard coded configuration

--- a/conf/functions_worker.yml
+++ b/conf/functions_worker.yml
@@ -349,6 +349,13 @@ tlsAllowInsecureConnection: false
 tlsEnableHostnameVerification: false
 # Tls cert refresh duration in seconds (set 0 to check on every new connection)
 tlsCertRefreshCheckDurationSec: 300
+# PIP-478 TLS factory (PulsarTlsFactory) class name for the functions-worker web server TLS (purpose WEB).
+# When set, the new PIP-478 TLS SPI is used instead of the built-in file-based TLS loading: an empty value
+# or the literal 'default' selects the built-in default factory composed from these tls* settings, otherwise
+# the named class is instantiated via its public no-arg constructor.
+tlsFactoryClassName: ""
+# PIP-478 configuration parameters for tlsFactoryClassName (JSON object or comma-separated key=value list)
+tlsFactoryConfig: ""
 # Whether client certificates are required for TLS. Connections are rejected if the client
 # certificate isn't trusted.
 tlsRequireTrustedClientCertOnConnect: false

--- a/conf/proxy.conf
+++ b/conf/proxy.conf
@@ -213,6 +213,26 @@ tlsEnabledWithBroker=false
 # Tls cert refresh duration in seconds (set 0 to check on every new connection)
 tlsCertRefreshCheckDurationSec=300
 
+# PIP-478 TLS factory (PulsarTlsFactory) class name for the proxy's server-side TLS (binary front-end and
+# web server; purposes PROXY/WEB). An empty value or the literal 'default' selects the built-in default
+# factory composed from these tls* settings, otherwise the named class is instantiated via its public
+# no-arg constructor. This is the only server TLS path; the removed PIP-337 sslFactoryPlugin keys are
+# rejected at startup when set to a non-default value.
+tlsFactoryClassName=
+
+# PIP-478 configuration parameters for tlsFactoryClassName (JSON object or comma-separated key=value list)
+tlsFactoryConfig=
+
+# PIP-478 TLS factory (PulsarTlsFactory) class name for the proxy's own outbound (proxy-to-broker) client
+# connections (purpose BROKER_CLIENT). An empty value or the literal 'default' selects the built-in default
+# factory composed from the brokerClient tls* settings, otherwise the named class is instantiated via its
+# public no-arg constructor. This is the only outbound-client TLS path; the removed PIP-337
+# brokerClientSslFactoryPlugin keys are rejected at startup when set to a non-default value.
+brokerClientTlsFactoryClassName=
+
+# PIP-478 configuration parameters for brokerClientTlsFactoryClassName (JSON object or key=value list)
+brokerClientTlsFactoryConfig=
+
 # You can add extra configuration options for the Pulsar Client
 # by prefixing them with "brokerClient_". These configurations are applied after hard coded configuration
 # and before the above brokerClient configurations named above.

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -479,6 +479,16 @@ tlsEnabled=false
 # Tls cert refresh duration in seconds (set 0 to check on every new connection)
 tlsCertRefreshCheckDurationSec=300
 
+# PIP-478 TLS factory (PulsarTlsFactory) class name for the embedded broker's server-side TLS (binary
+# listener and web server; purposes BROKER/PROXY/WEB). An empty value or the literal 'default' selects the
+# built-in DefaultBrokerTlsFactory composed from these tls* settings, otherwise the named class is
+# instantiated via its public no-arg constructor. This is the only server TLS path; the removed PIP-337
+# sslFactoryPlugin keys are rejected at startup when set to a non-default value.
+tlsFactoryClassName=
+
+# PIP-478 configuration parameters for tlsFactoryClassName (JSON object or comma-separated key=value list)
+tlsFactoryConfig=
+
 # Path for the TLS certificate file
 tlsCertificateFilePath=
 
@@ -603,6 +613,16 @@ brokerClientTlsCiphers=
 # Examples:
 # brokerClientTlsProtocols=TLSv1.3,TLSv1.2
 brokerClientTlsProtocols=
+
+# PIP-478 TLS factory (PulsarTlsFactory) class name for the embedded broker's own outbound
+# (broker-to-broker) client connections (purpose BROKER_CLIENT). An empty value or the literal 'default'
+# selects the built-in default factory composed from the brokerClient tls* settings, otherwise the named
+# class is instantiated via its public no-arg constructor. This is the only outbound-client TLS path; the
+# removed PIP-337 brokerClientSslFactoryPlugin keys are rejected at startup when set to a non-default value.
+brokerClientTlsFactoryClassName=
+
+# PIP-478 configuration parameters for brokerClientTlsFactoryClassName (JSON object or key=value list)
+brokerClientTlsFactoryConfig=
 
 # Enable or disable system topic
 systemTopicEnabled=true

--- a/conf/websocket.conf
+++ b/conf/websocket.conf
@@ -156,6 +156,15 @@ tlsRequireTrustedClientCertOnConnect=false
 # Tls cert refresh duration in seconds (set 0 to check on every new connection)
 tlsCertRefreshCheckDurationSec=300
 
+# PIP-478 TLS factory (PulsarTlsFactory) class name for the WebSocket proxy's web server TLS (purpose WEB).
+# When set, the new PIP-478 TLS SPI is used instead of the built-in file-based TLS loading: an empty value
+# or the literal 'default' selects the built-in default factory composed from these tls* settings, otherwise
+# the named class is instantiated via its public no-arg constructor.
+tlsFactoryClassName=
+
+# PIP-478 configuration parameters for tlsFactoryClassName (JSON object or comma-separated key=value list)
+tlsFactoryConfig=
+
 # Specify the TLS provider for the WebSocket: SunJSSE, Conscrypt and etc.
 tlsProvider=Conscrypt
 

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -52,7 +52,6 @@ import org.apache.pulsar.common.policies.data.TopicType;
 import org.apache.pulsar.common.protocol.Commands;
 import org.apache.pulsar.common.sasl.SaslConstants;
 import org.apache.pulsar.common.topics.TopicsPattern;
-import org.apache.pulsar.common.util.DefaultPulsarSslFactory;
 import org.apache.pulsar.common.util.DirectMemoryUtils;
 import org.apache.pulsar.metadata.api.MetadataStoreFactory;
 import org.apache.pulsar.metadata.impl.ZKMetadataStore;
@@ -1887,15 +1886,39 @@ public class ServiceConfiguration implements PulsarConfiguration {
         doc = "Specify whether Client certificates are required for TLS Reject.\n"
             + "the Connection if the Client Certificate is not trusted")
     private boolean tlsRequireTrustedClientCertOnConnect = false;
+    /**
+     * @deprecated since 5.0.0: the PIP-337 SSL factory plugin is removed (PIP-478); a non-default value is
+     *     rejected at broker startup. Use {@code tlsFactoryClassName}.
+     */
+    @Deprecated
     @FieldContext(
             category = CATEGORY_TLS,
-            doc = "SSL Factory Plugin class to provide SSLEngine and SSLContext objects. The default "
-                    + " class used is DefaultSslFactory.")
-    private String sslFactoryPlugin = DefaultPulsarSslFactory.class.getName();
+            doc = "Deprecated (PIP-478): the PIP-337 SSL factory plugin is removed in Pulsar 5.0. Retained only "
+                    + "to reject a stale configuration at startup; use tlsFactoryClassName instead.")
+    private String sslFactoryPlugin = "";
+    /**
+     * @deprecated since 5.0.0: superseded by {@code tlsFactoryConfig} (PIP-478).
+     */
+    @Deprecated
     @FieldContext(
             category = CATEGORY_TLS,
-            doc = "SSL Factory plugin configuration parameters.")
+            doc = "Deprecated (PIP-478): the PIP-337 SSL factory plugin is removed in Pulsar 5.0; superseded by "
+                    + "tlsFactoryConfig.")
     private String sslFactoryPluginParams = "";
+    @FieldContext(
+            category = CATEGORY_TLS,
+            doc = "PIP-478 TLS factory (PulsarTlsFactory) class name for the broker's server-side TLS "
+                    + "(binary listener and web server; purposes BROKER/PROXY/WEB). An empty value or the "
+                    + "literal 'default' selects the built-in DefaultBrokerTlsFactory composed from these "
+                    + "tls* settings, otherwise the named class is instantiated via its public no-arg "
+                    + "constructor. This is the only server TLS path; the removed PIP-337 sslFactoryPlugin "
+                    + "keys are rejected at startup when set to a non-default value.")
+    private String tlsFactoryClassName = "";
+    @FieldContext(
+            category = CATEGORY_TLS,
+            doc = "PIP-478 configuration parameters for tlsFactoryClassName, passed to the factory as its "
+                    + "init params. Accepts a JSON object or a comma-separated key=value list.")
+    private String tlsFactoryConfig = "";
 
     /***** --- Authentication. --- ****/
     @FieldContext(
@@ -4126,15 +4149,40 @@ public class ServiceConfiguration implements PulsarConfiguration {
                   + " used by the internal client to authenticate with Pulsar brokers"
     )
     private Set<String> brokerClientTlsProtocols = new TreeSet<>();
+    /**
+     * @deprecated since 5.0.0: the PIP-337 SSL factory plugin is removed (PIP-478); a non-default value is
+     *     rejected at broker startup. Use {@code brokerClientTlsFactoryClassName}.
+     */
+    @Deprecated
     @FieldContext(
             category = CATEGORY_TLS,
-            doc = "SSL Factory Plugin class used by internal client to provide SSLEngine and SSLContext objects. "
-                    + "The default class used is DefaultSslFactory.")
-    private String brokerClientSslFactoryPlugin = DefaultPulsarSslFactory.class.getName();
+            doc = "Deprecated (PIP-478): the PIP-337 SSL factory plugin is removed in Pulsar 5.0. Retained only "
+                    + "to reject a stale configuration at startup; use brokerClientTlsFactoryClassName instead.")
+    private String brokerClientSslFactoryPlugin = "";
+    /**
+     * @deprecated since 5.0.0: superseded by {@code brokerClientTlsFactoryConfig} (PIP-478).
+     */
+    @Deprecated
     @FieldContext(
             category = CATEGORY_TLS,
-            doc = "SSL Factory plugin configuration parameters used by internal client.")
+            doc = "Deprecated (PIP-478): the PIP-337 SSL factory plugin is removed in Pulsar 5.0; superseded by "
+                    + "brokerClientTlsFactoryConfig.")
     private String brokerClientSslFactoryPluginParams = "";
+    @FieldContext(
+            category = CATEGORY_TLS,
+            doc = "PIP-478 TLS factory (PulsarTlsFactory) class name for the broker's own outbound "
+                    + "(broker-to-broker) client connections (purpose BROKER_CLIENT). An empty value or the "
+                    + "literal 'default' selects the built-in default factory composed from the brokerClient "
+                    + "tls* settings, otherwise the named class is instantiated via its public no-arg "
+                    + "constructor. This is the only outbound-client TLS path; the removed PIP-337 "
+                    + "brokerClientSslFactoryPlugin keys are rejected at startup when set to a non-default "
+                    + "value.")
+    private String brokerClientTlsFactoryClassName = "";
+    @FieldContext(
+            category = CATEGORY_TLS,
+            doc = "PIP-478 configuration parameters for brokerClientTlsFactoryClassName. Accepts a JSON "
+                    + "object or a comma-separated key=value list.")
+    private String brokerClientTlsFactoryConfig = "";
 
     /* packages management service configurations (begin) */
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -132,6 +132,7 @@ import org.apache.pulsar.broker.stats.prometheus.PulsarPrometheusMetricsServlet;
 import org.apache.pulsar.broker.storage.BookkeeperManagedLedgerStorageClass;
 import org.apache.pulsar.broker.storage.ManagedLedgerStorage;
 import org.apache.pulsar.broker.storage.ManagedLedgerStorageClass;
+import org.apache.pulsar.broker.tls.TlsFactorySupport;
 import org.apache.pulsar.broker.transaction.buffer.TransactionBufferProvider;
 import org.apache.pulsar.broker.transaction.buffer.impl.TransactionBufferClientImpl;
 import org.apache.pulsar.broker.transaction.coordinator.v5.TransactionCoordinatorV5;
@@ -149,6 +150,7 @@ import org.apache.pulsar.broker.web.plugin.servlet.AdditionalServletWithPulsarSe
 import org.apache.pulsar.broker.web.plugin.servlet.AdditionalServlets;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminBuilder;
+import org.apache.pulsar.client.admin.internal.PulsarAdminBuilderImpl;
 import org.apache.pulsar.client.api.AuthenticationFactory;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
@@ -157,6 +159,7 @@ import org.apache.pulsar.client.impl.DnsResolverGroupImpl;
 import org.apache.pulsar.client.impl.PulsarClientImpl;
 import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 import org.apache.pulsar.client.impl.conf.ConfigurationDataUtils;
+import org.apache.pulsar.client.impl.tls.ClientTlsFactorySupport;
 import org.apache.pulsar.client.internal.PropertiesUtils;
 import org.apache.pulsar.client.util.ExecutorProvider;
 import org.apache.pulsar.client.util.ScheduledExecutorProvider;
@@ -844,6 +847,20 @@ public class PulsarService implements AutoCloseable, ShutdownService {
     /**
      * Start the pulsar service instance.
      */
+    // PIP-478: reject a stale, non-default PIP-337 sslFactoryPlugin / brokerClientSslFactoryPlugin
+    // (removed in 5.0) at startup. The @Deprecated getters are read intentionally here to enforce the removal.
+    @SuppressWarnings("deprecation")
+    private static void rejectRemovedPip337SslFactoryPlugin(ServiceConfiguration config)
+            throws PulsarServerException {
+        if (TlsFactorySupport.isLegacyCustom(config.getSslFactoryPlugin())
+                || TlsFactorySupport.isLegacyCustom(config.getBrokerClientSslFactoryPlugin())) {
+            throw new PulsarServerException("The PIP-337 sslFactoryPlugin / brokerClientSslFactoryPlugin "
+                    + "configuration is removed in Pulsar 5.0 (PIP-478); migrate the custom factory to a "
+                    + "PulsarTlsFactory via tlsFactoryClassName / brokerClientTlsFactoryClassName and clear "
+                    + "sslFactoryPlugin / brokerClientSslFactoryPlugin.");
+        }
+    }
+
     public void start() throws PulsarServerException {
         log.info()
                 .attr("version", (brokerVersion != null ? brokerVersion : "unknown"))
@@ -893,6 +910,11 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                         config.getBacklogQuotaDefaultLimitSecond(),
                         config.getDefaultRetentionTimeInMinutes() * 60));
             }
+
+            // PIP-478: the PIP-337 sslFactoryPlugin path is removed; reject a stale, non-default
+            // sslFactoryPlugin / brokerClientSslFactoryPlugin loudly at startup rather than silently ignore a
+            // security-relevant setting.
+            rejectRemovedPip337SslFactoryPlugin(config);
 
             openTelemetryTopicStats = new OpenTelemetryTopicStats(this);
             openTelemetryConsumerStats = new OpenTelemetryConsumerStats(this);
@@ -1813,8 +1835,12 @@ public class PulsarService implements AutoCloseable, ShutdownService {
     public PulsarClientImpl createClientImpl(ClientConfigurationData conf,
                                              Consumer<PulsarClientImpl.PulsarClientImplBuilder> customizer)
             throws PulsarClientException {
+        ClientConfigurationData clientConf = conf != null ? conf : createClientConfigurationData();
+        // PIP-478: route the broker's own outbound clients (replication + cluster-internal lookup)
+        // onto the new TLS SPI (BROKER_CLIENT) when opted in via brokerClientTlsFactoryClassName.
+        maybeApplyBrokerClientTlsFactory(clientConf);
         PulsarClientImpl.PulsarClientImplBuilder pulsarClientImplBuilder = PulsarClientImpl.builder()
-                .conf(conf != null ? conf : createClientConfigurationData())
+                .conf(clientConf)
                 .eventLoopGroup(ioEventLoopGroup)
                 .timer(brokerClientSharedTimer)
                 .internalExecutorProvider(brokerClientSharedInternalExecutorProvider)
@@ -1826,6 +1852,70 @@ public class PulsarService implements AutoCloseable, ShutdownService {
             customizer.accept(pulsarClientImplBuilder);
         }
         return pulsarClientImplBuilder.build();
+    }
+
+    /**
+     * Route the broker's own outbound Pulsar client (geo-replication and cluster-internal lookup) onto the
+     * new PIP-478 TLS SPI for the {@code BROKER_CLIENT} purpose, gated on the
+     * {@code brokerClientTlsFactoryClassName} opt-in. The broker-client material — per-cluster
+     * {@code ClusterData.brokerClientTls*} first, else the broker's {@code brokerClient*}
+     * {@code ServiceConfiguration} — is already mapped onto the config's {@code tls*} fields by the caller
+     * ({@code createClientConfigurationData} / {@code BrokerService.configTlsSettings}), so this only attaches
+     * a per-client {@link org.apache.pulsar.common.tls.PulsarTlsFactory} composed from those fields (folding
+     * the broker-client {@code Authentication} TLS material). Leaves the config on the legacy PIP-337 path
+     * when the gate is off, or when the outbound client is not TLS, or when it is already on the new path.
+     *
+     * @param conf the outbound client configuration (mutated to carry the TLS factory when opted in)
+     */
+    private void maybeApplyBrokerClientTlsFactory(ClientConfigurationData conf) {
+        String factoryClassName = getConfiguration().getBrokerClientTlsFactoryClassName();
+        if (!isNotBlank(factoryClassName)) {
+            return;
+        }
+        if (conf.getTlsFactory() != null || conf.getTlsPolicyMap() != null || !conf.isUseTls()) {
+            return;
+        }
+        conf.setTlsFactory(ClientTlsFactorySupport.brokerClientTlsFactory(conf, factoryClassName));
+        // PIP-478: deliver brokerClientTlsFactoryConfig to a custom factory via the init context
+        // params (parsed the same way as the server-side tlsFactoryConfig).
+        conf.setTlsFactoryParams(TlsFactorySupport.parseFactoryConfig(
+                getConfiguration().getBrokerClientTlsFactoryConfig()));
+    }
+
+    /**
+     * Route the broker's own outbound admin clients (the {@code PulsarAdmin} instances built by
+     * {@link #getCreateAdminClientBuilder} and {@code BrokerService.getClusterPulsarAdmin}) onto the new
+     * PIP-478 TLS SPI, gated on the same {@code brokerClientTlsFactoryClassName} opt-in as the
+     * binary path. The admin builder rides a {@link ClientConfigurationData} internally; this
+     * reaches it through {@link PulsarAdminBuilderImpl#getConf()} and attaches a per-client
+     * {@link org.apache.pulsar.common.tls.PulsarTlsFactory} composed from the broker-client {@code tls*}
+     * material already mapped onto the config (folding the broker-client {@code Authentication} TLS material).
+     * The {@code AsyncHttpConnector} adopts, initializes and closes the factory. Leaves the builder on the
+     * legacy PIP-337 path when the gate is off, when the admin URL is not TLS, or when it is already on the
+     * new path.
+     *
+     * @param builder the admin builder to route (a {@link PulsarAdminBuilderImpl}; other implementations are
+     *                left untouched)
+     */
+    public void applyBrokerClientTlsFactoryToAdmin(PulsarAdminBuilder builder) {
+        String factoryClassName = getConfiguration().getBrokerClientTlsFactoryClassName();
+        if (!isNotBlank(factoryClassName) || !(builder instanceof PulsarAdminBuilderImpl adminBuilder)) {
+            return;
+        }
+        ClientConfigurationData conf = adminBuilder.getConf();
+        if (conf.getTlsFactory() != null || conf.getTlsPolicyMap() != null) {
+            return;
+        }
+        // Admin traffic is HTTP; TLS is selected by an https service URL (there is no useTls flag on the
+        // admin builder path).
+        if (conf.getServiceUrl() == null || !conf.getServiceUrl().startsWith("https")) {
+            return;
+        }
+        conf.setTlsFactory(ClientTlsFactorySupport.brokerClientTlsFactory(conf, factoryClassName));
+        // PIP-478: deliver brokerClientTlsFactoryConfig to a custom factory via the init context
+        // params (parsed the same way as the server-side tlsFactoryConfig).
+        conf.setTlsFactoryParams(TlsFactorySupport.parseFactoryConfig(
+                getConfiguration().getBrokerClientTlsFactoryConfig()));
     }
 
     public synchronized PulsarClient getClient() throws PulsarServerException {
@@ -1865,8 +1955,6 @@ public class PulsarService implements AutoCloseable, ShutdownService {
             conf.setTlsProtocols(this.getConfiguration().getBrokerClientTlsProtocols());
             conf.setTlsAllowInsecureConnection(this.getConfiguration().isTlsAllowInsecureConnection());
             conf.setTlsHostnameVerificationEnable(this.getConfiguration().isTlsHostnameVerificationEnabled());
-            conf.setSslFactoryPlugin(this.getConfiguration().getBrokerClientSslFactoryPlugin());
-            conf.setSslFactoryPluginParams(this.getConfiguration().getBrokerClientSslFactoryPluginParams());
             if (this.getConfiguration().isBrokerClientTlsEnabledWithKeyStore()) {
                 conf.setUseKeyStoreTls(true);
                 conf.setTlsTrustStoreType(this.getConfiguration().getBrokerClientTlsTrustStoreType());
@@ -1940,9 +2028,7 @@ public class PulsarService implements AutoCloseable, ShutdownService {
 
         if (conf.isBrokerClientTlsEnabled()) {
             builder.tlsCiphers(conf.getBrokerClientTlsCiphers())
-                    .tlsProtocols(conf.getBrokerClientTlsProtocols())
-                    .sslFactoryPlugin(conf.getBrokerClientSslFactoryPlugin())
-                    .sslFactoryPluginParams(conf.getBrokerClientSslFactoryPluginParams());
+                    .tlsProtocols(conf.getBrokerClientTlsProtocols());
             if (conf.isBrokerClientTlsEnabledWithKeyStore()) {
                 builder.useKeyStoreTls(true).tlsTrustStoreType(conf.getBrokerClientTlsTrustStoreType())
                         .tlsTrustStorePath(conf.getBrokerClientTlsTrustStore())
@@ -1962,6 +2048,8 @@ public class PulsarService implements AutoCloseable, ShutdownService {
         // most of the admin request requires to make zk-call so, keep the max read-timeout based on
         // zk-operation timeout
         builder.readTimeout(conf.getMetadataStoreOperationTimeoutSeconds(), TimeUnit.SECONDS);
+        // PIP-478: route the broker's own admin client onto the new TLS SPI when opted in.
+        applyBrokerClientTlsFactoryToAdmin(builder);
         return builder;
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -1714,9 +1714,7 @@ public class NamespaceService implements AutoCloseable {
                         .enableTls(true)
                         .tlsTrustCertsFilePath(pulsar.getConfiguration().getBrokerClientTrustCertsFilePath())
                         .allowTlsInsecureConnection(pulsar.getConfiguration().isTlsAllowInsecureConnection())
-                        .enableTlsHostnameVerification(pulsar.getConfiguration().isTlsHostnameVerificationEnabled())
-                        .sslFactoryPlugin(pulsar.getConfiguration().getBrokerClientSslFactoryPlugin())
-                        .sslFactoryPluginParams(pulsar.getConfiguration().getBrokerClientSslFactoryPluginParams());
+                        .enableTlsHostnameVerification(pulsar.getConfiguration().isTlsHostnameVerificationEnabled());
                 } else {
                     clientBuilder.serviceUrl(isNotBlank(cluster.getBrokerServiceUrl())
                         ? cluster.getBrokerServiceUrl() : cluster.getServiceUrl());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -142,6 +142,7 @@ import org.apache.pulsar.broker.stats.prometheus.metrics.ObserverGauge;
 import org.apache.pulsar.broker.stats.prometheus.metrics.Summary;
 import org.apache.pulsar.broker.storage.ManagedLedgerStorage;
 import org.apache.pulsar.broker.storage.ManagedLedgerStorageClass;
+import org.apache.pulsar.broker.tls.TlsFactorySupport;
 import org.apache.pulsar.broker.topiclistlimit.TopicListMemoryLimiter;
 import org.apache.pulsar.broker.topiclistlimit.TopicListSizeResultCache;
 import org.apache.pulsar.broker.validator.BindAddressValidator;
@@ -325,6 +326,8 @@ public class BrokerService implements Closeable {
     private PulsarChannelInitializer.Factory pulsarChannelInitFactory = PulsarChannelInitializer.DEFAULT_FACTORY;
 
     private final List<Channel> listenChannels = new ArrayList<>(2);
+    // PIP-478: the channel initializers that own a PulsarTlsFactory (new-SPI TLS path); closed on shutdown.
+    private final List<PulsarChannelInitializer> pulsarChannelInitializers = new ArrayList<>(2);
     private Channel listenChannel;
     private Channel listenChannelTls;
 
@@ -641,8 +644,10 @@ public class BrokerService implements Closeable {
                             .listenerName(a.getListenerName()).build();
 
             ServerBootstrap b = defaultServerBootstrap.clone();
-            b.childHandler(
-                    pulsarChannelInitFactory.newPulsarChannelInitializer(pulsar, opts));
+            PulsarChannelInitializer channelInitializer =
+                    pulsarChannelInitFactory.newPulsarChannelInitializer(pulsar, opts);
+            pulsarChannelInitializers.add(channelInitializer);
+            b.childHandler(channelInitializer);
             try {
                 Channel ch = b.bind(addr).sync().channel();
                 listenChannels.add(ch);
@@ -926,6 +931,9 @@ public class BrokerService implements Closeable {
                                         asyncCloseFutures.add(closeChannel(ch));
                                     }
                                 });
+
+                                // PIP-478: dispose any PulsarTlsFactory subscriptions held by the listeners.
+                                pulsarChannelInitializers.forEach(PulsarChannelInitializer::close);
 
                                 maxTopicListInFlightLimiter.close();
 
@@ -1555,6 +1563,7 @@ public class BrokerService implements Closeable {
             try {
                 ClusterData data = clusterDataOp
                         .orElseThrow(() -> new MetadataStoreException.NotFoundException(cluster));
+                failIfRemovedCustomClusterSslFactoryPluginConfigured(cluster, data);
                 ClientBuilder clientBuilder = PulsarClient.builder()
                         .enableTcpNoDelay(false)
                         .connectionsPerBroker(pulsar.getConfiguration().getReplicationConnectionsPerBroker())
@@ -1593,9 +1602,7 @@ public class BrokerService implements Closeable {
                             data.getBrokerClientTrustCertsFilePath(),
                             data.getBrokerClientKeyFilePath(),
                             data.getBrokerClientCertificateFilePath(),
-                            pulsar.getConfiguration().isTlsHostnameVerificationEnabled(),
-                            data.getBrokerClientSslFactoryPlugin(),
-                            data.getBrokerClientSslFactoryPluginParams()
+                            pulsar.getConfiguration().isTlsHostnameVerificationEnabled()
                     );
                 } else if (pulsar.getConfiguration().isBrokerClientTlsEnabled()) {
                     configTlsSettings(clientBuilder, serviceUrlTls,
@@ -1610,9 +1617,7 @@ public class BrokerService implements Closeable {
                             pulsar.getConfiguration().getBrokerClientTrustCertsFilePath(),
                             pulsar.getConfiguration().getBrokerClientKeyFilePath(),
                             pulsar.getConfiguration().getBrokerClientCertificateFilePath(),
-                            pulsar.getConfiguration().isTlsHostnameVerificationEnabled(),
-                            pulsar.getConfiguration().getBrokerClientSslFactoryPlugin(),
-                            pulsar.getConfiguration().getBrokerClientSslFactoryPluginParams()
+                            pulsar.getConfiguration().isTlsHostnameVerificationEnabled()
                     );
                 } else {
                     clientBuilder.serviceUrl(
@@ -1638,6 +1643,27 @@ public class BrokerService implements Closeable {
         });
     }
 
+    /**
+     * PIP-478 (B1/H2, escalating ruling R6): a per-cluster {@code brokerClientSslFactoryPlugin} that names a
+     * CUSTOM PIP-337 factory (a per-cluster KMS/HSM SSL factory) is removed in Pulsar 5.0. Silently building
+     * file-based TLS instead would downgrade the cluster's broker-client identity/trust after an upgrade — a
+     * security regression that could send replication/admin traffic with the wrong identity or fail the
+     * handshake. So fail loudly at cluster-client/admin creation with an actionable migration message, instead
+     * of the prior WARN-and-ignore. A blank value or the removed default's FQCN is not a custom factory (the
+     * new path builds the same file-based TLS), so it is still tolerated for metadata compatibility.
+     */
+    private void failIfRemovedCustomClusterSslFactoryPluginConfigured(String cluster, ClusterData data) {
+        String plugin = data.getBrokerClientSslFactoryPlugin();
+        if (TlsFactorySupport.isLegacyCustom(plugin)) {
+            throw new IllegalStateException("The per-cluster brokerClientSslFactoryPlugin '" + plugin
+                    + "' for cluster '" + cluster + "' names a custom PIP-337 SSL factory, which is removed in "
+                    + "Pulsar 5.0 (PIP-478). The broker will not silently fall back to file-based TLS (that would "
+                    + "downgrade the broker-client identity/trust for this cluster); migrate the cluster to a "
+                    + "PulsarTlsFactory via the broker-level brokerClientTlsFactoryClassName and clear "
+                    + "ClusterData.brokerClientSslFactoryPlugin.");
+        }
+    }
+
     private void configTlsSettings(ClientBuilder clientBuilder, String serviceUrl,
                                    boolean brokerClientTlsEnabledWithKeyStore, boolean isTlsAllowInsecureConnection,
                                    String brokerClientTlsTrustStoreType, String brokerClientTlsTrustStore,
@@ -1645,16 +1671,13 @@ public class BrokerService implements Closeable {
                                    String brokerClientTlsKeyStore, String brokerClientTlsKeyStorePassword,
                                    String brokerClientTrustCertsFilePath,
                                    String brokerClientKeyFilePath, String brokerClientCertificateFilePath,
-                                   boolean isTlsHostnameVerificationEnabled, String brokerClientSslFactoryPlugin,
-                                   String brokerClientSslFactoryPluginParams) {
+                                   boolean isTlsHostnameVerificationEnabled) {
+        // PIP-478: the PIP-337 sslFactoryPlugin path is removed; the broker-level value is rejected
+        // at startup and the per-cluster ClusterData value is ignored with a WARN (see getReplicationClient).
         clientBuilder
                 .serviceUrl(serviceUrl)
                 .allowTlsInsecureConnection(isTlsAllowInsecureConnection)
                 .enableTlsHostnameVerification(isTlsHostnameVerificationEnabled);
-        if (StringUtils.isNotBlank(brokerClientSslFactoryPlugin)) {
-            clientBuilder.sslFactoryPlugin(brokerClientSslFactoryPlugin)
-                    .sslFactoryPluginParams(brokerClientSslFactoryPluginParams);
-        }
         if (brokerClientTlsEnabledWithKeyStore) {
             clientBuilder.useKeyStoreTls(true)
                     .tlsTrustStoreType(brokerClientTlsTrustStoreType)
@@ -1677,8 +1700,8 @@ public class BrokerService implements Closeable {
                                         String brokerClientTlsKeyStore, String brokerClientTlsKeyStorePassword,
                                         String brokerClientTrustCertsFilePath,
                                         String brokerClientKeyFilePath, String brokerClientCertificateFilePath,
-                                        boolean isTlsHostnameVerificationEnabled, String brokerClientSslFactoryPlugin,
-                                        String brokerClientSslFactoryPluginParams) {
+                                        boolean isTlsHostnameVerificationEnabled) {
+        // PIP-478: the PIP-337 sslFactoryPlugin path is removed (see configTlsSettings).
         if (brokerClientTlsEnabledWithKeyStore) {
             adminBuilder.useKeyStoreTls(true)
                     .tlsTrustStoreType(brokerClientTlsTrustStoreType)
@@ -1693,9 +1716,7 @@ public class BrokerService implements Closeable {
                     .tlsCertificateFilePath(brokerClientCertificateFilePath);
         }
         adminBuilder.allowTlsInsecureConnection(isTlsAllowInsecureConnection)
-                .enableTlsHostnameVerification(isTlsHostnameVerificationEnabled)
-                .sslFactoryPlugin(brokerClientSslFactoryPlugin)
-                .sslFactoryPluginParams(brokerClientSslFactoryPluginParams);
+                .enableTlsHostnameVerification(isTlsHostnameVerificationEnabled);
     }
 
     public PulsarAdmin getClusterPulsarAdmin(String cluster, Optional<ClusterData> clusterDataOp) {
@@ -1707,6 +1728,7 @@ public class BrokerService implements Closeable {
             try {
                 ClusterData data = clusterDataOp
                         .orElseThrow(() -> new MetadataStoreException.NotFoundException(cluster));
+                failIfRemovedCustomClusterSslFactoryPluginConfigured(cluster, data);
                 PulsarAdminBuilder builder = PulsarAdmin.builder();
 
                 ServiceConfiguration conf = pulsar.getConfig();
@@ -1742,9 +1764,7 @@ public class BrokerService implements Closeable {
                             data.getBrokerClientTrustCertsFilePath(),
                             data.getBrokerClientKeyFilePath(),
                             data.getBrokerClientCertificateFilePath(),
-                            pulsar.getConfiguration().isTlsHostnameVerificationEnabled(),
-                            data.getBrokerClientSslFactoryPlugin(),
-                            data.getBrokerClientSslFactoryPluginParams()
+                            pulsar.getConfiguration().isTlsHostnameVerificationEnabled()
                     );
                 } else if (conf.isBrokerClientTlsEnabled()) {
                     configAdminTlsSettings(builder,
@@ -1759,15 +1779,16 @@ public class BrokerService implements Closeable {
                             conf.getBrokerClientTrustCertsFilePath(),
                             conf.getBrokerClientKeyFilePath(),
                             conf.getBrokerClientCertificateFilePath(),
-                            pulsar.getConfiguration().isTlsHostnameVerificationEnabled(),
-                            conf.getBrokerClientSslFactoryPlugin(),
-                            conf.getBrokerClientSslFactoryPluginParams()
+                            pulsar.getConfiguration().isTlsHostnameVerificationEnabled()
                     );
                 }
 
                 // most of the admin request requires to make zk-call so, keep the max read-timeout based on
                 // zk-operation timeout
                 builder.readTimeout(conf.getMetadataStoreOperationTimeoutSeconds(), TimeUnit.SECONDS);
+
+                // PIP-478: route this per-cluster admin client onto the new TLS SPI when opted in.
+                pulsar.applyBrokerClientTlsFactoryToAdmin(builder);
 
                 PulsarAdmin adminClient = builder.build();
                 log.info().attr("adminApiUrl", adminApiUrl).log("Created client admin instance");

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarChannelInitializer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarChannelInitializer.java
@@ -24,18 +24,23 @@ import io.netty.channel.ChannelInitializer;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.flow.FlowControlHandler;
 import io.netty.handler.flush.FlushConsolidationHandler;
-import io.netty.handler.ssl.SslHandler;
-import java.util.concurrent.TimeUnit;
+import io.netty.handler.ssl.SslContext;
 import lombok.Builder;
 import lombok.CustomLog;
 import lombok.Data;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.tls.DefaultBrokerTlsFactory;
+import org.apache.pulsar.broker.tls.TlsFactorySupport;
 import org.apache.pulsar.common.protocol.ByteBufPair;
 import org.apache.pulsar.common.protocol.FrameDecoderUtil;
 import org.apache.pulsar.common.protocol.OptionalProxyProtocolDecoder;
-import org.apache.pulsar.common.util.PulsarSslConfiguration;
-import org.apache.pulsar.common.util.PulsarSslFactory;
+import org.apache.pulsar.common.tls.PulsarTlsFactory;
+import org.apache.pulsar.common.tls.TlsFactoryInitContext;
+import org.apache.pulsar.common.tls.TlsHandle;
+import org.apache.pulsar.common.tls.TlsPurpose;
+import org.apache.pulsar.common.tls.impl.TlsContextAcquisition;
+import org.apache.pulsar.common.tls.impl.TlsSynthesisSpec;
 
 @CustomLog
 public class PulsarChannelInitializer extends ChannelInitializer<SocketChannel> {
@@ -46,7 +51,10 @@ public class PulsarChannelInitializer extends ChannelInitializer<SocketChannel> 
     private final String listenerName;
     private final boolean enableTls;
     private final ServiceConfiguration brokerConf;
-    private PulsarSslFactory sslFactory;
+    // PIP-478 TLS SPI factory (the only server TLS path since PIP-337 removal).
+    private PulsarTlsFactory tlsFactory;
+    private TlsHandle<SslContext> tlsSubscription;
+    private volatile SslContext tlsServerContext;
 
     /**
      * @param pulsar
@@ -61,19 +69,51 @@ public class PulsarChannelInitializer extends ChannelInitializer<SocketChannel> 
         this.enableTls = opts.isEnableTLS();
         ServiceConfiguration serviceConfig = pulsar.getConfiguration();
         if (this.enableTls) {
-            PulsarSslConfiguration pulsarSslConfig = buildSslConfiguration(serviceConfig);
-            this.sslFactory = (PulsarSslFactory) Class.forName(serviceConfig.getSslFactoryPlugin())
-                    .getConstructor().newInstance();
-            this.sslFactory.initialize(pulsarSslConfig);
-            this.sslFactory.createInternalSslContext();
-            if (serviceConfig.getTlsCertRefreshCheckDurationSec() > 0) {
-                this.pulsar.getExecutor().scheduleWithFixedDelay(this::refreshSslContext,
-                        serviceConfig.getTlsCertRefreshCheckDurationSec(),
-                        serviceConfig.getTlsCertRefreshCheckDurationSec(),
-                        TimeUnit.SECONDS);
-            }
+            initializeTlsFactory(serviceConfig);
         }
         this.brokerConf = pulsar.getConfiguration();
+    }
+
+    // PIP-478: build the PulsarTlsFactory, initialize it, and subscribe to the BROKER purpose. A volatile
+    // Netty SslContext holds the latest instance; rotation is delivered by the subscription (no refresh
+    // task). The subscription's first delivery happens-before its future completes, so tlsServerContext is
+    // set by the time this returns.
+    private void initializeTlsFactory(ServiceConfiguration serviceConfig) throws Exception {
+        this.tlsFactory = TlsFactorySupport.createFactory(serviceConfig.getTlsFactoryClassName(),
+                DefaultBrokerTlsFactory.class,
+                () -> DefaultBrokerTlsFactory.fromServiceConfiguration(serviceConfig));
+        try {
+            TlsFactoryInitContext initContext = TlsFactorySupport.initContext(
+                    TlsFactorySupport.parseFactoryConfig(serviceConfig.getTlsFactoryConfig()),
+                    pulsar.getExecutor(), pulsar.getExecutor(), pulsar.getOpenTelemetry().getOpenTelemetry());
+            TlsFactorySupport.initializeBlocking(this.tlsFactory, initContext);
+            this.tlsSubscription = TlsContextAcquisition.acquireNettyContext(this.tlsFactory, TlsPurpose.BROKER,
+                            TlsSynthesisSpec.server(serviceConfig.isTlsRequireTrustedClientCertOnConnect()),
+                            ctx -> this.tlsServerContext = ctx)
+                    .get()
+                    .orElseThrow(() -> new IllegalStateException(
+                            "TLS factory supplied no Netty SslContext for purpose " + TlsPurpose.BROKER));
+        } catch (Exception e) {
+            // Ctor-throw cleanup (F9): the factory was created (and possibly initialized, its rotation
+            // scheduler running) but the subscription failed; close() will not be called on a half-constructed
+            // initializer, so release it here. close() is null-safe and idempotent.
+            close();
+            throw e;
+        }
+    }
+
+    /** Dispose the PIP-478 TLS factory and its subscription, if any. Safe to call more than once. */
+    public void close() {
+        TlsHandle<SslContext> subscription = this.tlsSubscription;
+        if (subscription != null) {
+            this.tlsSubscription = null;
+            subscription.dispose();
+        }
+        PulsarTlsFactory factory = this.tlsFactory;
+        if (factory != null) {
+            this.tlsFactory = null;
+            factory.close();
+        }
     }
 
     @Override
@@ -85,7 +125,11 @@ public class PulsarChannelInitializer extends ChannelInitializer<SocketChannel> 
         ch.config().setWriteBufferLowWaterMark(pulsar.getConfig().getPulsarChannelWriteBufferLowWaterMark());
         ch.pipeline().addLast("consolidation", new FlushConsolidationHandler(1024, true));
         if (this.enableTls) {
-            ch.pipeline().addLast(TLS_HANDLER, new SslHandler(this.sslFactory.createServerSslEngine(ch.alloc())));
+            // PIP-478: build the handler from the current (possibly rotated) factory-owned SslContext, pinning
+            // it across newHandler so a concurrent rotation cannot free the native OpenSSL context mid-build
+            // (F1 use-after-free guard).
+            ch.pipeline().addLast(TLS_HANDLER, TlsContextAcquisition.withPinnedContext(
+                    () -> this.tlsServerContext, ctx -> ctx.newHandler(ch.alloc())));
         }
         ch.pipeline().addLast("ByteBufPairEncoder", ByteBufPair.getEncoder(this.enableTls));
 
@@ -129,34 +173,5 @@ public class PulsarChannelInitializer extends ChannelInitializer<SocketChannel> 
          * The name of the listener to associate with the channel (optional).
          */
         private String listenerName;
-    }
-
-    protected PulsarSslConfiguration buildSslConfiguration(ServiceConfiguration serviceConfig) {
-        return PulsarSslConfiguration.builder()
-                .tlsKeyStoreType(serviceConfig.getTlsKeyStoreType())
-                .tlsKeyStorePath(serviceConfig.getTlsKeyStore())
-                .tlsKeyStorePassword(serviceConfig.getTlsKeyStorePassword())
-                .tlsTrustStoreType(serviceConfig.getTlsTrustStoreType())
-                .tlsTrustStorePath(serviceConfig.getTlsTrustStore())
-                .tlsTrustStorePassword(serviceConfig.getTlsTrustStorePassword())
-                .tlsCiphers(serviceConfig.getTlsCiphers())
-                .tlsProtocols(serviceConfig.getTlsProtocols())
-                .tlsTrustCertsFilePath(serviceConfig.getTlsTrustCertsFilePath())
-                .tlsCertificateFilePath(serviceConfig.getTlsCertificateFilePath())
-                .tlsKeyFilePath(serviceConfig.getTlsKeyFilePath())
-                .allowInsecureConnection(serviceConfig.isTlsAllowInsecureConnection())
-                .requireTrustedClientCertOnConnect(serviceConfig.isTlsRequireTrustedClientCertOnConnect())
-                .tlsEnabledWithKeystore(serviceConfig.isTlsEnabledWithKeyStore())
-                .tlsCustomParams(serviceConfig.getSslFactoryPluginParams())
-                .serverMode(true)
-                .build();
-    }
-
-    protected void refreshSslContext() {
-        try {
-            this.sslFactory.update();
-        } catch (Exception e) {
-            log.error().exception(e).log("Failed to refresh SSL context");
-        }
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/WebService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/WebService.java
@@ -30,8 +30,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
 import javax.servlet.DispatcherType;
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
@@ -48,12 +46,15 @@ import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.intercept.BrokerInterceptor;
 import org.apache.pulsar.broker.intercept.BrokerInterceptors;
+import org.apache.pulsar.broker.tls.DefaultBrokerTlsFactory;
+import org.apache.pulsar.broker.tls.TlsFactorySupport;
 import org.apache.pulsar.broker.validator.BindAddressValidator;
 import org.apache.pulsar.common.configuration.BindAddress;
-import org.apache.pulsar.common.util.PulsarSslConfiguration;
-import org.apache.pulsar.common.util.PulsarSslFactory;
+import org.apache.pulsar.common.tls.PulsarTlsFactory;
+import org.apache.pulsar.common.tls.TlsFactoryInitContext;
+import org.apache.pulsar.common.tls.TlsPurpose;
 import org.apache.pulsar.jetty.metrics.JettyStatisticsCollector;
-import org.apache.pulsar.jetty.tls.JettySslContextFactory;
+import org.apache.pulsar.jetty.tls.JettyTlsFactory;
 import org.eclipse.jetty.ee8.nested.ContextHandler;
 import org.eclipse.jetty.ee8.nested.ResourceHandler;
 import org.eclipse.jetty.ee8.servlet.FilterHolder;
@@ -109,8 +110,9 @@ public class WebService implements AutoCloseable {
     private final ServerConnector httpsConnector;
     private final FilterInitializer filterInitializer;
     private JettyStatisticsCollector jettyStatisticsCollector;
-    private PulsarSslFactory sslFactory;
-    private ScheduledFuture<?> sslContextRefreshTask;
+    // PIP-478 TLS SPI factory (the only server TLS path since PIP-337 removal).
+    private PulsarTlsFactory tlsFactory;
+    private JettyTlsFactory.ReloadableServerTls reloadableServerTls;
 
     @Getter
     private static final DynamicSkipUnknownPropertyHandler sharedUnknownPropertyHandler =
@@ -163,21 +165,7 @@ public class WebService implements AutoCloseable {
         SslContextFactory.Server sslCtxFactory = null;
         if (tlsRequired) {
             try {
-                PulsarSslConfiguration sslConfiguration = buildSslConfiguration(config);
-                this.sslFactory = (PulsarSslFactory) Class.forName(config.getSslFactoryPlugin())
-                        .getConstructor().newInstance();
-                this.sslFactory.initialize(sslConfiguration);
-                this.sslFactory.createInternalSslContext();
-                if (config.getTlsCertRefreshCheckDurationSec() > 0) {
-                    this.sslContextRefreshTask = this.pulsar.getExecutor()
-                            .scheduleWithFixedDelay(this::refreshSslContext,
-                                    config.getTlsCertRefreshCheckDurationSec(),
-                                    config.getTlsCertRefreshCheckDurationSec(),
-                                    TimeUnit.SECONDS);
-                }
-                sslCtxFactory = JettySslContextFactory.createSslContextFactory(config.getWebServiceTlsProvider(),
-                        this.sslFactory, config.isTlsRequireTrustedClientCertOnConnect(),
-                        config.getTlsCiphers(), config.getTlsProtocols());
+                sslCtxFactory = createTlsFactoryWebServer(config);
             } catch (Exception e) {
                 throw new PulsarServerException(e);
             }
@@ -541,8 +529,14 @@ public class WebService implements AutoCloseable {
             jettyStatisticsCollector = null;
         }
         webServiceExecutor.join();
-        if (this.sslContextRefreshTask != null) {
-            this.sslContextRefreshTask.cancel(true);
+        // PIP-478: dispose the TLS factory subscription and close the factory, if the new path was used.
+        if (this.reloadableServerTls != null) {
+            this.reloadableServerTls.subscription().dispose();
+            this.reloadableServerTls = null;
+        }
+        if (this.tlsFactory != null) {
+            this.tlsFactory.close();
+            this.tlsFactory = null;
         }
         webExecutorThreadPoolStats.close();
         this.executorStats.close();
@@ -565,33 +559,19 @@ public class WebService implements AutoCloseable {
         }
     }
 
-    protected PulsarSslConfiguration buildSslConfiguration(ServiceConfiguration serviceConfig) {
-        return PulsarSslConfiguration.builder()
-                .tlsKeyStoreType(serviceConfig.getTlsKeyStoreType())
-                .tlsKeyStorePath(serviceConfig.getTlsKeyStore())
-                .tlsKeyStorePassword(serviceConfig.getTlsKeyStorePassword())
-                .tlsTrustStoreType(serviceConfig.getTlsTrustStoreType())
-                .tlsTrustStorePath(serviceConfig.getTlsTrustStore())
-                .tlsTrustStorePassword(serviceConfig.getTlsTrustStorePassword())
-                .tlsCiphers(serviceConfig.getTlsCiphers())
-                .tlsProtocols(serviceConfig.getTlsProtocols())
-                .tlsTrustCertsFilePath(serviceConfig.getTlsTrustCertsFilePath())
-                .tlsCertificateFilePath(serviceConfig.getTlsCertificateFilePath())
-                .tlsKeyFilePath(serviceConfig.getTlsKeyFilePath())
-                .allowInsecureConnection(serviceConfig.isTlsAllowInsecureConnection())
-                .requireTrustedClientCertOnConnect(serviceConfig.isTlsRequireTrustedClientCertOnConnect())
-                .tlsEnabledWithKeystore(serviceConfig.isTlsEnabledWithKeyStore())
-                .tlsCustomParams(serviceConfig.getSslFactoryPluginParams())
-                .serverMode(true)
-                .isHttps(true)
-                .build();
-    }
-
-    protected void refreshSslContext() {
-        try {
-            this.sslFactory.update();
-        } catch (Exception e) {
-            log.error().exception(e).log("Failed to refresh SSL context");
-        }
+    // PIP-478: build the PulsarTlsFactory and drive a vanilla Jetty SslContextFactory.Server through the
+    // SSLContext subscription (setSslContext pre-start, reload() on rotation). The web server has no cert
+    // refresh task — the factory delivers rotations to the reloading server factory.
+    private SslContextFactory.Server createTlsFactoryWebServer(ServiceConfiguration config) throws Exception {
+        this.tlsFactory = TlsFactorySupport.createFactory(config.getTlsFactoryClassName(),
+                DefaultBrokerTlsFactory.class, () -> DefaultBrokerTlsFactory.fromServiceConfiguration(config));
+        TlsFactoryInitContext initContext = TlsFactorySupport.initContext(
+                TlsFactorySupport.parseFactoryConfig(config.getTlsFactoryConfig()),
+                pulsar.getExecutor(), pulsar.getExecutor(), pulsar.getOpenTelemetry().getOpenTelemetry());
+        TlsFactorySupport.initializeBlocking(this.tlsFactory, initContext);
+        this.reloadableServerTls = JettyTlsFactory.createReloadingServerFactory(this.tlsFactory, TlsPurpose.WEB,
+                config.getWebServiceTlsProvider(), config.isTlsRequireTrustedClientCertOnConnect(),
+                config.isTlsAllowInsecureConnection(), config.getTlsCiphers(), config.getTlsProtocols());
+        return this.reloadableServerTls.sslContextFactory();
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactorTool.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactorTool.java
@@ -95,9 +95,7 @@ public class CompactorTool {
         if (internalListener.getBrokerServiceUrlTls() != null && brokerConfig.isBrokerClientTlsEnabled()) {
             clientBuilder.serviceUrl(internalListener.getBrokerServiceUrlTls().toString())
                     .allowTlsInsecureConnection(brokerConfig.isTlsAllowInsecureConnection())
-                    .enableTlsHostnameVerification(brokerConfig.isTlsHostnameVerificationEnabled())
-                    .sslFactoryPlugin(brokerConfig.getBrokerClientSslFactoryPlugin())
-                    .sslFactoryPluginParams(brokerConfig.getBrokerClientSslFactoryPluginParams());
+                    .enableTlsHostnameVerification(brokerConfig.isTlsHostnameVerificationEnabled());
             if (brokerConfig.isBrokerClientTlsEnabledWithKeyStore()) {
                 clientBuilder.useKeyStoreTls(true)
                         .tlsKeyStoreType(brokerConfig.getBrokerClientTlsKeyStoreType())

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTlsAuthTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTlsAuthTest.java
@@ -52,7 +52,8 @@ import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.ResourceGroup;
 import org.apache.pulsar.common.policies.data.TenantInfoImpl;
 import org.apache.pulsar.common.tls.NoopHostnameVerifier;
-import org.apache.pulsar.common.util.SecurityUtility;
+import org.apache.pulsar.common.util.tls.JdkSslContexts;
+import org.apache.pulsar.common.util.tls.PemReader;
 import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.client.ClientProperties;
 import org.glassfish.jersey.jackson.JacksonFeature;
@@ -112,12 +113,12 @@ public class AdminApiTlsAuthTest extends MockedPulsarServiceBaseTest {
         ClientBuilder clientBuilder = ClientBuilder.newBuilder().withConfig(httpConfig)
             .register(JacksonConfigurator.class).register(JacksonFeature.class);
 
-        X509Certificate trustCertificates[] = SecurityUtility.loadCertificatesFromPemFile(
+        X509Certificate trustCertificates[] = PemReader.loadCertificatesFromPemFile(
                 CA_CERT_FILE_PATH);
-        SSLContext sslCtx = SecurityUtility.createSslContext(
+        SSLContext sslCtx = JdkSslContexts.createSslContext(
                 false, trustCertificates,
-                SecurityUtility.loadCertificatesFromPemFile(getTlsFileForClient(user + ".cert")),
-                SecurityUtility.loadPrivateKeyFromPemFile(getTlsFileForClient(user + ".key-pk8")));
+                PemReader.loadCertificatesFromPemFile(getTlsFileForClient(user + ".cert")),
+                PemReader.loadPrivateKeyFromPemFile(getTlsFileForClient(user + ".key-pk8")));
         clientBuilder.sslContext(sslCtx).hostnameVerifier(NoopHostnameVerifier.INSTANCE);
         Client client = clientBuilder.build();
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/BrokerAdminClientTlsFactoryTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/BrokerAdminClientTlsFactoryTest.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.admin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import java.util.Optional;
+import java.util.Set;
+import lombok.CustomLog;
+import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
+import org.apache.pulsar.client.admin.internal.PulsarAdminImpl;
+import org.apache.pulsar.common.policies.data.ClusterData;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * PIP-478 stage 4b: the broker's own outbound admin client (the {@code AsyncHttpConnector} behind
+ * {@link org.apache.pulsar.broker.PulsarService#getAdminClient()}) on the new TLS SPI, opted in via
+ * {@code brokerClientTlsFactoryClassName=default}. A targeted variant of {@link BrokerAdminClientTlsAuthTest};
+ * that test exercises the legacy PIP-337 default (gate off) unmodified.
+ */
+@CustomLog
+@Test(groups = "broker-admin")
+public class BrokerAdminClientTlsFactoryTest extends MockedPulsarServiceBaseTest {
+
+    @BeforeMethod
+    @Override
+    public void setup() throws Exception {
+        conf.setWebServicePortTls(Optional.of(0));
+        conf.setBrokerServicePortTls(Optional.of(0));
+        conf.setTlsCertificateFilePath(BROKER_CERT_FILE_PATH);
+        conf.setTlsKeyFilePath(BROKER_KEY_FILE_PATH);
+        conf.setTlsTrustCertsFilePath(CA_CERT_FILE_PATH);
+        conf.setAuthenticationEnabled(true);
+        // The broker's own admin client authenticates with the broker cert (CN=broker-localhost-SAN).
+        conf.setSuperUserRoles(Set.of("broker-localhost-SAN"));
+        conf.setAuthenticationProviders(
+                Set.of("org.apache.pulsar.broker.authentication.AuthenticationProviderTls"));
+        conf.setAuthorizationEnabled(true);
+        conf.setBrokerClientTlsEnabled(true);
+        conf.setTlsAllowInsecureConnection(true);
+        // Opt in (decision D8): route the broker's own outbound clients — including the admin client — onto
+        // the PIP-478 TLS SPI. The base MockedPulsarServiceBaseTest wires the broker-client AuthenticationTls
+        // material (broker cert/key + CA trust) automatically for the web-TLS + AuthenticationProviderTls case.
+        conf.setBrokerClientTlsFactoryClassName("default");
+        super.internalSetup();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    @Override
+    public void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @Test
+    public void brokerAdminClientRidesNewTlsPathAndWorksOverTls() throws Exception {
+        // The broker's own admin client targets its https web service; the gate routes its AsyncHttpConnector
+        // onto the new SPI.
+        PulsarAdminImpl admin = (PulsarAdminImpl) pulsar.getAdminClient();
+        assertThat(admin.getServiceUrl()).startsWith("https://");
+        assertThat(admin.getAsyncHttpConnector().getTlsFactory())
+                .as("the broker admin client should ride the PIP-478 TLS SPI when "
+                        + "brokerClientTlsFactoryClassName is set")
+                .isNotNull();
+        // Create then read a cluster over TLS: a full write+read admin round-trip driven by the new-SPI
+        // handshake (a TLS failure on either call would throw, so completion proves the factory is wired).
+        admin.clusters().createCluster(configClusterName,
+                ClusterData.builder().serviceUrl(brokerUrl.toString()).build());
+        assertThat(admin.clusters().getClusters()).contains(configClusterName);
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorDeduplicationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorDeduplicationTest.java
@@ -321,12 +321,10 @@ public class OneWayReplicatorDeduplicationTest extends OneWayReplicatorTestBase 
             (conf, eventLoopGroup) -> new ClientCnx(InstrumentProvider.NOOP, conf, eventLoopGroup) {
 
                 @Override
-                protected ByteBuf newConnectCommand() throws Exception {
+                protected ByteBuf buildConnectCommand(AuthData authData) throws Exception {
                     if (supportsReplDedupByLidAndEid) {
-                        return super.newConnectCommand();
+                        return super.buildConnectCommand(authData);
                     }
-                    authenticationDataProvider = authentication.getAuthData(remoteHostName);
-                    AuthData authData = authenticationDataProvider.authenticate(AuthData.INIT_AUTH_DATA);
                     BaseCommand cmd = Commands.newConnectWithoutSerialize(authentication.getAuthMethodName(), authData,
                             this.protocolVersion, clientVersion, proxyToTargetBrokerAddress,
                             null, null, null, null, null);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTlsFactoryTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTlsFactoryTest.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import java.util.List;
+import java.util.Optional;
+import lombok.Cleanup;
+import lombok.CustomLog;
+import org.apache.pulsar.broker.BrokerTestUtil;
+import org.apache.pulsar.client.impl.PulsarClientImpl;
+import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.policies.data.ClusterData;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ * PIP-478 stage 4a: the broker's own outbound clients (geo-replication, cluster-internal lookup) on the new
+ * TLS SPI ({@code BROKER_CLIENT}). A targeted variant of {@link ReplicatorTlsTest} that opts in via
+ * {@code brokerClientTlsFactoryClassName=default}; {@link ReplicatorTlsTest} itself exercises the legacy
+ * PIP-337 default (gate off) unmodified.
+ */
+@Test(groups = "broker-replication")
+@CustomLog
+public class ReplicatorTlsFactoryTest extends ReplicatorTestBase {
+
+    @Override
+    @BeforeClass(timeOut = 300000)
+    public void setup() throws Exception {
+        // The per-cluster replication clients already ride TLS from their ClusterData brokerClientTls* material
+        // (configured by ReplicatorTestBase); opting in via brokerClientTlsFactoryClassName routes them onto the
+        // PIP-478 TLS SPI. (Deliberately not setting the ServiceConfiguration brokerClientTlsEnabled flag: it is
+        // unrelated to this gate — the replication path keys off ClusterData — and toggling it perturbs the
+        // remote-admin harness independently of PIP-478.)
+        config1.setBrokerClientTlsFactoryClassName("default");
+        config2.setBrokerClientTlsFactoryClassName("default");
+        config3.setBrokerClientTlsFactoryClassName("default");
+        super.setup();
+    }
+
+    @Override
+    @AfterClass(alwaysRun = true, timeOut = 300000)
+    public void cleanup() throws Exception {
+        super.cleanup();
+    }
+
+    @Test
+    public void testReplicationClientOnNewTlsPath() throws Exception {
+        log.info("--- Starting ReplicatorTlsFactoryTest::testReplicationClientOnNewTlsPath ---");
+        for (BrokerService ns : List.of(ns1, ns2, ns3)) {
+            ns.getReplicationClient(cluster1, Optional.of(admin1.clusters().getCluster(cluster1)));
+            ns.getReplicationClient(cluster2, Optional.of(admin1.clusters().getCluster(cluster2)));
+            ns.getReplicationClient(cluster3, Optional.of(admin1.clusters().getCluster(cluster3)));
+
+            ns.getReplicationClients().forEach((cluster, client) -> {
+                ClientConfigurationData conf = ((PulsarClientImpl) client).getConfiguration();
+                assertTrue(conf.isUseTls());
+                // The PIP-478 TLS factory was adopted for the broker's own outbound client.
+                assertNotNull(conf.getTlsFactory(), "broker-client should ride the PIP-478 TLS SPI when "
+                        + "brokerClientTlsFactoryClassName is set");
+                // The broker-client material is still mapped onto the config fields (composed into the factory).
+                assertEquals(conf.getTlsTrustCertsFilePath(), caCertFilePath);
+                assertEquals(conf.getTlsKeyFilePath(), clientKeyFilePath);
+                assertEquals(conf.getTlsCertificateFilePath(), clientCertFilePath);
+            });
+        }
+    }
+
+    @Test
+    public void testReplicatesAcrossClustersOnNewTlsPath() throws Exception {
+        log.info("--- Starting ReplicatorTlsFactoryTest::testReplicatesAcrossClustersOnNewTlsPath ---");
+        // A real broker-to-broker TLS handshake on the new path: replication rides the BROKER_CLIENT
+        // connection, so producing on cluster1 and consuming the replicated messages on cluster2 / cluster3
+        // exercises the new-SPI TLS handshake end to end.
+        final TopicName dest = TopicName.get(
+                BrokerTestUtil.newUniqueName("persistent://pulsar/ns/tlsFactoryReplTopic"));
+
+        @Cleanup
+        MessageProducer producer1 = new MessageProducer(url1, dest);
+        @Cleanup
+        MessageConsumer consumer1 = new MessageConsumer(url1, dest);
+        @Cleanup
+        MessageConsumer consumer2 = new MessageConsumer(url2, dest);
+        @Cleanup
+        MessageConsumer consumer3 = new MessageConsumer(url3, dest);
+
+        // Local first (confirms the topic + starts the replicators to r2/r3 over the BROKER_CLIENT connection).
+        producer1.produce(2);
+        consumer1.receive(2);
+        // Replicated: broker-to-broker delivery over the new-SPI TLS connection.
+        consumer2.receive(2, 30);
+        consumer3.receive(2, 30);
+    }
+
+    /**
+     * PIP-478 B1/H2 (escalating ruling R6): a per-cluster {@code brokerClientSslFactoryPlugin} that names a
+     * CUSTOM PIP-337 factory must FAIL LOUDLY at cluster-client / cluster-admin creation — silently falling
+     * back to file-based TLS would downgrade the broker-client identity/trust for that cluster on upgrade. A
+     * blank / removed-default-FQCN value is not a custom factory and is still tolerated.
+     */
+    @Test
+    public void perClusterCustomSslFactoryPluginFailsLoud() throws Exception {
+        ClusterData base = admin1.clusters().getCluster(cluster1);
+        ClusterData custom = ClusterData.builder()
+                .serviceUrl(base.getServiceUrl())
+                .serviceUrlTls(base.getServiceUrlTls())
+                .brokerServiceUrl(base.getBrokerServiceUrl())
+                .brokerServiceUrlTls(base.getBrokerServiceUrlTls())
+                .brokerClientSslFactoryPlugin("com.example.CustomKmsSslFactory")
+                .build();
+
+        assertThatThrownBy(() -> ns1.getReplicationClient("pip478-b1-fail-loud-repl", Optional.of(custom)))
+                .as("custom per-cluster SSL factory -> replication client creation fails loud")
+                .hasMessageContaining("brokerClientTlsFactoryClassName")
+                .hasRootCauseInstanceOf(IllegalStateException.class);
+        assertThatThrownBy(() -> ns1.getClusterPulsarAdmin("pip478-b1-fail-loud-admin", Optional.of(custom)))
+                .as("custom per-cluster SSL factory -> cluster admin creation fails loud")
+                .hasMessageContaining("brokerClientTlsFactoryClassName")
+                .hasRootCauseInstanceOf(IllegalStateException.class);
+
+        // A removed-default-FQCN value is not a custom factory: the check does not throw and the client builds.
+        ClusterData defaultFqcn = ClusterData.builder()
+                .serviceUrl(base.getServiceUrl())
+                .serviceUrlTls(base.getServiceUrlTls())
+                .brokerServiceUrl(base.getBrokerServiceUrl())
+                .brokerServiceUrlTls(base.getBrokerServiceUrlTls())
+                .brokerClientSslFactoryPlugin("org.apache.pulsar.common.util.DefaultPulsarSslFactory")
+                .build();
+        assertThat(ns1.getReplicationClient("pip478-b1-default-ok", Optional.of(defaultFqcn)))
+                .as("removed-default FQCN is tolerated -> client builds").isNotNull();
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/tls/CountingWebTlsFactory.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/tls/CountingWebTlsFactory.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.tls;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.pulsar.common.tls.PulsarTlsFactory;
+import org.apache.pulsar.common.tls.TlsEndpoint;
+import org.apache.pulsar.common.tls.TlsFactoryInitContext;
+import org.apache.pulsar.common.tls.TlsHandle;
+import org.apache.pulsar.common.tls.TlsPolicy;
+import org.apache.pulsar.common.tls.TlsPurpose;
+import org.apache.pulsar.common.tls.impl.FileBasedTlsFactory;
+import org.apache.pulsar.common.tls.impl.FileBasedTlsFactorySettings;
+
+/**
+ * A PIP-478 test factory selected via {@code tlsFactoryClassName} that counts every {@code createInstance}
+ * call so a test can prove the new TLS SPI was actually exercised for the WEB (HTTPS) purpose — the Jetty web
+ * path requests the JDK {@code javax.net.ssl.SSLContext} and {@code SSLParameters}, so unlike
+ * {@code SslContextOnlyTlsFactory} (which counts only refused Netty {@code SslContext} requests) this counts
+ * the JDK-context path. Material loading is delegated to a real {@link FileBasedTlsFactory} built from the
+ * {@code trust}/{@code cert}/{@code key}/{@code insecure} factory-config params, so the served context is a
+ * genuine, usable WEB context.
+ *
+ * <p>Reflectively instantiable via the public no-arg constructor.
+ */
+public class CountingWebTlsFactory implements PulsarTlsFactory {
+
+    private static final AtomicInteger CREATE_INSTANCE_CALLS = new AtomicInteger();
+
+    private volatile FileBasedTlsFactory delegate;
+
+    public CountingWebTlsFactory() {
+    }
+
+    /** Total number of {@code createInstance} calls served (across all instances). */
+    public static int createInstanceCount() {
+        return CREATE_INSTANCE_CALLS.get();
+    }
+
+    public static void reset() {
+        CREATE_INSTANCE_CALLS.set(0);
+    }
+
+    @Override
+    public CompletableFuture<Void> initialize(TlsFactoryInitContext context) {
+        Map<String, String> params = context.params();
+        TlsPolicy policy = TlsPolicy.builder()
+                .format(TlsPolicy.Format.PEM)
+                .trustCertsFilePath(StringUtils.trimToNull(params.get("trust")))
+                .certificateFilePath(StringUtils.trimToNull(params.get("cert")))
+                .keyFilePath(StringUtils.trimToNull(params.get("key")))
+                .allowInsecureConnection(Boolean.parseBoolean(params.getOrDefault("insecure", "false")))
+                .enableHostnameVerification(false)
+                .build();
+        this.delegate = new FileBasedTlsFactory(Map.of(TlsPurpose.WEB, policy),
+                FileBasedTlsFactorySettings.builder().build());
+        return delegate.initialize(context);
+    }
+
+    @Override
+    public <T> CompletableFuture<Optional<TlsHandle<T>>> createInstance(TlsPurpose purpose, Class<T> instanceClass) {
+        CREATE_INSTANCE_CALLS.incrementAndGet();
+        return delegate.createInstance(purpose, instanceClass);
+    }
+
+    @Override
+    public <T> CompletableFuture<Optional<TlsHandle<T>>> createInstance(
+            TlsPurpose purpose, TlsEndpoint endpoint, Class<T> instanceClass) {
+        CREATE_INSTANCE_CALLS.incrementAndGet();
+        return delegate.createInstance(purpose, endpoint, instanceClass);
+    }
+
+    @Override
+    public <T> CompletableFuture<Optional<TlsHandle<T>>> createInstance(
+            TlsPurpose purpose, Class<T> instanceClass, Consumer<T> onLoadOrReload) {
+        CREATE_INSTANCE_CALLS.incrementAndGet();
+        return delegate.createInstance(purpose, instanceClass, onLoadOrReload);
+    }
+
+    @Override
+    public void close() {
+        if (delegate != null) {
+            delegate.close();
+        }
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/web/WebServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/web/WebServiceTest.java
@@ -73,7 +73,7 @@ import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.ClusterDataImpl;
 import org.apache.pulsar.common.policies.data.TenantInfo;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
-import org.apache.pulsar.common.util.SecurityUtility;
+import org.apache.pulsar.common.util.tls.PemReader;
 import org.apache.pulsar.utils.ResourceUtils;
 import org.asynchttpclient.AsyncHttpClient;
 import org.asynchttpclient.BoundRequestBuilder;
@@ -471,8 +471,8 @@ public class WebServiceTest {
             if (useTls) {
                 KeyManager[] keyManagers = null;
                 if (useAuth) {
-                    Certificate[] tlsCert = SecurityUtility.loadCertificatesFromPemFile(CLIENT_CERT_FILE_PATH);
-                    PrivateKey tlsKey = SecurityUtility.loadPrivateKeyFromPemFile(CLIENT_KEY_FILE_PATH);
+                    Certificate[] tlsCert = PemReader.loadCertificatesFromPemFile(CLIENT_CERT_FILE_PATH);
+                    PrivateKey tlsKey = PemReader.loadPrivateKeyFromPemFile(CLIENT_KEY_FILE_PATH);
 
                     KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
                     ks.load(null, null);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/BrokerServiceLookupTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/BrokerServiceLookupTest.java
@@ -95,7 +95,7 @@ import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.PoliciesUtil;
 import org.apache.pulsar.common.policies.data.TenantInfoImpl;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
-import org.apache.pulsar.common.util.SecurityUtility;
+import org.apache.pulsar.common.util.tls.JdkSslContexts;
 import org.apache.pulsar.policies.data.loadbalancer.LocalBrokerData;
 import org.apache.pulsar.policies.data.loadbalancer.NamespaceBundleStats;
 import org.apache.zookeeper.KeeperException;
@@ -620,7 +620,7 @@ public class BrokerServiceLookupTest extends ProducerConsumerBase implements ITe
         final String lookupResourceUrl = "/lookup/v2/topic/persistent/my-property/my-ns/my-topic1";
 
         // set client cert_key file
-        SSLContext sslCtx = SecurityUtility.createSslContext(false, CA_CERT_FILE_PATH,
+        SSLContext sslCtx = JdkSslContexts.createSslContext(false, CA_CERT_FILE_PATH,
                 getTlsFileForClient("admin.cert"), getTlsFileForClient("admin.key-pk8"), "");
         HttpsURLConnection.setDefaultSSLSocketFactory(sslCtx.getSocketFactory());
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/TlsFactoryProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/TlsFactoryProducerConsumerTest.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import java.util.concurrent.TimeUnit;
+import lombok.Cleanup;
+import org.testng.annotations.Test;
+
+/**
+ * PIP-478 stage 2b: verifies the broker serves TLS end-to-end over the new {@code PulsarTlsFactory} path
+ * (selected by {@code tlsFactoryClassName=default}, which wires the built-in {@code DefaultBrokerTlsFactory})
+ * for both the binary listener (purpose BROKER) and the web server (purpose WEB), including mTLS client-auth
+ * in REQUIRE mode. The legacy PIP-337 path is exercised by {@link TlsProducerConsumerTest}.
+ */
+@Test(groups = "broker-api")
+public class TlsFactoryProducerConsumerTest extends TlsProducerConsumerBase {
+
+    @Override
+    protected void internalSetUpForBroker() {
+        super.internalSetUpForBroker();
+        // Select the new PIP-478 TLS SPI (built-in DefaultBrokerTlsFactory) for BROKER/PROXY/WEB purposes.
+        conf.setTlsFactoryClassName("default");
+    }
+
+    @Test(timeOut = 60000)
+    public void testTlsFactoryProduceConsumeOverBinaryAndHttps() throws Exception {
+        // Admin over HTTPS exercises the web server on the new WEB-purpose path.
+        internalSetUpForNamespace();
+
+        // Producer/consumer over binary TLS with mTLS client-auth exercises the BROKER-purpose path.
+        internalSetUpForClient(true, pulsar.getBrokerServiceUrlTls());
+        final String topic = "persistent://my-property/my-ns/tls-factory-topic";
+
+        @Cleanup
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topic)
+                .subscriptionName("tls-factory-sub").subscribe();
+
+        @Cleanup
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topic).create();
+
+        final int numMessages = 10;
+        for (int i = 0; i < numMessages; i++) {
+            producer.send(("msg-" + i).getBytes());
+        }
+
+        for (int i = 0; i < numMessages; i++) {
+            Message<byte[]> msg = consumer.receive(5, TimeUnit.SECONDS);
+            assertThat(msg).isNotNull();
+            assertThat(new String(msg.getData())).isEqualTo("msg-" + i);
+            consumer.acknowledge(msg);
+        }
+    }
+
+    @Test(timeOut = 60000)
+    public void testTlsFactoryBinaryProtocolRequiresClientCert() throws Exception {
+        internalSetUpForNamespace();
+        final String topic = "persistent://my-property/my-ns/tls-factory-noauth-topic";
+
+        // Without client certs, the REQUIRE-mode broker must fail the TLS handshake.
+        internalSetUpForClient(false, pulsar.getBrokerServiceUrlTls());
+        assertThat(catchSubscribeFailure(topic)).isTrue();
+
+        // With client certs, the connection succeeds.
+        internalSetUpForClient(true, pulsar.getBrokerServiceUrlTls());
+        @Cleanup
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topic)
+                .subscriptionName("tls-factory-sub").subscribe();
+        assertThat(consumer.isConnected()).isTrue();
+    }
+
+    private boolean catchSubscribeFailure(String topic) {
+        try (Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topic)
+                .subscriptionName("tls-factory-sub").subscriptionType(SubscriptionType.Exclusive).subscribe()) {
+            return false;
+        } catch (Exception ex) {
+            return true;
+        }
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/v5/V5TlsProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/v5/V5TlsProducerConsumerTest.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.api.v5;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import java.time.Duration;
+import lombok.Cleanup;
+import org.apache.pulsar.client.api.TlsProducerConsumerBase;
+import org.apache.pulsar.client.api.v5.auth.AuthenticationFactory;
+import org.apache.pulsar.client.api.v5.schema.Schema;
+import org.apache.pulsar.common.tls.TlsPolicy;
+import org.testng.annotations.Test;
+
+/**
+ * End-to-end mTLS produce/consume over the v5 client's new PIP-478 TLS path (stage 3b): a v5
+ * {@link PulsarClient} configured with {@code tlsPolicy(...)} against a TLS broker that requires a trusted
+ * client certificate. The binary transport builds its per-connection {@code SslContext} through the
+ * client-side {@code FileBasedTlsFactory} — the only client TLS path since the PIP-337 removal (stage 4c).
+ */
+@Test(groups = "broker-api")
+public class V5TlsProducerConsumerTest extends TlsProducerConsumerBase {
+
+    private static final String TOPIC = "persistent://my-property/my-ns/v5-tls-topic";
+
+    /** mTLS material supplied directly through {@link PulsarClientBuilder#tlsPolicy(TlsPolicy)}. */
+    @Test
+    public void testV5MtlsViaTlsPolicy() throws Exception {
+        internalSetUpForNamespace();
+
+        TlsPolicy policy = TlsPolicy.builder()
+                .format(TlsPolicy.Format.PEM)
+                .trustCertsFilePath(CA_CERT_FILE_PATH)
+                .certificateFilePath(getTlsFileForClient("admin.cert"))
+                .keyFilePath(getTlsFileForClient("admin.key-pk8"))
+                // The shared test broker cert is not guaranteed to carry a SAN for the advertised host, so
+                // (as the v4 TLS suites do) hostname verification is left off; the new path bakes trust and
+                // the client certificate into the factory-built context.
+                .enableHostnameVerification(false)
+                .build();
+
+        @Cleanup
+        PulsarClient client = PulsarClient.builder()
+                .serviceUrl(pulsar.getBrokerServiceUrlTls())
+                .tlsPolicy(policy)
+                .build();
+
+        assertProduceConsume(client, TOPIC + "-policy", "v5-mtls-via-policy");
+    }
+
+    /**
+     * mTLS trust supplied through {@code tlsPolicy(...)} and the client identity through a bridged v4
+     * {@code AuthenticationTls} — exercising the builder-time material fold that merges the auth plugin's
+     * certificate/key into the {@code CLIENT_DEFAULT} policy on the new path.
+     */
+    @Test
+    public void testV5MtlsViaAuthenticationTlsFold() throws Exception {
+        internalSetUpForNamespace();
+
+        TlsPolicy trustOnly = TlsPolicy.builder()
+                .format(TlsPolicy.Format.PEM)
+                .trustCertsFilePath(CA_CERT_FILE_PATH)
+                .enableHostnameVerification(false)
+                .build();
+
+        @Cleanup
+        PulsarClient client = PulsarClient.builder()
+                .serviceUrl(pulsar.getBrokerServiceUrlTls())
+                .tlsPolicy(trustOnly)
+                .authentication(AuthenticationFactory.tls(
+                        getTlsFileForClient("admin.cert"), getTlsFileForClient("admin.key-pk8")))
+                .build();
+
+        assertProduceConsume(client, TOPIC + "-fold", "v5-mtls-via-fold");
+    }
+
+    private static void assertProduceConsume(PulsarClient client, String topic, String payload)
+            throws Exception {
+        @Cleanup
+        Producer<String> producer = client.newProducer(Schema.string())
+                .topic(topic)
+                .create();
+
+        @Cleanup
+        QueueConsumer<String> consumer = client.newQueueConsumer(Schema.string())
+                .topic(topic)
+                .subscriptionName("v5-tls-sub")
+                .subscribe();
+
+        producer.newMessage().value(payload).send();
+
+        Message<String> received = consumer.receive(Duration.ofSeconds(10));
+        assertThat(received).isNotNull();
+        assertThat(received.value()).isEqualTo(payload);
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/AdminApiKeyStoreTlsAuthTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/AdminApiKeyStoreTlsAuthTest.java
@@ -22,6 +22,10 @@ import static org.apache.pulsar.client.impl.auth.AuthenticationKeyStoreTls.mapTo
 import static org.testng.AssertJUnit.fail;
 import com.google.common.collect.Sets;
 import io.jsonwebtoken.SignatureAlgorithm;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.KeyStore;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -30,7 +34,9 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import javax.crypto.SecretKey;
+import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.WebTarget;
@@ -50,7 +56,6 @@ import org.apache.pulsar.client.impl.auth.AuthenticationKeyStoreTls;
 import org.apache.pulsar.client.impl.auth.AuthenticationToken;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.TenantInfoImpl;
-import org.apache.pulsar.common.util.keystoretls.KeyStoreSSLContext;
 import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.client.ClientProperties;
 import org.glassfish.jersey.jackson.JacksonFeature;
@@ -139,7 +144,7 @@ public class AdminApiKeyStoreTlsAuthTest extends ProducerConsumerBase {
         ClientBuilder clientBuilder = ClientBuilder.newBuilder().withConfig(httpConfig)
             .register(JacksonConfigurator.class).register(JacksonFeature.class);
 
-        SSLContext sslCtx = KeyStoreSSLContext.createClientSslContext(
+        SSLContext sslCtx = createJdkClientSslContext(
                 KEYSTORE_TYPE,
                 PROXY_KEYSTORE_FILE_PATH,
                 PROXY_KEYSTORE_PW,
@@ -151,6 +156,30 @@ public class AdminApiKeyStoreTlsAuthTest extends ProducerConsumerBase {
         Client client = clientBuilder.build();
 
         return client.target(brokerUrlTls.toString());
+    }
+
+    // PIP-478 stage 4c: builds the Jersey test client's mutual-TLS SSLContext straight from the JDK KeyStore /
+    // SSLContext APIs (replacing the removed KeyStoreSSLContext.createClientSslContext helper).
+    private static SSLContext createJdkClientSslContext(String keyStoreType, String keyStorePath,
+            String keyStorePassword, String trustStoreType, String trustStorePath, String trustStorePassword)
+            throws Exception {
+        KeyStore keyStore = KeyStore.getInstance(keyStoreType);
+        try (InputStream in = Files.newInputStream(Paths.get(keyStorePath))) {
+            keyStore.load(in, keyStorePassword.toCharArray());
+        }
+        KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+        kmf.init(keyStore, keyStorePassword.toCharArray());
+
+        KeyStore trustStore = KeyStore.getInstance(trustStoreType);
+        try (InputStream in = Files.newInputStream(Paths.get(trustStorePath))) {
+            trustStore.load(in, trustStorePassword.toCharArray());
+        }
+        TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+        tmf.init(trustStore);
+
+        SSLContext sslContext = SSLContext.getInstance("TLS");
+        sslContext.init(kmf.getKeyManagers(), tmf.getTrustManagers(), null);
+        return sslContext;
     }
 
     PulsarAdmin buildAdminClient() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/AdminOnlyOAuth2AuthTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/AdminOnlyOAuth2AuthTest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.Set;
+import lombok.Cleanup;
+import org.apache.pulsar.broker.auth.MockOIDCIdentityProvider;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.api.Authentication;
+import org.apache.pulsar.client.api.AuthenticationDataProvider;
+import org.apache.pulsar.client.impl.auth.oauth2.AuthenticationFactoryOAuth2;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * PIP-478 stage-4c (R4): admin-only OAuth2. A {@link PulsarAdmin} built without a {@link PulsarClient} must
+ * acquire its OAuth2 token through the framework HTTP client bound by {@code PulsarAdminImpl} (mirroring
+ * {@code PulsarClientImpl}), not the removed private OAuth2 {@code AsyncHttpClient}. Building the admin runs
+ * {@code auth.start()}, which resolves the IdP metadata, and the first {@code getAuthData()} fetches the
+ * token — both over the framework client. If the binding were missing, {@code getHttpClient()} would throw
+ * "OAuth2 requires the authentication to be initialized by a PulsarClient/PulsarAdmin".
+ */
+@Test(groups = "broker-impl")
+public class AdminOnlyOAuth2AuthTest {
+
+    private static final String CREDENTIALS_FILE =
+            "./src/test/resources/authentication/token/credentials_file.json";
+    private static final String AUDIENCE = "my-pulsar-cluster";
+
+    private MockOIDCIdentityProvider server;
+
+    @BeforeMethod(alwaysRun = true)
+    public void setUp() {
+        server = new MockOIDCIdentityProvider("super-secret-client-secret", AUDIENCE, 30000);
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void tearDown() {
+        if (server != null) {
+            server.stop();
+            server = null;
+        }
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void adminOnlyOAuth2AcquiresTokenViaFrameworkClient() throws Exception {
+        Path credentials = Paths.get(CREDENTIALS_FILE).toAbsolutePath();
+        Authentication auth = AuthenticationFactoryOAuth2.clientCredentials(
+                new URL(server.getIssuer()), credentials.toUri().toURL(), AUDIENCE);
+
+        // Building the admin runs auth.start() (IdP metadata resolution); with no PulsarClient in play, that
+        // must go over the framework HTTP client bound by PulsarAdminImpl (R4). A missing binding would throw
+        // here. The dummy service URL is never contacted during token acquisition.
+        @Cleanup
+        PulsarAdmin admin = PulsarAdmin.builder()
+                .serviceHttpUrl("http://localhost:65535")
+                .authentication(auth)
+                .build();
+
+        // The first getAuthData() fetches the token over the same framework client; a Bearer token surfaces
+        // through the auth data's HTTP headers.
+        AuthenticationDataProvider data = auth.getAuthData();
+        assertThat(data.hasDataForHttp()).isTrue();
+        Set<Map.Entry<String, String>> headers = data.getHttpHeaders();
+        assertThat(headers).anyMatch(h -> "Authorization".equals(h.getKey())
+                && h.getValue() != null && h.getValue().startsWith("Bearer "));
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/WorkerServerTlsFactoryTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/WorkerServerTlsFactoryTest.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.functions.worker;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import org.apache.pulsar.broker.authentication.AuthenticationService;
+import org.apache.pulsar.broker.tls.CountingWebTlsFactory;
+import org.apache.pulsar.common.util.tls.JdkSslContexts;
+import org.apache.pulsar.common.util.tls.PemReader;
+import org.apache.pulsar.functions.worker.rest.WorkerServer;
+import org.apache.pulsar.utils.ResourceUtils;
+import org.eclipse.jetty.client.ContentResponse;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.testng.annotations.Test;
+
+/**
+ * PIP-478 (T5): the functions-worker {@link WorkerServer} serves its WEB (HTTPS) listener through a custom
+ * {@link org.apache.pulsar.common.tls.PulsarTlsFactory} selected via {@code tlsFactoryClassName}. A counting
+ * factory proves the new SPI path is exercised (its {@code createInstance} is invoked while building the WEB
+ * SslContextFactory) and a successful HTTPS request against the unauthenticated {@code /version} endpoint
+ * proves the synthesized web TLS listener actually works. The {@link WorkerService} is mocked, so no broker /
+ * bookkeeper is started — the worker's Jetty web server alone.
+ */
+public class WorkerServerTlsFactoryTest {
+
+    private static final String CA = ResourceUtils.getAbsolutePath("certificate-authority/certs/ca.cert.pem");
+    private static final String CERT =
+            ResourceUtils.getAbsolutePath("certificate-authority/server-keys/broker.cert.pem");
+    private static final String KEY =
+            ResourceUtils.getAbsolutePath("certificate-authority/server-keys/broker.key-pk8.pem");
+
+    @Test
+    public void webListenerServedThroughCustomTlsFactory() throws Exception {
+        int before = CountingWebTlsFactory.createInstanceCount();
+
+        WorkerConfig workerConfig = new WorkerConfig();
+        workerConfig.setWorkerHostname("localhost");
+        workerConfig.setWorkerPort(null);
+        workerConfig.setWorkerPortTls(0);
+        workerConfig.setTlsEnabled(true);
+        workerConfig.setTlsCertificateFilePath(CERT);
+        workerConfig.setTlsKeyFilePath(KEY);
+        workerConfig.setTlsTrustCertsFilePath(CA);
+        workerConfig.setTlsFactoryClassName(CountingWebTlsFactory.class.getName());
+        workerConfig.setTlsFactoryConfig("trust=" + CA + ",cert=" + CERT + ",key=" + KEY);
+
+        WorkerService workerService = mock(WorkerService.class);
+        when(workerService.getWorkerConfig()).thenReturn(workerConfig);
+        AuthenticationService authenticationService = mock(AuthenticationService.class);
+
+        WorkerServer workerServer = new WorkerServer(workerService, authenticationService);
+        workerServer.start();
+        try {
+            int port = workerServer.getListenPortHTTPS().orElseThrow();
+            ContentResponse response = httpsGet("https://localhost:" + port + "/version");
+            assertThat(response.getStatus()).isEqualTo(200);
+            assertThat(response.getContentAsString()).contains("version");
+            assertThat(CountingWebTlsFactory.createInstanceCount())
+                    .as("the WEB purpose was served through the custom tlsFactoryClassName")
+                    .isGreaterThan(before);
+        } finally {
+            workerServer.stop();
+        }
+    }
+
+    private static ContentResponse httpsGet(String url) throws Exception {
+        SslContextFactory.Client sslContextFactory = new SslContextFactory.Client();
+        sslContextFactory.setSslContext(JdkSslContexts.createSslContext(
+                false, PemReader.loadCertificatesFromPemFile(CA), null));
+        HttpClient httpClient = new HttpClient();
+        httpClient.setSslContextFactory(sslContextFactory);
+        httpClient.start();
+        try {
+            return httpClient.newRequest(url).send();
+        } finally {
+            httpClient.stop();
+        }
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/ProxyPublishConsumeTlsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/ProxyPublishConsumeTlsTest.java
@@ -31,7 +31,8 @@ import lombok.Cleanup;
 import lombok.CustomLog;
 import org.apache.pulsar.client.api.TlsProducerConsumerBase;
 import org.apache.pulsar.client.impl.auth.AuthenticationTls;
-import org.apache.pulsar.common.util.SecurityUtility;
+import org.apache.pulsar.common.util.tls.JdkSslContexts;
+import org.apache.pulsar.common.util.tls.PemReader;
 import org.apache.pulsar.metadata.impl.ZKMetadataStore;
 import org.apache.pulsar.websocket.WebSocketService;
 import org.apache.pulsar.websocket.service.ProxyServer;
@@ -106,8 +107,8 @@ public class ProxyPublishConsumeTlsTest extends TlsProducerConsumerBase {
         URI produceUri = URI.create(producerUri);
 
         SslContextFactory.Client sslContextFactory = new SslContextFactory.Client();
-        sslContextFactory.setSslContext(SecurityUtility
-                .createSslContext(false, SecurityUtility.loadCertificatesFromPemFile(CA_CERT_FILE_PATH), null));
+        sslContextFactory.setSslContext(JdkSslContexts
+                .createSslContext(false, PemReader.loadCertificatesFromPemFile(CA_CERT_FILE_PATH), null));
         @Cleanup("stop")
         HttpClient httpClient = new HttpClient();
         httpClient.setSslContextFactory(sslContextFactory);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/WebSocketProxyTlsFactoryTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/WebSocketProxyTlsFactoryTest.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.websocket.proxy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import java.util.Optional;
+import org.apache.pulsar.broker.tls.CountingWebTlsFactory;
+import org.apache.pulsar.common.configuration.VipStatus;
+import org.apache.pulsar.common.util.tls.JdkSslContexts;
+import org.apache.pulsar.common.util.tls.PemReader;
+import org.apache.pulsar.utils.ResourceUtils;
+import org.apache.pulsar.websocket.service.ProxyServer;
+import org.apache.pulsar.websocket.service.WebSocketProxyConfiguration;
+import org.eclipse.jetty.client.ContentResponse;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.testng.annotations.Test;
+
+/**
+ * PIP-478 (T5): the standalone WebSocket proxy serves its WEB (HTTPS) listener through a custom
+ * {@link org.apache.pulsar.common.tls.PulsarTlsFactory} selected via {@code tlsFactoryClassName}. A counting
+ * factory proves the new SPI path is exercised (its {@code createInstance} is invoked while building the WEB
+ * SslContextFactory) and a successful HTTPS request against the {@code /status.html} endpoint proves the
+ * synthesized web TLS listener actually works. No broker is started — the proxy's Jetty web server alone.
+ */
+@Test(groups = "websocket")
+public class WebSocketProxyTlsFactoryTest {
+
+    private static final String CA = ResourceUtils.getAbsolutePath("certificate-authority/certs/ca.cert.pem");
+    private static final String CERT =
+            ResourceUtils.getAbsolutePath("certificate-authority/server-keys/broker.cert.pem");
+    private static final String KEY =
+            ResourceUtils.getAbsolutePath("certificate-authority/server-keys/broker.key-pk8.pem");
+
+    @Test
+    public void webListenerServedThroughCustomTlsFactory() throws Exception {
+        int before = CountingWebTlsFactory.createInstanceCount();
+
+        WebSocketProxyConfiguration config = new WebSocketProxyConfiguration();
+        config.setClusterName("test");
+        config.setWebServicePort(Optional.empty());
+        config.setWebServicePortTls(Optional.of(0));
+        config.setTlsFactoryClassName(CountingWebTlsFactory.class.getName());
+        config.setTlsFactoryConfig("trust=" + CA + ",cert=" + CERT + ",key=" + KEY);
+        config.setStatusFilePath(CA);
+
+        ProxyServer proxyServer = new ProxyServer(config);
+        proxyServer.addRestResource("/", VipStatus.ATTRIBUTE_STATUS_FILE_PATH, CA, VipStatus.class);
+        proxyServer.start();
+        try {
+            int port = proxyServer.getListenPortHTTPS().orElseThrow();
+            ContentResponse response = httpsGet("https://localhost:" + port + "/status.html");
+            assertThat(response.getStatus()).isEqualTo(200);
+            assertThat(response.getContentAsString()).isEqualTo("OK");
+            assertThat(CountingWebTlsFactory.createInstanceCount())
+                    .as("the WEB purpose was served through the custom tlsFactoryClassName")
+                    .isGreaterThan(before);
+        } finally {
+            proxyServer.stop();
+        }
+    }
+
+    private static ContentResponse httpsGet(String url) throws Exception {
+        SslContextFactory.Client sslContextFactory = new SslContextFactory.Client();
+        sslContextFactory.setSslContext(JdkSslContexts.createSslContext(
+                false, PemReader.loadCertificatesFromPemFile(CA), null));
+        HttpClient httpClient = new HttpClient();
+        httpClient.setSslContextFactory(sslContextFactory);
+        httpClient.start();
+        try {
+            return httpClient.newRequest(url).send();
+        } finally {
+            httpClient.stop();
+        }
+    }
+}

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
@@ -530,6 +530,20 @@ public class WorkerConfig implements Serializable, PulsarConfiguration {
             doc = "Tls cert refresh duration in seconds (set 0 to check on every new connection)"
         )
         private long tlsCertRefreshCheckDurationSec = 300;
+    @FieldContext(
+            category = CATEGORY_SECURITY,
+            doc = "PIP-478 TLS factory (PulsarTlsFactory) class name for the functions-worker web server "
+                    + "TLS (purpose WEB). When set, the new PIP-478 TLS SPI is used instead of the built-in "
+                    + "file-based TLS loading: an empty value or the literal 'default' selects the built-in "
+                    + "default factory composed from these tls* settings, otherwise the named class is "
+                    + "instantiated via its public no-arg constructor. This is the functions worker's first "
+                    + "TLS-factory pluggability.")
+    private String tlsFactoryClassName = "";
+    @FieldContext(
+            category = CATEGORY_SECURITY,
+            doc = "PIP-478 configuration parameters for tlsFactoryClassName. Accepts a JSON object or a "
+                    + "comma-separated key=value list.")
+    private String tlsFactoryConfig = "";
 
     /**** --- KeyStore TLS config variables. --- ****/
     @FieldContext(

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/PulsarWorkerOpenTelemetry.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/PulsarWorkerOpenTelemetry.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.functions.worker;
 
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.metrics.Meter;
 import java.io.Closeable;
 import lombok.Getter;
@@ -31,6 +32,11 @@ public class PulsarWorkerOpenTelemetry implements Closeable {
 
     private final OpenTelemetryService openTelemetryService;
 
+    // PIP-478: the OpenTelemetry root, so a component's TlsFactoryInitContext gets a real handle (the
+    // pulsar.tls.reload / last_reload_success instruments) instead of OpenTelemetry.noop().
+    @Getter
+    private final OpenTelemetry openTelemetry;
+
     @Getter
     private final Meter meter;
 
@@ -40,7 +46,8 @@ public class PulsarWorkerOpenTelemetry implements Closeable {
                 .serviceName(SERVICE_NAME)
                 .serviceVersion(PulsarVersion.getVersion())
                 .build();
-        meter = openTelemetryService.getOpenTelemetry().getMeter(INSTRUMENTATION_SCOPE_NAME);
+        openTelemetry = openTelemetryService.getOpenTelemetry();
+        meter = openTelemetry.getMeter(INSTRUMENTATION_SCOPE_NAME);
     }
 
     @Override

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/WorkerServer.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/WorkerServer.java
@@ -22,28 +22,34 @@ import io.opentelemetry.api.OpenTelemetry;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 import javax.servlet.DispatcherType;
 import lombok.CustomLog;
 import org.apache.pulsar.broker.authentication.AuthenticationService;
+import org.apache.pulsar.broker.tls.TlsFactorySupport;
 import org.apache.pulsar.broker.web.AuthenticationFilter;
 import org.apache.pulsar.broker.web.JettyRequestLogFactory;
 import org.apache.pulsar.broker.web.RateLimitingFilter;
 import org.apache.pulsar.broker.web.WebExecutorThreadPool;
 import org.apache.pulsar.client.util.ExecutorProvider;
-import org.apache.pulsar.common.util.DefaultPulsarSslFactory;
-import org.apache.pulsar.common.util.PulsarSslConfiguration;
-import org.apache.pulsar.common.util.PulsarSslFactory;
+import org.apache.pulsar.common.tls.PulsarTlsFactory;
+import org.apache.pulsar.common.tls.TlsFactoryInitContext;
+import org.apache.pulsar.common.tls.TlsPolicy;
+import org.apache.pulsar.common.tls.TlsPurpose;
+import org.apache.pulsar.common.tls.impl.FileBasedTlsFactory;
+import org.apache.pulsar.common.tls.impl.FileBasedTlsFactorySettings;
 import org.apache.pulsar.functions.worker.PulsarWorkerOpenTelemetry;
+import org.apache.pulsar.functions.worker.PulsarWorkerService;
 import org.apache.pulsar.functions.worker.WorkerConfig;
 import org.apache.pulsar.functions.worker.WorkerService;
 import org.apache.pulsar.functions.worker.rest.api.v2.WorkerApiV2Resource;
 import org.apache.pulsar.functions.worker.rest.api.v2.WorkerStatsApiV2Resource;
 import org.apache.pulsar.jetty.metrics.JettyStatisticsCollector;
-import org.apache.pulsar.jetty.tls.JettySslContextFactory;
+import org.apache.pulsar.jetty.tls.JettyTlsFactory;
 import org.eclipse.jetty.ee8.servlet.FilterHolder;
 import org.eclipse.jetty.ee8.servlet.ServletContextHandler;
 import org.eclipse.jetty.ee8.servlet.ServletHolder;
@@ -81,8 +87,10 @@ public class WorkerServer {
     private ServerConnector httpsConnector;
 
     private final FilterInitializer filterInitializer;
-    private PulsarSslFactory sslFactory;
     private ScheduledExecutorService scheduledExecutorService;
+    // PIP-478 TLS SPI factory (the only server TLS path since the PIP-337 removal).
+    private PulsarTlsFactory tlsFactory;
+    private JettyTlsFactory.ReloadableServerTls reloadableServerTls;
 
     public WorkerServer(WorkerService workerService, AuthenticationService authenticationService) {
         this.workerConfig = workerService.getWorkerConfig();
@@ -171,22 +179,12 @@ public class WorkerServer {
             log.info().attr("port", this.workerConfig.getWorkerPortTls())
                     .log("Configuring https server");
             try {
-                PulsarSslConfiguration sslConfiguration = buildSslConfiguration(workerConfig);
-                this.sslFactory = new DefaultPulsarSslFactory();
-                this.sslFactory.initialize(sslConfiguration);
-                this.sslFactory.createInternalSslContext();
                 this.scheduledExecutorService = Executors
                         .newSingleThreadScheduledExecutor(new ExecutorProvider
                                 .ExtendedThreadFactory("functions-worker-web-ssl-refresh"));
-                this.scheduledExecutorService.scheduleWithFixedDelay(this::refreshSslContext,
-                        workerConfig.getTlsCertRefreshCheckDurationSec(),
-                        workerConfig.getTlsCertRefreshCheckDurationSec(),
-                        TimeUnit.SECONDS);
-                SslContextFactory.Server sslCtxFactory =
-                        JettySslContextFactory.createSslContextFactory(this.workerConfig.getTlsProvider(),
-                                this.sslFactory, this.workerConfig.isTlsRequireTrustedClientCertOnConnect(),
-                                this.workerConfig.getWebServiceTlsCiphers(),
-                                this.workerConfig.getWebServiceTlsProtocols());
+                // PIP-478: the functions worker web listener uses the PulsarTlsFactory SPI (the built-in
+                // file-based factory by default, or a custom tlsFactoryClassName).
+                SslContextFactory.Server sslCtxFactory = createTlsFactoryWebServer(workerConfig);
                 List<ConnectionFactory> connectionFactories = new ArrayList<>();
                 if (workerConfig.isWebServiceHaProxyProtocolEnabled()) {
                     connectionFactories.add(new ProxyConnectionFactory());
@@ -291,6 +289,15 @@ public class WorkerServer {
         if (this.scheduledExecutorService != null) {
             this.scheduledExecutorService.shutdownNow();
         }
+        // PIP-478: dispose the TLS factory subscription and close the factory, if the new path was used.
+        if (this.reloadableServerTls != null) {
+            this.reloadableServerTls.subscription().dispose();
+            this.reloadableServerTls = null;
+        }
+        if (this.tlsFactory != null) {
+            this.tlsFactory.close();
+            this.tlsFactory = null;
+        }
     }
 
     public Optional<Integer> getListenPortHTTP() {
@@ -309,32 +316,63 @@ public class WorkerServer {
         }
     }
 
-    protected void refreshSslContext() {
-        try {
-            this.sslFactory.update();
-        } catch (Exception e) {
-            log.error().exception(e).log("Failed to refresh SSL context");
+    // PIP-478: the OpenTelemetry root for the WEB-purpose TlsFactoryInitContext, so pulsar.tls.reload emits
+    // for the worker web listener; OpenTelemetry.noop() when no PulsarWorkerService OTel handle is available.
+    private OpenTelemetry workerOpenTelemetry() {
+        if (workerService instanceof PulsarWorkerService pulsarWorkerService
+                && pulsarWorkerService.getOpenTelemetry() != null) {
+            return pulsarWorkerService.getOpenTelemetry().getOpenTelemetry();
         }
+        return OpenTelemetry.noop();
     }
 
-    protected PulsarSslConfiguration buildSslConfiguration(WorkerConfig config) {
-        return PulsarSslConfiguration.builder()
-                .tlsKeyStoreType(config.getTlsKeyStoreType())
-                .tlsKeyStorePath(config.getTlsKeyStore())
-                .tlsKeyStorePassword(config.getTlsKeyStorePassword())
-                .tlsTrustStoreType(config.getTlsTrustStoreType())
-                .tlsTrustStorePath(config.getTlsTrustStore())
-                .tlsTrustStorePassword(config.getTlsTrustStorePassword())
-                .tlsCiphers(config.getWebServiceTlsCiphers())
-                .tlsProtocols(config.getWebServiceTlsProtocols())
-                .tlsTrustCertsFilePath(config.getTlsTrustCertsFilePath())
-                .tlsCertificateFilePath(config.getTlsCertificateFilePath())
-                .tlsKeyFilePath(config.getTlsKeyFilePath())
+    // PIP-478: build the PulsarTlsFactory for the WEB purpose and drive a vanilla Jetty
+    // SslContextFactory.Server via the SSLContext subscription (no cert refresh task).
+    private SslContextFactory.Server createTlsFactoryWebServer(WorkerConfig config) throws Exception {
+        this.tlsFactory = TlsFactorySupport.createFactory(config.getTlsFactoryClassName(), null,
+                () -> buildDefaultWebTlsFactory(config));
+        TlsFactoryInitContext initContext = TlsFactorySupport.initContext(
+                TlsFactorySupport.parseFactoryConfig(config.getTlsFactoryConfig()),
+                scheduledExecutorService, scheduledExecutorService, workerOpenTelemetry());
+        TlsFactorySupport.initializeBlocking(this.tlsFactory, initContext);
+        this.reloadableServerTls = JettyTlsFactory.createReloadingServerFactory(this.tlsFactory, TlsPurpose.WEB,
+                config.getTlsProvider(), config.isTlsRequireTrustedClientCertOnConnect(),
+                config.isTlsAllowInsecureConnection(), config.getWebServiceTlsCiphers(),
+                config.getWebServiceTlsProtocols());
+        return this.reloadableServerTls.sslContextFactory();
+    }
+
+    private static PulsarTlsFactory buildDefaultWebTlsFactory(WorkerConfig config) {
+        TlsPolicy.Builder policyBuilder = TlsPolicy.builder()
                 .allowInsecureConnection(config.isTlsAllowInsecureConnection())
-                .requireTrustedClientCertOnConnect(config.isTlsRequireTrustedClientCertOnConnect())
-                .tlsEnabledWithKeystore(config.isTlsEnabledWithKeyStore())
-                .serverMode(true)
-                .isHttps(true)
+                .protocols(toList(config.getWebServiceTlsProtocols()))
+                .ciphers(toList(config.getWebServiceTlsCiphers()));
+        if (config.isTlsEnabledWithKeyStore()) {
+            policyBuilder.format(TlsPolicy.Format.KEYSTORE)
+                    .keyStoreType(config.getTlsKeyStoreType())
+                    .trustStoreType(config.getTlsTrustStoreType())
+                    .keyStorePath(config.getTlsKeyStore())
+                    .keyStorePassword(config.getTlsKeyStorePassword())
+                    .trustStorePath(config.getTlsTrustStore())
+                    .trustStorePassword(config.getTlsTrustStorePassword());
+        } else {
+            policyBuilder.format(TlsPolicy.Format.PEM)
+                    .trustCertsFilePath(config.getTlsTrustCertsFilePath())
+                    .certificateFilePath(config.getTlsCertificateFilePath())
+                    .keyFilePath(config.getTlsKeyFilePath());
+        }
+        Map<TlsPurpose, TlsPolicy> policies = Map.of(TlsPurpose.WEB, policyBuilder.build());
+        long refresh = config.getTlsCertRefreshCheckDurationSec();
+        // The Jetty web path uses a JDK SSLContext, so the Netty engine selection is irrelevant here.
+        FileBasedTlsFactorySettings settings = FileBasedTlsFactorySettings.builder()
+                .requireTrustedClientCert(config.isTlsRequireTrustedClientCertOnConnect())
+                .refreshIntervalSeconds(refresh <= 0 ? FileBasedTlsFactorySettings.DEFAULT_REFRESH_INTERVAL_SECONDS
+                        : (int) Math.min(refresh, Integer.MAX_VALUE))
                 .build();
+        return new FileBasedTlsFactory(policies, settings);
+    }
+
+    private static List<String> toList(Set<String> values) {
+        return values == null ? List.of() : List.copyOf(values);
     }
 }

--- a/pulsar-proxy/build.gradle.kts
+++ b/pulsar-proxy/build.gradle.kts
@@ -81,4 +81,7 @@ dependencies {
     testImplementation(libs.jjwt.impl)
     testImplementation(libs.okhttp3)
     testImplementation(libs.testcontainers)
+    // PIP-478: assert the proxy's TLS factory emits pulsar.tls.reload through the wired OpenTelemetry root.
+    testImplementation(libs.opentelemetry.sdk)
+    testImplementation(libs.opentelemetry.sdk.testing)
 }

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/AdminProxyHandler.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/AdminProxyHandler.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.proxy.server;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
+import io.opentelemetry.api.OpenTelemetry;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -28,20 +29,22 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLContext;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import lombok.CustomLog;
 import org.apache.pulsar.broker.PulsarServerException;
+import org.apache.pulsar.broker.tls.TlsFactorySupport;
 import org.apache.pulsar.broker.web.AuthenticationFilter;
 import org.apache.pulsar.client.api.Authentication;
-import org.apache.pulsar.client.api.AuthenticationDataProvider;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.util.ExecutorProvider;
-import org.apache.pulsar.common.util.PulsarSslConfiguration;
-import org.apache.pulsar.common.util.PulsarSslFactory;
+import org.apache.pulsar.common.tls.PulsarTlsFactory;
+import org.apache.pulsar.common.tls.TlsFactoryInitContext;
+import org.apache.pulsar.common.tls.TlsHandle;
+import org.apache.pulsar.common.tls.TlsPurpose;
+import org.apache.pulsar.jetty.tls.JettyTlsFactory;
 import org.apache.pulsar.policies.data.loadbalancer.ServiceLookupData;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.ProtocolHandlers;
@@ -84,27 +87,54 @@ class AdminProxyHandler extends ProxyServlet {
     private final Authentication proxyClientAuthentication;
     private final String brokerWebServiceUrl;
     private final String functionWorkerWebServiceUrl;
-    private PulsarSslFactory pulsarSslFactory;
+    // PIP-478 broker-client TLS SPI factory (the only path since the PIP-337 removal).
+    private PulsarTlsFactory brokerClientTlsFactory;
+    // PIP-478 (F3): the BROKER_CLIENT SSLContext subscription driving the Jetty HttpClient's reloading
+    // SslContextFactory.Client, so rotated broker-client material reaches new admin connections. Disposed
+    // in destroy().
+    private TlsHandle<SSLContext> brokerClientTlsSubscription;
+    // PIP-478: the OpenTelemetry root threaded into the BROKER_CLIENT-purpose TlsFactoryInitContext so
+    // pulsar.tls.reload emits; OpenTelemetry.noop() when unset.
+    private final OpenTelemetry openTelemetry;
     private ScheduledExecutorService sslContextRefresher;
 
     AdminProxyHandler(ProxyConfiguration config, BrokerDiscoveryProvider discoveryProvider,
                       Authentication proxyClientAuthentication) {
+        this(config, discoveryProvider, proxyClientAuthentication, OpenTelemetry.noop());
+    }
+
+    AdminProxyHandler(ProxyConfiguration config, BrokerDiscoveryProvider discoveryProvider,
+                      Authentication proxyClientAuthentication, OpenTelemetry openTelemetry) {
         this.config = config;
         this.discoveryProvider = discoveryProvider;
         this.proxyClientAuthentication = proxyClientAuthentication;
+        this.openTelemetry = openTelemetry;
         this.brokerWebServiceUrl = config.isTlsEnabledWithBroker() ? config.getBrokerWebServiceURLTLS()
                 : config.getBrokerWebServiceURL();
         this.functionWorkerWebServiceUrl = config.isTlsEnabledWithBroker() ? config.getFunctionWorkerWebServiceURLTLS()
                 : config.getFunctionWorkerWebServiceURL();
         if (config.isTlsEnabledWithBroker()) {
-            this.pulsarSslFactory = createPulsarSslFactory();
             this.sslContextRefresher = Executors.newSingleThreadScheduledExecutor(
                     new ExecutorProvider.ExtendedThreadFactory("pulsar-proxy-admin-handler-ssl-refresh"));
-            if (config.getTlsCertRefreshCheckDurationSec() > 0) {
-                this.sslContextRefresher.scheduleWithFixedDelay(this::refreshSslContext,
-                        config.getTlsCertRefreshCheckDurationSec(), config.getTlsCertRefreshCheckDurationSec(),
-                        TimeUnit.SECONDS);
-            }
+            this.brokerClientTlsFactory = createBrokerClientTlsFactory();
+        }
+    }
+
+    // PIP-478: build+initialize the broker-client PulsarTlsFactory (BROKER_CLIENT purpose). The factory owns
+    // rotation internally; newHttpClient() builds a self-reloading SslContextFactory.Client that swaps the
+    // context on rotation (F3), so a long-lived admin HttpClient picks up rotated broker-client material.
+    private PulsarTlsFactory createBrokerClientTlsFactory() {
+        try {
+            PulsarTlsFactory factory = TlsFactorySupport.createFactory(config.getBrokerClientTlsFactoryClassName(),
+                    null, () -> ProxyTlsFactories.brokerClientFactory(config, proxyClientAuthentication));
+            TlsFactoryInitContext initContext = TlsFactorySupport.initContext(
+                    TlsFactorySupport.parseFactoryConfig(config.getBrokerClientTlsFactoryConfig()),
+                    sslContextRefresher, sslContextRefresher, openTelemetry);
+            TlsFactorySupport.initializeBlocking(factory, initContext);
+            return factory;
+        } catch (Exception e) {
+            log.error().exception(e).log("Failed to create Pulsar TLS factory");
+            throw new RuntimeException(e);
         }
     }
 
@@ -222,7 +252,15 @@ class AdminProxyHandler extends ProxyServlet {
         try {
             if (config.isTlsEnabledWithBroker()) {
                 try {
-                    SslContextFactory.Client contextFactory = new Client(this.pulsarSslFactory);
+                    // PIP-478 (F3): a self-reloading (non-subclassed) client factory subscribed to the
+                    // BROKER_CLIENT SSLContext, so rotated broker-client material reaches new connections.
+                    JettyTlsFactory.ReloadableClientTls reloadable = JettyTlsFactory.createReloadingClientFactory(
+                            this.brokerClientTlsFactory, TlsPurpose.BROKER_CLIENT,
+                            config.getBrokerClientSslProvider());
+                    // Replace any prior subscription (newHttpClient may be invoked more than once).
+                    disposeBrokerClientTlsSubscription();
+                    this.brokerClientTlsSubscription = reloadable.subscription();
+                    SslContextFactory.Client contextFactory = reloadable.sslContextFactory();
                     if (!config.isTlsHostnameVerificationEnabled()) {
                         contextFactory.setEndpointIdentificationAlgorithm(null);
                     }
@@ -316,79 +354,26 @@ class AdminProxyHandler extends ProxyServlet {
         }
     }
 
-    private static class Client extends SslContextFactory.Client {
-
-        private final PulsarSslFactory sslFactory;
-
-        public Client(PulsarSslFactory sslFactory) {
-            super();
-            this.sslFactory = sslFactory;
-        }
-
-        @Override
-        public SSLContext getSslContext() {
-            return this.sslFactory.getInternalSslContext();
-        }
-    }
-
-    protected PulsarSslConfiguration buildSslConfiguration(AuthenticationDataProvider authData) {
-        return PulsarSslConfiguration.builder()
-                .tlsProvider(config.getBrokerClientSslProvider())
-                .tlsKeyStoreType(config.getBrokerClientTlsKeyStoreType())
-                .tlsKeyStorePath(config.getBrokerClientTlsKeyStore())
-                .tlsKeyStorePassword(config.getBrokerClientTlsKeyStorePassword())
-                .tlsTrustStoreType(config.getBrokerClientTlsTrustStoreType())
-                .tlsTrustStorePath(config.getBrokerClientTlsTrustStore())
-                .tlsTrustStorePassword(config.getBrokerClientTlsTrustStorePassword())
-                .tlsCiphers(config.getBrokerClientTlsCiphers())
-                .tlsProtocols(config.getBrokerClientTlsProtocols())
-                .tlsTrustCertsFilePath(config.getBrokerClientTrustCertsFilePath())
-                .tlsCertificateFilePath(config.getBrokerClientCertificateFilePath())
-                .tlsKeyFilePath(config.getBrokerClientKeyFilePath())
-                .allowInsecureConnection(config.isTlsAllowInsecureConnection())
-                .requireTrustedClientCertOnConnect(false)
-                .tlsEnabledWithKeystore(config.isBrokerClientTlsEnabledWithKeyStore())
-                .tlsCustomParams(config.getBrokerClientSslFactoryPluginParams())
-                .authData(authData)
-                .serverMode(false)
-                .isHttps(true)
-                .build();
-    }
-
-    protected PulsarSslFactory createPulsarSslFactory() {
-        try {
-            try {
-                AuthenticationDataProvider authData =
-                        proxyClientAuthentication.getAuthData(URI.create(getWebServiceUrl()).getHost());
-                PulsarSslConfiguration pulsarSslConfiguration = buildSslConfiguration(authData);
-                PulsarSslFactory sslFactory =
-                        (PulsarSslFactory) Class.forName(config.getBrokerClientSslFactoryPlugin())
-                                .getConstructor().newInstance();
-                sslFactory.initialize(pulsarSslConfiguration);
-                sslFactory.createInternalSslContext();
-                return sslFactory;
-            } catch (Exception e) {
-                log.error().exception(e).log("Failed to create Pulsar SSLFactory");
-                throw new PulsarClientException.InvalidConfigurationException(e.getMessage());
-            }
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    protected void refreshSslContext() {
-        try {
-            this.pulsarSslFactory.update();
-        } catch (Exception e) {
-            log.error().exception(e).log("Failed to refresh SSL context");
-        }
-    }
-
     @Override
     public void destroy() {
         super.destroy();
+        // PIP-478 (F3): dispose the BROKER_CLIENT SSLContext subscription driving the reloading Jetty
+        // client factory, then close the broker-client TLS factory if the new path was used.
+        disposeBrokerClientTlsSubscription();
+        if (this.brokerClientTlsFactory != null) {
+            this.brokerClientTlsFactory.close();
+            this.brokerClientTlsFactory = null;
+        }
         if (this.sslContextRefresher != null) {
             this.sslContextRefresher.shutdownNow();
+        }
+    }
+
+    private void disposeBrokerClientTlsSubscription() {
+        TlsHandle<SSLContext> subscription = this.brokerClientTlsSubscription;
+        if (subscription != null) {
+            this.brokerClientTlsSubscription = null;
+            subscription.dispose();
         }
     }
 }

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/DirectProxyHandler.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/DirectProxyHandler.java
@@ -20,7 +20,6 @@ package org.apache.pulsar.proxy.server;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
-import static org.apache.commons.lang3.StringUtils.isEmpty;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -39,13 +38,10 @@ import io.netty.handler.codec.haproxy.HAProxyMessage;
 import io.netty.handler.codec.haproxy.HAProxyProtocolVersion;
 import io.netty.handler.codec.haproxy.HAProxyProxiedProtocol;
 import io.netty.handler.flush.FlushConsolidationHandler;
-import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.timeout.ReadTimeoutHandler;
 import io.netty.util.CharsetUtil;
 import java.net.InetSocketAddress;
 import java.util.Arrays;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import lombok.CustomLog;
 import lombok.Getter;
@@ -64,9 +60,7 @@ import org.apache.pulsar.common.protocol.Commands;
 import org.apache.pulsar.common.protocol.FrameDecoderUtil;
 import org.apache.pulsar.common.protocol.PulsarDecoder;
 import org.apache.pulsar.common.stats.Rate;
-import org.apache.pulsar.common.util.PulsarSslConfiguration;
-import org.apache.pulsar.common.util.PulsarSslFactory;
-import org.apache.pulsar.common.util.SecurityUtility;
+import org.apache.pulsar.common.tls.impl.TlsContextAcquisition;
 import org.apache.pulsar.common.util.netty.NettyChannelUtil;
 
 @CustomLog
@@ -89,9 +83,7 @@ public class DirectProxyHandler {
     private AuthenticationDataProvider authenticationDataProvider;
     private final ProxyService service;
     private final Runnable onHandshakeCompleteAction;
-    private final boolean tlsHostnameVerificationEnabled;
     final boolean tlsEnabledWithBroker;
-    private Map<String, PulsarSslFactory> pulsarSslFactoryMap;
 
     @SneakyThrows
     public DirectProxyHandler(ProxyService service, ProxyConnection proxyConnection) {
@@ -104,9 +96,7 @@ public class DirectProxyHandler {
         this.clientAuthData = proxyConnection.clientAuthData;
         this.clientAuthMethod = proxyConnection.clientAuthMethod;
         this.tlsEnabledWithBroker = service.getConfiguration().isTlsEnabledWithBroker();
-        this.tlsHostnameVerificationEnabled = service.getConfiguration().isTlsHostnameVerificationEnabled();
         this.onHandshakeCompleteAction = proxyConnection::cancelKeepAliveTask;
-        this.pulsarSslFactoryMap = new ConcurrentHashMap<>();
     }
 
     public void connect(String brokerHostAndPort, InetSocketAddress targetBrokerAddress, int protocolVersion,
@@ -121,30 +111,10 @@ public class DirectProxyHandler {
             inboundChannel.close();
             return;
         }
-        PulsarSslFactory sslFactory =
-                tlsEnabledWithBroker ? pulsarSslFactoryMap.computeIfAbsent(remoteHost, (hostname) -> {
-                    AuthenticationDataProvider authData = null;
-
-                    if (!isEmpty(service.getConfiguration().getBrokerClientAuthenticationPlugin())) {
-                        try {
-                            authData = authentication.getAuthData(remoteHost);
-                        } catch (PulsarClientException e) {
-                            throw new RuntimeException(e);
-                        }
-                    }
-                    PulsarSslConfiguration sslConfiguration =
-                            buildSslConfiguration(service.getConfiguration(), authData);
-                    try {
-                        PulsarSslFactory factory =
-                                (PulsarSslFactory) Class.forName(service.getConfiguration().getSslFactoryPlugin())
-                                        .getConstructor().newInstance();
-                        factory.initialize(sslConfiguration);
-                        factory.createInternalSslContext();
-                        return factory;
-                    } catch (Exception e) {
-                        throw new RuntimeException(e);
-                    }
-                }) : null;
+        // PIP-478: ProxyService holds a shared, rotating SslContext for the BROKER_CLIENT purpose; it is read
+        // and pinned per connection inside initChannel below (the only broker-client TLS path since PIP-337
+        // removal). Reading it at connect time (rather than capturing it here, before the async
+        // connect) both narrows the use-after-free window and uses the freshest rotated material.
         ProxyConfiguration config = service.getConfiguration();
 
         // Start the connection attempt.
@@ -172,11 +142,13 @@ public class DirectProxyHandler {
                 if (tlsEnabledWithBroker) {
                     String host = targetBrokerAddress.getHostString();
                     int port = targetBrokerAddress.getPort();
-                    SslHandler handler = new SslHandler(sslFactory.createClientSslEngine(ch.alloc(), host, port));
-                    if (tlsHostnameVerificationEnabled) {
-                        SecurityUtility.configureSSLHandler(handler);
-                    }
-                    ch.pipeline().addLast(TLS_HANDLER, handler);
+                    // PIP-478: build the handler from the shared, rotating client SslContext, pinning it across
+                    // newHandler so a concurrent rotation cannot free the native OpenSSL context mid-build (F1
+                    // use-after-free guard). Hostname verification is baked into the context at build time (per
+                    // the client TlsPolicy), so it is not re-applied here; host/port drive SNI and the
+                    // verification target.
+                    ch.pipeline().addLast(TLS_HANDLER, TlsContextAcquisition.withPinnedContext(
+                            service::getBrokerClientSslContext, ctx -> ctx.newHandler(ch.alloc(), host, port)));
                 }
                 int brokerProxyReadTimeoutMs = service.getConfiguration().getBrokerProxyReadTimeoutMs();
                 if (brokerProxyReadTimeoutMs > 0) {
@@ -481,30 +453,6 @@ public class DirectProxyHandler {
 
     private void writeAndFlush(ByteBuf cmd) {
         NettyChannelUtil.writeAndFlushWithVoidPromise(outboundChannel, cmd);
-    }
-
-    protected PulsarSslConfiguration buildSslConfiguration(ProxyConfiguration config,
-                                                           AuthenticationDataProvider authData) {
-        return PulsarSslConfiguration.builder()
-                .tlsProvider(config.getBrokerClientSslProvider())
-                .tlsKeyStoreType(config.getBrokerClientTlsKeyStoreType())
-                .tlsKeyStorePath(config.getBrokerClientTlsKeyStore())
-                .tlsKeyStorePassword(config.getBrokerClientTlsKeyStorePassword())
-                .tlsTrustStoreType(config.getBrokerClientTlsTrustStoreType())
-                .tlsTrustStorePath(config.getBrokerClientTlsTrustStore())
-                .tlsTrustStorePassword(config.getBrokerClientTlsTrustStorePassword())
-                .tlsCiphers(config.getBrokerClientTlsCiphers())
-                .tlsProtocols(config.getBrokerClientTlsProtocols())
-                .tlsTrustCertsFilePath(config.getBrokerClientTrustCertsFilePath())
-                .tlsCertificateFilePath(config.getBrokerClientCertificateFilePath())
-                .tlsKeyFilePath(config.getBrokerClientKeyFilePath())
-                .allowInsecureConnection(config.isTlsAllowInsecureConnection())
-                .requireTrustedClientCertOnConnect(false)
-                .tlsEnabledWithKeystore(config.isBrokerClientTlsEnabledWithKeyStore())
-                .tlsCustomParams(config.getBrokerClientSslFactoryPluginParams())
-                .authData(authData)
-                .serverMode(false)
-                .build();
     }
 
 }

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyClientCnx.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyClientCnx.java
@@ -56,7 +56,9 @@ public class ProxyClientCnx extends ClientCnx {
     }
 
     @Override
-    protected ByteBuf newConnectCommand() throws Exception {
+    protected ByteBuf buildConnectCommand(AuthData authData) throws Exception {
+        // The proxy's own broker credential ({@code authData}) is resolved and published by ClientCnx's
+        // single connect continuation (PIP-478); here we only add the forwarded client identity to the frame.
         log.debug()
                 .attr("clientAuthRole", clientAuthRole)
                 .attr("clientAuthData", proxyConnection.getClientAuthData())
@@ -69,8 +71,6 @@ public class ProxyClientCnx extends ClientCnx {
             // authentication data.
             clientAuthData = proxyConnection.getClientAuthData();
         }
-        authenticationDataProvider = authentication.getAuthData(remoteHostName);
-        AuthData authData = authenticationDataProvider.authenticate(AuthData.INIT_AUTH_DATA);
         return Commands.newConnect(authentication.getAuthMethodName(), authData, protocolVersion,
                 proxyConnection.clientVersion, proxyToTargetBrokerAddress, clientAuthRole, clientAuthData,
                 clientAuthMethod, PulsarVersion.getVersion(), null);

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
@@ -42,7 +42,6 @@ import org.apache.pulsar.common.configuration.PulsarConfiguration;
 import org.apache.pulsar.common.nar.NarClassLoader;
 import org.apache.pulsar.common.protocol.Commands;
 import org.apache.pulsar.common.sasl.SaslConstants;
-import org.apache.pulsar.common.util.DefaultPulsarSslFactory;
 
 
 @Getter
@@ -668,15 +667,39 @@ public class ProxyConfiguration implements PulsarConfiguration {
     )
     private String tlsTrustStorePassword = null;
 
+    /**
+     * @deprecated since 5.0.0: the PIP-337 SSL factory plugin is removed (PIP-478); a non-default value is
+     *     rejected at proxy startup. Use {@code tlsFactoryClassName}.
+     */
+    @Deprecated
     @FieldContext(
             category = CATEGORY_TLS,
-            doc = "SSL Factory Plugin class to provide SSLEngine and SSLContext objects. The default "
-                    + " class used is DefaultSslFactory.")
-    private String sslFactoryPlugin = DefaultPulsarSslFactory.class.getName();
+            doc = "Deprecated (PIP-478): the PIP-337 SSL factory plugin is removed in Pulsar 5.0. Retained only "
+                    + "to reject a stale configuration at startup; use tlsFactoryClassName instead.")
+    private String sslFactoryPlugin = "";
+    /**
+     * @deprecated since 5.0.0: superseded by {@code tlsFactoryConfig} (PIP-478).
+     */
+    @Deprecated
     @FieldContext(
             category = CATEGORY_TLS,
-            doc = "SSL Factory plugin configuration parameters.")
+            doc = "Deprecated (PIP-478): the PIP-337 SSL factory plugin is removed in Pulsar 5.0; superseded by "
+                    + "tlsFactoryConfig.")
     private String sslFactoryPluginParams = "";
+    @FieldContext(
+            category = CATEGORY_TLS,
+            doc = "PIP-478 TLS factory (PulsarTlsFactory) class name for the proxy's server-side TLS "
+                    + "(binary front-end and web server; purposes PROXY/WEB). An empty value or the literal "
+                    + "'default' selects the built-in default factory composed from these tls* settings, "
+                    + "otherwise the named class is instantiated via its public no-arg constructor. This is "
+                    + "the only server TLS path; the removed PIP-337 sslFactoryPlugin keys are rejected at "
+                    + "startup when set to a non-default value.")
+    private String tlsFactoryClassName = "";
+    @FieldContext(
+            category = CATEGORY_TLS,
+            doc = "PIP-478 configuration parameters for tlsFactoryClassName. Accepts a JSON object or a "
+                    + "comma-separated key=value list.")
+    private String tlsFactoryConfig = "";
 
     /**
      * KeyStore TLS config variables used for proxy to auth with broker.
@@ -747,15 +770,40 @@ public class ProxyConfiguration implements PulsarConfiguration {
     )
     private Set<String> brokerClientTlsProtocols = new TreeSet<>();
 
+    /**
+     * @deprecated since 5.0.0: the PIP-337 SSL factory plugin is removed (PIP-478); a non-default value is
+     *     rejected at proxy startup. Use {@code brokerClientTlsFactoryClassName}.
+     */
+    @Deprecated
     @FieldContext(
             category = CATEGORY_TLS,
-            doc = "SSL Factory Plugin class used by internal client to provide SSLEngine and SSLContext objects. "
-                    + "The default class used is DefaultSslFactory.")
-    private String brokerClientSslFactoryPlugin = DefaultPulsarSslFactory.class.getName();
+            doc = "Deprecated (PIP-478): the PIP-337 SSL factory plugin is removed in Pulsar 5.0. Retained only "
+                    + "to reject a stale configuration at startup; use brokerClientTlsFactoryClassName instead.")
+    private String brokerClientSslFactoryPlugin = "";
+    /**
+     * @deprecated since 5.0.0: superseded by {@code brokerClientTlsFactoryConfig} (PIP-478).
+     */
+    @Deprecated
     @FieldContext(
             category = CATEGORY_TLS,
-            doc = "SSL Factory plugin configuration parameters used by internal client.")
+            doc = "Deprecated (PIP-478): the PIP-337 SSL factory plugin is removed in Pulsar 5.0; superseded by "
+                    + "brokerClientTlsFactoryConfig.")
     private String brokerClientSslFactoryPluginParams = "";
+    @FieldContext(
+            category = CATEGORY_TLS,
+            doc = "PIP-478 TLS factory (PulsarTlsFactory) class name for the proxy's own outbound "
+                    + "(proxy-to-broker) client connections (purpose BROKER_CLIENT). An empty value or the "
+                    + "literal 'default' selects the built-in default factory composed from the brokerClient "
+                    + "tls* settings, otherwise the named class is instantiated via its public no-arg "
+                    + "constructor. This is the only outbound-client TLS path; the removed PIP-337 "
+                    + "brokerClientSslFactoryPlugin keys are rejected at startup when set to a non-default "
+                    + "value.")
+    private String brokerClientTlsFactoryClassName = "";
+    @FieldContext(
+            category = CATEGORY_TLS,
+            doc = "PIP-478 configuration parameters for brokerClientTlsFactoryClassName. Accepts a JSON "
+                    + "object or a comma-separated key=value list.")
+    private String brokerClientTlsFactoryConfig = "";
 
     // HTTP
 

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConnection.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConnection.java
@@ -878,6 +878,25 @@ public class ProxyConnection extends PulsarHandler {
     }
 
     ClientConfigurationData createClientConfiguration() {
+        return createClientConfiguration(service);
+    }
+
+    /**
+     * Build the deterministic broker-client {@link ClientConfigurationData} the proxy uses for its outbound
+     * (proxy&rarr;broker) lookup and direct connections. The result depends only on the {@link ProxyService}
+     * configuration (identical for every connection), so {@link ProxyService} also calls it once at startup to
+     * derive the representative config for building the shared lookup client TLS factory.
+     *
+     * <p>PIP-478: when TLS with the broker is enabled the resolved lookup client TLS factory
+     * ({@link ProxyService#getLookupClientTlsFactory()}) is stashed on the config so the lookup
+     * {@code ConnectionPool}'s client transport can build its per-connection {@code SslContext} for the
+     * {@code CLIENT_DEFAULT} purpose. This method self-builds the config outside
+     * {@code PulsarClientImpl} (which is where the client factory is normally resolved), so the factory must
+     * be stashed here explicitly; otherwise the proxy binary lookup path hits a null-factory NPE. The factory
+     * is {@code null} while it is itself being built at startup, which is harmless: that representative config
+     * is only read for its {@code tls*} fields.
+     */
+    static ClientConfigurationData createClientConfiguration(ProxyService service) {
         ClientConfigurationData initialConf = new ClientConfigurationData();
         ProxyConfiguration proxyConfig = service.getConfiguration();
         initialConf.setServiceUrl(
@@ -892,7 +911,7 @@ public class ProxyConnection extends PulsarHandler {
                 .filterAndMapProperties(proxyConfig.getProperties(), "brokerClient_");
         ClientConfigurationData clientConf = ConfigurationDataUtils
                 .loadData(overrides, initialConf, ClientConfigurationData.class);
-        clientConf.setAuthentication(this.getClientAuthentication());
+        clientConf.setAuthentication(service.getProxyClientAuthenticationPlugin());
         if (proxyConfig.isTlsEnabledWithBroker()) {
             clientConf.setUseTls(true);
             clientConf.setTlsHostnameVerificationEnable(proxyConfig.isTlsHostnameVerificationEnabled());
@@ -910,6 +929,7 @@ public class ProxyConnection extends PulsarHandler {
                 clientConf.setTlsCertificateFilePath(proxyConfig.getBrokerClientCertificateFilePath());
             }
             clientConf.setTlsAllowInsecureConnection(proxyConfig.isTlsAllowInsecureConnection());
+            clientConf.setTlsFactory(service.getLookupClientTlsFactory());
         }
         return clientConf;
     }

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyService.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyService.java
@@ -31,6 +31,7 @@ import io.netty.channel.EventLoopGroup;
 import io.netty.channel.epoll.EpollServerSocketChannel;
 import io.netty.channel.socket.ServerSocketChannel;
 import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.ssl.SslContext;
 import io.netty.resolver.dns.DnsAddressResolverGroup;
 import io.netty.resolver.dns.DnsNameResolverBuilder;
 import io.netty.util.concurrent.DefaultThreadFactory;
@@ -63,13 +64,22 @@ import org.apache.pulsar.broker.limiter.ConnectionController;
 import org.apache.pulsar.broker.resources.PulsarResources;
 import org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsServlet;
 import org.apache.pulsar.broker.stats.prometheus.PrometheusRawMetricsProvider;
+import org.apache.pulsar.broker.tls.TlsFactorySupport;
 import org.apache.pulsar.broker.topiclistlimit.TopicListMemoryLimiter;
 import org.apache.pulsar.broker.topiclistlimit.TopicListSizeResultCache;
 import org.apache.pulsar.broker.web.plugin.servlet.AdditionalServlets;
 import org.apache.pulsar.client.api.Authentication;
+import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
+import org.apache.pulsar.client.impl.tls.ClientTlsFactorySupport;
 import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
 import org.apache.pulsar.common.configuration.PulsarConfigurationLoader;
 import org.apache.pulsar.common.semaphore.AsyncDualMemoryLimiterImpl;
+import org.apache.pulsar.common.tls.PulsarTlsFactory;
+import org.apache.pulsar.common.tls.TlsFactoryInitContext;
+import org.apache.pulsar.common.tls.TlsHandle;
+import org.apache.pulsar.common.tls.TlsPurpose;
+import org.apache.pulsar.common.tls.impl.TlsContextAcquisition;
+import org.apache.pulsar.common.tls.impl.TlsSynthesisSpec;
 import org.apache.pulsar.common.util.netty.DnsResolverUtil;
 import org.apache.pulsar.common.util.netty.EventLoopUtil;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
@@ -122,6 +132,19 @@ public class ProxyService implements Closeable {
 
     private final ScheduledExecutorService statsExecutor;
     private ScheduledExecutorService sslContextRefresher;
+    // PIP-478: the TLS front-end channel initializer that may own a PulsarTlsFactory (closed on shutdown),
+    // and the shared broker-client (proxy->broker) TLS. DirectProxyHandler reads the volatile SslContext
+    // without blocking the event loop; the subscription delivers rotation.
+    private ServiceChannelInitializer tlsServiceChannelInitializer;
+    private PulsarTlsFactory brokerClientTlsFactory;
+    private TlsHandle<SslContext> brokerClientTlsSubscription;
+    private volatile SslContext brokerClientSslContext;
+    // PIP-478: the shared client TLS factory serving the CLIENT_DEFAULT purpose for the proxy's binary
+    // lookup ConnectionPool (ProxyConnection stashes it on each self-built ClientConfigurationData). The
+    // proxy->broker lookup transport is a normal Pulsar client, whose PulsarChannelInitializer requests
+    // CLIENT_DEFAULT — the BROKER_CLIENT-purpose brokerClientTlsFactory above cannot serve it, so this is a
+    // second factory built from the same broker-client tls* material. Closed with the ProxyService.
+    private PulsarTlsFactory lookupClientTlsFactory;
 
     static final Gauge ACTIVE_CONNECTIONS = Gauge
             .build("pulsar_proxy_active_connections", "Number of connections currently active in the proxy").create()
@@ -287,8 +310,9 @@ public class ProxyService implements Closeable {
                     .newSingleThreadScheduledExecutor(
                             new DefaultThreadFactory("proxy-ssl-context-refresher"));
             ServerBootstrap tlsBootstrap = bootstrap.clone();
-            tlsBootstrap.childHandler(new ServiceChannelInitializer(this, proxyConfig, true,
-                    sslContextRefresher));
+            this.tlsServiceChannelInitializer = new ServiceChannelInitializer(this, proxyConfig, true,
+                    sslContextRefresher);
+            tlsBootstrap.childHandler(this.tlsServiceChannelInitializer);
             listenChannelTls = tlsBootstrap.bind(proxyConfig.getBindAddress(),
                     proxyConfig.getServicePortTls().get()).sync().channel();
             log.info()
@@ -309,6 +333,40 @@ public class ProxyService implements Closeable {
             this.serviceUrlTls = String.format("pulsar+ssl://%s:%d/", hostname, getListenPortTls().get());
         } else {
             this.serviceUrlTls = null;
+        }
+
+        // PIP-478: for the proxy->broker binary path, build one shared PulsarTlsFactory serving the
+        // BROKER_CLIENT purpose and subscribe to a volatile SslContext that DirectProxyHandler reads without
+        // blocking the event loop (rotation delivered by the subscription). This uses the subscribing overload
+        // rather than the client one-shot form on purpose: the proxy is a long-lived server holding outbound
+        // connections, and blocking createInstance().get() on the Netty event loop per connection is not
+        // acceptable. The endpoint hint is moot for the default file-based factory, which ignores it.
+        if (proxyConfig.isTlsEnabledWithBroker()) {
+            this.brokerClientTlsFactory = TlsFactorySupport.createFactory(
+                    proxyConfig.getBrokerClientTlsFactoryClassName(), null,
+                    () -> ProxyTlsFactories.brokerClientFactory(proxyConfig, proxyClientAuthentication));
+            TlsFactoryInitContext initContext = TlsFactorySupport.initContext(
+                    TlsFactorySupport.parseFactoryConfig(proxyConfig.getBrokerClientTlsFactoryConfig()),
+                    statsExecutor, statsExecutor, openTelemetry.getOpenTelemetry());
+            TlsFactorySupport.initializeBlocking(this.brokerClientTlsFactory, initContext);
+            this.brokerClientTlsSubscription = TlsContextAcquisition.acquireNettyContext(
+                            this.brokerClientTlsFactory, TlsPurpose.BROKER_CLIENT,
+                            TlsSynthesisSpec.client(proxyConfig.isTlsHostnameVerificationEnabled()),
+                            ctx -> this.brokerClientSslContext = ctx)
+                    .get()
+                    .orElseThrow(() -> new IllegalStateException(
+                            "TLS factory supplied no Netty SslContext for purpose " + TlsPurpose.BROKER_CLIENT));
+
+            // PIP-478: the proxy's binary lookup ConnectionPool uses a normal Pulsar client transport, whose
+            // PulsarChannelInitializer requests a CLIENT_DEFAULT SslContext from the factory stashed on its
+            // ClientConfigurationData. ProxyConnection builds that config per connection but does not run the
+            // PulsarClientImpl setup that resolves the client factory, so build one shared CLIENT_DEFAULT
+            // factory here (from the same broker-client tls* material, initialized off the event loop) and let
+            // ProxyConnection stash it on each config. Built from a representative config; the factory itself is
+            // still null at this point, so resolveClientTlsFactory takes the default (non-adopted) path.
+            ClientConfigurationData lookupClientConf = ProxyConnection.createClientConfiguration(this);
+            this.lookupClientTlsFactory = ClientTlsFactorySupport.resolveClientTlsFactory(
+                    lookupClientConf, statsExecutor, statsExecutor, openTelemetry.getOpenTelemetry());
         }
 
         createMetricsServlet();
@@ -475,6 +533,30 @@ public class ProxyService implements Closeable {
                 Thread.currentThread().interrupt();
             }
         }
+
+        // PIP-478 (F2): dispose the new-SPI TLS resources (front-end subscription + shared broker-client
+        // factory) ONLY AFTER the worker and extension event loops are fully quiesced. Those loops run the
+        // proxy's inbound TLS handshakes (ServiceChannelInitializer) and outbound broker-connects
+        // (DirectProxyHandler), both of which build handlers from these factory-owned Netty contexts. Freeing
+        // the contexts while a loop can still start a connection would run newHandler on a released native
+        // OpenSSL context (use-after-free) — mirror the broker's loops-before-initializer-close ordering.
+        if (this.tlsServiceChannelInitializer != null) {
+            this.tlsServiceChannelInitializer.close();
+            this.tlsServiceChannelInitializer = null;
+        }
+        if (this.brokerClientTlsSubscription != null) {
+            this.brokerClientTlsSubscription.dispose();
+            this.brokerClientTlsSubscription = null;
+        }
+        if (this.brokerClientTlsFactory != null) {
+            this.brokerClientTlsFactory.close();
+            this.brokerClientTlsFactory = null;
+        }
+        if (this.lookupClientTlsFactory != null) {
+            this.lookupClientTlsFactory.close();
+            this.lookupClientTlsFactory = null;
+        }
+
         log.info("ProxyService closed.");
     }
 
@@ -513,6 +595,28 @@ public class ProxyService implements Closeable {
 
     public ProxyConfiguration getConfiguration() {
         return proxyConfig;
+    }
+
+    /**
+     * PIP-478: the current proxy&rarr;broker (BROKER_CLIENT) Netty {@link SslContext} when the new TLS SPI is
+     * selected for broker-client TLS, or {@code null} when the legacy PIP-337 path is used. Read by
+     * {@code DirectProxyHandler} to build the outbound SslHandler without blocking the event loop.
+     *
+     * @return the shared broker-client SslContext, or {@code null} on the legacy path
+     */
+    public SslContext getBrokerClientSslContext() {
+        return brokerClientSslContext;
+    }
+
+    /**
+     * The shared CLIENT_DEFAULT TLS factory for the proxy's binary lookup ConnectionPool (PIP-478).
+     * {@code null} when TLS with the broker is disabled, and transiently {@code null} while it is being
+     * built at startup (the factory is resolved from a representative {@code ClientConfigurationData}).
+     *
+     * @return the lookup client TLS factory, or {@code null}
+     */
+    public PulsarTlsFactory getLookupClientTlsFactory() {
+        return lookupClientTlsFactory;
     }
 
     public AuthenticationService getAuthenticationService() {

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyServiceStarter.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyServiceStarter.java
@@ -47,6 +47,7 @@ import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.authentication.AuthenticationService;
 import org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsServlet;
+import org.apache.pulsar.broker.tls.TlsFactorySupport;
 import org.apache.pulsar.broker.web.plugin.servlet.AdditionalServletWithClassLoader;
 import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.AuthenticationFactory;
@@ -173,6 +174,11 @@ public class ProxyServiceStarter {
                 proxyConfigurationCustomizer.accept(config);
             }
 
+            // PIP-478: the PIP-337 sslFactoryPlugin path is removed; reject a stale, non-default
+            // sslFactoryPlugin / brokerClientSslFactoryPlugin loudly at startup rather than silently ignore a
+            // security-relevant setting.
+            rejectRemovedPip337SslFactoryPlugin(config);
+
             if (!isBlank(zookeeperServers)) {
                 // Use zookeeperServers from command line
                 config.setMetadataStoreUrl(zookeeperServers);
@@ -243,6 +249,19 @@ public class ProxyServiceStarter {
                 + " it should point to the discovery service provider.");
     }
 
+    // PIP-478: reject a stale, non-default PIP-337 sslFactoryPlugin / brokerClientSslFactoryPlugin
+    // (removed in 5.0) at startup. The @Deprecated getters are read intentionally here to enforce the removal.
+    @SuppressWarnings("deprecation")
+    private static void rejectRemovedPip337SslFactoryPlugin(ProxyConfiguration config) {
+        if (TlsFactorySupport.isLegacyCustom(config.getSslFactoryPlugin())
+                || TlsFactorySupport.isLegacyCustom(config.getBrokerClientSslFactoryPlugin())) {
+            throw new IllegalArgumentException("The PIP-337 sslFactoryPlugin / brokerClientSslFactoryPlugin "
+                    + "configuration is removed in Pulsar 5.0 (PIP-478); migrate the custom factory to a "
+                    + "PulsarTlsFactory via tlsFactoryClassName / brokerClientTlsFactoryClassName and clear "
+                    + "sslFactoryPlugin / brokerClientSslFactoryPlugin.");
+        }
+    }
+
     public static void main(String[] args) throws Exception {
         ProxyServiceStarter serviceStarter = new ProxyServiceStarter(args);
         try {
@@ -277,8 +296,9 @@ public class ProxyServiceStarter {
 
         // create proxy service
         proxyService = new ProxyService(config, authenticationService, proxyClientAuthentication);
-        // create a web-service
-        server = new WebServer(config, authenticationService);
+        // create a web-service (PIP-478: share the proxy's OpenTelemetry root so the WEB-purpose TLS factory
+        // emits pulsar.tls.reload instead of a no-op)
+        server = new WebServer(config, authenticationService, proxyService.getOpenTelemetry().getOpenTelemetry());
 
         if (!embeddedMode) {
             Runtime.getRuntime().addShutdownHook(new Thread(this::close));
@@ -391,8 +411,12 @@ public class ProxyServiceStarter {
             }
         }
 
+        // PIP-478: thread the proxy's OpenTelemetry root so the admin handler's BROKER_CLIENT TLS factory
+        // emits pulsar.tls.reload (no-op when no ProxyService is available, e.g. in tests).
+        io.opentelemetry.api.OpenTelemetry telemetryRoot = service != null
+                ? service.getOpenTelemetry().getOpenTelemetry() : io.opentelemetry.api.OpenTelemetry.noop();
         AdminProxyHandler adminProxyHandler = new AdminProxyHandler(config, discoveryProvider,
-                proxyClientAuthentication);
+                proxyClientAuthentication, telemetryRoot);
         ServletHolder servletHolder = new ServletHolder(adminProxyHandler);
         server.addServlet("/admin", servletHolder);
         server.addServlet("/lookup", servletHolder);

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyTlsFactories.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyTlsFactories.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.proxy.server;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.pulsar.broker.tls.TlsFactorySupport;
+import org.apache.pulsar.client.api.Authentication;
+import org.apache.pulsar.client.api.AuthenticationDataProvider;
+import org.apache.pulsar.common.tls.PulsarTlsFactory;
+import org.apache.pulsar.common.tls.TlsPolicy;
+import org.apache.pulsar.common.tls.TlsPurpose;
+import org.apache.pulsar.common.tls.impl.FileBasedTlsFactory;
+import org.apache.pulsar.common.tls.impl.FileBasedTlsFactorySettings;
+
+/**
+ * Composes the proxy's built-in {@link PulsarTlsFactory} instances from a {@link ProxyConfiguration}
+ * (PIP-478 stage 2b), mirroring {@code DefaultBrokerTlsFactory} but reading the proxy config. Used when the
+ * new PIP-478 TLS path is selected without a custom {@code tlsFactoryClassName}.
+ */
+final class ProxyTlsFactories {
+
+    private ProxyTlsFactories() {
+    }
+
+    /**
+     * A server-side factory serving a single server purpose (PROXY or WEB) from the proxy's server TLS
+     * material with the supplied ciphers/protocols (the binary front-end and the web server use different
+     * cipher/protocol lists).
+     */
+    static PulsarTlsFactory serverFactory(ProxyConfiguration config, TlsPurpose purpose,
+                                          Set<String> ciphers, Set<String> protocols) {
+        Map<TlsPurpose, TlsPolicy> policies = Map.of(purpose, serverPolicy(config, ciphers, protocols));
+        FileBasedTlsFactorySettings settings = FileBasedTlsFactorySettings.builder()
+                .requireTrustedClientCert(config.isTlsRequireTrustedClientCertOnConnect())
+                .refreshIntervalSeconds(refreshIntervalSeconds(config))
+                .engineProvider(TlsFactorySupport.engineProvider(config.getTlsProvider()))
+                .build();
+        return new FileBasedTlsFactory(policies, settings);
+    }
+
+    /**
+     * A client-side factory serving {@link TlsPurpose#BROKER_CLIENT} from the proxy's {@code brokerClient*}
+     * TLS material, for the proxy&rarr;broker binary path and the admin HTTP client. When a broker-client
+     * authentication plugin is configured, its TLS material is folded over the file policy (auth-cert-wins,
+     * PIP-478) so the proxy presents the right identity to the broker and forwarded-principal authorization
+     * works — the server-side mirror of the client TLS override hook, preserving the removed PIP-337
+     * auth-data behavior.
+     *
+     * @param config             the proxy configuration
+     * @param brokerClientAuth   the proxy's broker-client authentication, or {@code null} for no fold
+     */
+    static PulsarTlsFactory brokerClientFactory(ProxyConfiguration config, Authentication brokerClientAuth) {
+        Map<TlsPurpose, TlsPolicy> policies = Map.of(TlsPurpose.BROKER_CLIENT, brokerClientPolicy(config));
+        FileBasedTlsFactorySettings settings = FileBasedTlsFactorySettings.builder()
+                .requireTrustedClientCert(false)
+                .refreshIntervalSeconds(refreshIntervalSeconds(config))
+                .engineProvider(TlsFactorySupport.engineProvider(config.getBrokerClientSslProvider()))
+                .build();
+        Map<TlsPurpose, Supplier<AuthenticationDataProvider>> authSuppliers =
+                (brokerClientAuth != null && StringUtils.isNotBlank(config.getBrokerClientAuthenticationPlugin()))
+                        ? Map.of(TlsPurpose.BROKER_CLIENT, FileBasedTlsFactory.authMaterialSupplier(brokerClientAuth))
+                        : Map.of();
+        return new FileBasedTlsFactory(policies, settings, authSuppliers);
+    }
+
+    private static TlsPolicy serverPolicy(ProxyConfiguration config, Set<String> ciphers, Set<String> protocols) {
+        TlsPolicy.Builder builder = TlsPolicy.builder()
+                .allowInsecureConnection(config.isTlsAllowInsecureConnection())
+                .enableHostnameVerification(config.isTlsHostnameVerificationEnabled())
+                .protocols(toList(protocols))
+                .ciphers(toList(ciphers));
+        if (config.isTlsEnabledWithKeyStore()) {
+            builder.format(TlsPolicy.Format.KEYSTORE)
+                    .keyStoreType(config.getTlsKeyStoreType())
+                    .trustStoreType(config.getTlsTrustStoreType())
+                    .keyStorePath(config.getTlsKeyStore())
+                    .keyStorePassword(config.getTlsKeyStorePassword())
+                    .trustStorePath(config.getTlsTrustStore())
+                    .trustStorePassword(config.getTlsTrustStorePassword());
+        } else {
+            builder.format(TlsPolicy.Format.PEM)
+                    .trustCertsFilePath(config.getTlsTrustCertsFilePath())
+                    .certificateFilePath(config.getTlsCertificateFilePath())
+                    .keyFilePath(config.getTlsKeyFilePath());
+        }
+        return builder.build();
+    }
+
+    private static TlsPolicy brokerClientPolicy(ProxyConfiguration config) {
+        TlsPolicy.Builder builder = TlsPolicy.builder()
+                .allowInsecureConnection(config.isTlsAllowInsecureConnection())
+                .enableHostnameVerification(config.isTlsHostnameVerificationEnabled())
+                .protocols(toList(config.getBrokerClientTlsProtocols()))
+                .ciphers(toList(config.getBrokerClientTlsCiphers()));
+        if (config.isBrokerClientTlsEnabledWithKeyStore()) {
+            builder.format(TlsPolicy.Format.KEYSTORE)
+                    .keyStoreType(config.getBrokerClientTlsKeyStoreType())
+                    .trustStoreType(config.getBrokerClientTlsTrustStoreType())
+                    .keyStorePath(config.getBrokerClientTlsKeyStore())
+                    .keyStorePassword(config.getBrokerClientTlsKeyStorePassword())
+                    .trustStorePath(config.getBrokerClientTlsTrustStore())
+                    .trustStorePassword(config.getBrokerClientTlsTrustStorePassword());
+        } else {
+            builder.format(TlsPolicy.Format.PEM)
+                    .trustCertsFilePath(config.getBrokerClientTrustCertsFilePath())
+                    .certificateFilePath(config.getBrokerClientCertificateFilePath())
+                    .keyFilePath(config.getBrokerClientKeyFilePath());
+        }
+        return builder.build();
+    }
+
+    private static int refreshIntervalSeconds(ProxyConfiguration config) {
+        long configured = config.getTlsCertRefreshCheckDurationSec();
+        if (configured <= 0) {
+            return FileBasedTlsFactorySettings.DEFAULT_REFRESH_INTERVAL_SECONDS;
+        }
+        return (int) Math.min(configured, Integer.MAX_VALUE);
+    }
+
+    private static List<String> toList(Set<String> values) {
+        return values == null ? List.of() : List.copyOf(values);
+    }
+}

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ServiceChannelInitializer.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ServiceChannelInitializer.java
@@ -21,15 +21,20 @@ package org.apache.pulsar.proxy.server;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.flush.FlushConsolidationHandler;
-import io.netty.handler.ssl.SslHandler;
+import io.netty.handler.ssl.SslContext;
 import io.netty.handler.timeout.ReadTimeoutHandler;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import lombok.CustomLog;
+import org.apache.pulsar.broker.tls.TlsFactorySupport;
 import org.apache.pulsar.common.protocol.FrameDecoderUtil;
 import org.apache.pulsar.common.protocol.OptionalProxyProtocolDecoder;
-import org.apache.pulsar.common.util.PulsarSslConfiguration;
-import org.apache.pulsar.common.util.PulsarSslFactory;
+import org.apache.pulsar.common.tls.PulsarTlsFactory;
+import org.apache.pulsar.common.tls.TlsFactoryInitContext;
+import org.apache.pulsar.common.tls.TlsHandle;
+import org.apache.pulsar.common.tls.TlsPurpose;
+import org.apache.pulsar.common.tls.impl.TlsContextAcquisition;
+import org.apache.pulsar.common.tls.impl.TlsSynthesisSpec;
 
 /**
  * Initialize service channel handlers.
@@ -45,7 +50,10 @@ public class ServiceChannelInitializer extends ChannelInitializer<SocketChannel>
     private final int brokerProxyReadTimeoutMs;
     private final int maxMessageSize;
 
-    private PulsarSslFactory sslFactory;
+    // PIP-478 TLS SPI factory (the only server TLS path since the PIP-337 removal).
+    private PulsarTlsFactory tlsFactory;
+    private TlsHandle<SslContext> tlsSubscription;
+    private volatile SslContext tlsServerContext;
 
     public ServiceChannelInitializer(ProxyService proxyService, ProxyConfiguration serviceConfig,
                                      boolean enableTls, ScheduledExecutorService sslContextRefresher)
@@ -58,16 +66,40 @@ public class ServiceChannelInitializer extends ChannelInitializer<SocketChannel>
         this.maxMessageSize = serviceConfig.getMaxMessageSize();
 
         if (enableTls) {
-            PulsarSslConfiguration sslConfiguration = buildSslConfiguration(serviceConfig);
-            this.sslFactory = (PulsarSslFactory) Class.forName(serviceConfig.getSslFactoryPlugin())
-                    .getConstructor().newInstance();
-            this.sslFactory.initialize(sslConfiguration);
-            this.sslFactory.createInternalSslContext();
-            if (serviceConfig.getTlsCertRefreshCheckDurationSec() > 0) {
-                sslContextRefresher.scheduleWithFixedDelay(this::refreshSslContext,
-                        serviceConfig.getTlsCertRefreshCheckDurationSec(),
-                        serviceConfig.getTlsCertRefreshCheckDurationSec(), TimeUnit.SECONDS);
-            }
+            initializeTlsFactory(serviceConfig, sslContextRefresher);
+        }
+    }
+
+    // PIP-478: build the PulsarTlsFactory and subscribe to the PROXY purpose; the volatile Netty SslContext
+    // holds the latest instance (rotation delivered by the subscription; no cert-refresh task).
+    private void initializeTlsFactory(ProxyConfiguration serviceConfig,
+                                      ScheduledExecutorService scheduler) throws Exception {
+        this.tlsFactory = TlsFactorySupport.createFactory(serviceConfig.getTlsFactoryClassName(), null,
+                () -> ProxyTlsFactories.serverFactory(serviceConfig, TlsPurpose.PROXY,
+                        serviceConfig.getTlsCiphers(), serviceConfig.getTlsProtocols()));
+        TlsFactoryInitContext initContext = TlsFactorySupport.initContext(
+                TlsFactorySupport.parseFactoryConfig(serviceConfig.getTlsFactoryConfig()),
+                scheduler, scheduler, proxyService.getOpenTelemetry().getOpenTelemetry());
+        TlsFactorySupport.initializeBlocking(this.tlsFactory, initContext);
+        this.tlsSubscription = TlsContextAcquisition.acquireNettyContext(this.tlsFactory, TlsPurpose.PROXY,
+                        TlsSynthesisSpec.server(serviceConfig.isTlsRequireTrustedClientCertOnConnect()),
+                        ctx -> this.tlsServerContext = ctx)
+                .get()
+                .orElseThrow(() -> new IllegalStateException(
+                        "TLS factory supplied no Netty SslContext for purpose " + TlsPurpose.PROXY));
+    }
+
+    /** Dispose the PIP-478 TLS factory and its subscription, if any. */
+    public void close() {
+        TlsHandle<SslContext> subscription = this.tlsSubscription;
+        if (subscription != null) {
+            this.tlsSubscription = null;
+            subscription.dispose();
+        }
+        PulsarTlsFactory factory = this.tlsFactory;
+        if (factory != null) {
+            this.tlsFactory = null;
+            factory.close();
         }
     }
 
@@ -76,7 +108,10 @@ public class ServiceChannelInitializer extends ChannelInitializer<SocketChannel>
         ch.pipeline().addLast("consolidation", new FlushConsolidationHandler(1024,
                 true));
         if (this.enableTls) {
-            ch.pipeline().addLast(TLS_HANDLER, new SslHandler(this.sslFactory.createServerSslEngine(ch.alloc())));
+            // PIP-478: pin the current (possibly rotated) factory-owned SslContext across newHandler so a
+            // concurrent rotation cannot free the native OpenSSL context mid-build (F1 use-after-free guard).
+            ch.pipeline().addLast(TLS_HANDLER, TlsContextAcquisition.withPinnedContext(
+                    () -> this.tlsServerContext, ctx -> ctx.newHandler(ch.alloc())));
         }
         if (brokerProxyReadTimeoutMs > 0) {
             ch.pipeline().addLast("readTimeoutHandler",
@@ -87,36 +122,5 @@ public class ServiceChannelInitializer extends ChannelInitializer<SocketChannel>
         }
         FrameDecoderUtil.addFrameDecoder(ch.pipeline(), maxMessageSize);
         ch.pipeline().addLast("handler", new ProxyConnection(proxyService, proxyService.getDnsAddressResolverGroup()));
-    }
-
-    protected PulsarSslConfiguration buildSslConfiguration(ProxyConfiguration config) {
-        return PulsarSslConfiguration.builder()
-                .tlsProvider(config.getTlsProvider())
-                .tlsKeyStoreType(config.getTlsKeyStoreType())
-                .tlsKeyStorePath(config.getTlsKeyStore())
-                .tlsKeyStorePassword(config.getTlsKeyStorePassword())
-                .tlsTrustStoreType(config.getTlsTrustStoreType())
-                .tlsTrustStorePath(config.getTlsTrustStore())
-                .tlsTrustStorePassword(config.getTlsTrustStorePassword())
-                .tlsCiphers(config.getTlsCiphers())
-                .tlsProtocols(config.getTlsProtocols())
-                .tlsTrustCertsFilePath(config.getTlsTrustCertsFilePath())
-                .tlsCertificateFilePath(config.getTlsCertificateFilePath())
-                .tlsKeyFilePath(config.getTlsKeyFilePath())
-                .allowInsecureConnection(config.isTlsAllowInsecureConnection())
-                .requireTrustedClientCertOnConnect(config.isTlsRequireTrustedClientCertOnConnect())
-                .tlsEnabledWithKeystore(config.isTlsEnabledWithKeyStore())
-                .tlsCustomParams(config.getSslFactoryPluginParams())
-                .authData(null)
-                .serverMode(true)
-                .build();
-    }
-
-    protected void refreshSslContext() {
-        try {
-            this.sslFactory.update();
-        } catch (Exception e) {
-            log.error().exception(e).log("Failed to refresh SSL context");
-        }
     }
 }

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/WebServer.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/WebServer.java
@@ -33,7 +33,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 import javax.servlet.DispatcherType;
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
@@ -46,17 +45,19 @@ import lombok.CustomLog;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.broker.authentication.AuthenticationService;
+import org.apache.pulsar.broker.tls.TlsFactorySupport;
 import org.apache.pulsar.broker.web.AuthenticationFilter;
 import org.apache.pulsar.broker.web.JettyRequestLogFactory;
 import org.apache.pulsar.broker.web.JsonMapperProvider;
 import org.apache.pulsar.broker.web.RateLimitingFilter;
 import org.apache.pulsar.broker.web.WebExecutorThreadPool;
 import org.apache.pulsar.client.util.ExecutorProvider;
+import org.apache.pulsar.common.tls.PulsarTlsFactory;
+import org.apache.pulsar.common.tls.TlsFactoryInitContext;
+import org.apache.pulsar.common.tls.TlsPurpose;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
-import org.apache.pulsar.common.util.PulsarSslConfiguration;
-import org.apache.pulsar.common.util.PulsarSslFactory;
 import org.apache.pulsar.jetty.metrics.JettyStatisticsCollector;
-import org.apache.pulsar.jetty.tls.JettySslContextFactory;
+import org.apache.pulsar.jetty.tls.JettyTlsFactory;
 import org.apache.pulsar.proxy.stats.PulsarProxyOpenTelemetry;
 import org.eclipse.jetty.ee8.servlet.FilterHolder;
 import org.eclipse.jetty.ee8.servlet.ServletContextHandler;
@@ -103,11 +104,23 @@ public class WebServer {
     private ServerConnector connectorTls;
 
     private ScheduledExecutorService sslRefreshScheduledExecutor;
-    private PulsarSslFactory sslFactory;
+    // PIP-478 TLS SPI factory (the only server TLS path since the PIP-337 removal).
+    private PulsarTlsFactory tlsFactory;
+    private JettyTlsFactory.ReloadableServerTls reloadableServerTls;
 
     private final FilterInitializer filterInitializer;
 
+    // PIP-478: the OpenTelemetry root threaded into the WEB-purpose TlsFactoryInitContext (so
+    // pulsar.tls.reload emits for the proxy web listener); OpenTelemetry.noop() when unset.
+    private final OpenTelemetry openTelemetry;
+
     public WebServer(ProxyConfiguration config, AuthenticationService authenticationService) {
+        this(config, authenticationService, OpenTelemetry.noop());
+    }
+
+    public WebServer(ProxyConfiguration config, AuthenticationService authenticationService,
+                     OpenTelemetry openTelemetry) {
+        this.openTelemetry = openTelemetry;
         this.webServiceExecutor = new WebExecutorThreadPool(config.getHttpNumThreads(), "pulsar-external-web",
                 config.getHttpServerThreadPoolQueueSize());
         this.server = new Server(webServiceExecutor);
@@ -143,22 +156,7 @@ public class WebServer {
         }
         if (config.getWebServicePortTls().isPresent()) {
             try {
-                this.sslRefreshScheduledExecutor = Executors.newSingleThreadScheduledExecutor(
-                        new ExecutorProvider.ExtendedThreadFactory("pulsar-proxy-web-server-tls-refresh"));
-                PulsarSslConfiguration sslConfiguration = buildSslConfiguration(config);
-                this.sslFactory = (PulsarSslFactory) Class.forName(config.getSslFactoryPlugin())
-                        .getConstructor().newInstance();
-                this.sslFactory.initialize(sslConfiguration);
-                this.sslFactory.createInternalSslContext();
-                if (config.getTlsCertRefreshCheckDurationSec() > 0) {
-                    sslRefreshScheduledExecutor.scheduleWithFixedDelay(this::refreshSslContext,
-                            config.getTlsCertRefreshCheckDurationSec(),
-                            config.getTlsCertRefreshCheckDurationSec(), TimeUnit.SECONDS);
-                }
-                SslContextFactory.Server sslCtxFactory =
-                        JettySslContextFactory.createSslContextFactory(config.getTlsProvider(),
-                                sslFactory, config.isTlsRequireTrustedClientCertOnConnect(),
-                                config.getWebServiceTlsCiphers(), config.getWebServiceTlsProtocols());
+                SslContextFactory.Server sslCtxFactory = createTlsFactoryWebServer(config);
                 List<ConnectionFactory> connectionFactories = new ArrayList<>();
                 if (config.isWebServiceHaProxyProtocolEnabled()) {
                     connectionFactories.add(new ProxyConnectionFactory());
@@ -387,6 +385,15 @@ public class WebServer {
         if (this.sslRefreshScheduledExecutor != null) {
             this.sslRefreshScheduledExecutor.shutdownNow();
         }
+        // PIP-478: dispose the TLS factory subscription and close the factory, if the new path was used.
+        if (this.reloadableServerTls != null) {
+            this.reloadableServerTls.subscription().dispose();
+            this.reloadableServerTls = null;
+        }
+        if (this.tlsFactory != null) {
+            this.tlsFactory.close();
+            this.tlsFactory = null;
+        }
         server.stop();
         webServiceExecutor.stop();
         log.info("Server stopped successfully");
@@ -412,36 +419,23 @@ public class WebServer {
         }
     }
 
-    protected PulsarSslConfiguration buildSslConfiguration(ProxyConfiguration config) {
-        return PulsarSslConfiguration.builder()
-                .tlsProvider(config.getTlsProvider())
-                .tlsKeyStoreType(config.getTlsKeyStoreType())
-                .tlsKeyStorePath(config.getTlsKeyStore())
-                .tlsKeyStorePassword(config.getTlsKeyStorePassword())
-                .tlsTrustStoreType(config.getTlsTrustStoreType())
-                .tlsTrustStorePath(config.getTlsTrustStore())
-                .tlsTrustStorePassword(config.getTlsTrustStorePassword())
-                .tlsCiphers(config.getTlsCiphers())
-                .tlsProtocols(config.getTlsProtocols())
-                .tlsTrustCertsFilePath(config.getTlsTrustCertsFilePath())
-                .tlsCertificateFilePath(config.getTlsCertificateFilePath())
-                .tlsKeyFilePath(config.getTlsKeyFilePath())
-                .allowInsecureConnection(config.isTlsAllowInsecureConnection())
-                .requireTrustedClientCertOnConnect(config.isTlsRequireTrustedClientCertOnConnect())
-                .tlsEnabledWithKeystore(config.isTlsEnabledWithKeyStore())
-                .tlsCustomParams(config.getSslFactoryPluginParams())
-                .authData(null)
-                .serverMode(true)
-                .isHttps(true)
-                .build();
-    }
-
-    protected void refreshSslContext() {
-        try {
-            this.sslFactory.update();
-        } catch (Exception e) {
-            log.error().exception(e).log("Failed to refresh SSL context");
-        }
+    // PIP-478: build the PulsarTlsFactory for the WEB purpose and drive a vanilla Jetty
+    // SslContextFactory.Server via the SSLContext subscription (no cert refresh task).
+    private SslContextFactory.Server createTlsFactoryWebServer(ProxyConfiguration config) throws Exception {
+        this.sslRefreshScheduledExecutor = Executors.newSingleThreadScheduledExecutor(
+                new ExecutorProvider.ExtendedThreadFactory("pulsar-proxy-web-server-tls-refresh"));
+        this.tlsFactory = TlsFactorySupport.createFactory(config.getTlsFactoryClassName(), null,
+                () -> ProxyTlsFactories.serverFactory(config, TlsPurpose.WEB,
+                        config.getWebServiceTlsCiphers(), config.getWebServiceTlsProtocols()));
+        TlsFactoryInitContext initContext = TlsFactorySupport.initContext(
+                TlsFactorySupport.parseFactoryConfig(config.getTlsFactoryConfig()),
+                sslRefreshScheduledExecutor, sslRefreshScheduledExecutor, openTelemetry);
+        TlsFactorySupport.initializeBlocking(this.tlsFactory, initContext);
+        this.reloadableServerTls = JettyTlsFactory.createReloadingServerFactory(this.tlsFactory, TlsPurpose.WEB,
+                config.getTlsProvider(), config.isTlsRequireTrustedClientCertOnConnect(),
+                config.isTlsAllowInsecureConnection(), config.getWebServiceTlsCiphers(),
+                config.getWebServiceTlsProtocols());
+        return this.reloadableServerTls.sslContextFactory();
     }
 
     static class CustomHeaderFilter implements Filter {

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/stats/PulsarProxyOpenTelemetry.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/stats/PulsarProxyOpenTelemetry.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.proxy.stats;
 
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.metrics.Meter;
 import java.io.Closeable;
 import lombok.Getter;
@@ -32,6 +33,11 @@ public class PulsarProxyOpenTelemetry implements Closeable {
 
     private final OpenTelemetryService openTelemetryService;
 
+    // PIP-478: the OpenTelemetry root, so a component's TlsFactoryInitContext gets a real handle (the
+    // pulsar.tls.reload / last_reload_success instruments) instead of OpenTelemetry.noop().
+    @Getter
+    private final OpenTelemetry openTelemetry;
+
     @Getter
     private final Meter meter;
 
@@ -41,7 +47,8 @@ public class PulsarProxyOpenTelemetry implements Closeable {
                 .serviceName(SERVICE_NAME)
                 .serviceVersion(PulsarVersion.getVersion())
                 .build();
-        meter = openTelemetryService.getOpenTelemetry().getMeter(INSTRUMENTATION_SCOPE_NAME);
+        openTelemetry = openTelemetryService.getOpenTelemetry();
+        meter = openTelemetry.getMeter(INSTRUMENTATION_SCOPE_NAME);
     }
 
     @Override

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/AuthedAdminProxyHandlerNewTlsPathTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/AuthedAdminProxyHandlerNewTlsPathTest.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.proxy.server;
+
+import org.apache.pulsar.broker.tls.TlsFactorySupport;
+
+/**
+ * The BROKER_CLIENT auth-material fold gate (PIP-478 stage 3c): re-runs {@link AuthedAdminProxyHandlerTest}
+ * with the <em>new</em> PIP-478 broker-client TLS path selected (a non-blank {@code brokerClientTlsFactoryClassName}
+ * makes {@code TlsFactorySupport.selectPath} choose {@code NEW}). The proxy's
+ * {@code brokerClientAuthenticationPlugin=AuthenticationTls} certificate must be folded over the (blank)
+ * {@code brokerClient*FilePath} policy, or the proxy would present no / the wrong identity to the broker and
+ * forwarded-principal authorization would fail (the flip-CI blocker). The superclass keeps exercising the
+ * legacy path unchanged.
+ */
+public class AuthedAdminProxyHandlerNewTlsPathTest extends AuthedAdminProxyHandlerTest {
+
+    @Override
+    protected void customizeProxyConfiguration(ProxyConfiguration proxyConfig) {
+        // Select the built-in default PIP-478 factory for the broker-client (BROKER_CLIENT) purpose.
+        proxyConfig.setBrokerClientTlsFactoryClassName(TlsFactorySupport.DEFAULT_FACTORY);
+    }
+}

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/AuthedAdminProxyHandlerTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/AuthedAdminProxyHandlerTest.java
@@ -110,6 +110,10 @@ public class AuthedAdminProxyHandlerTest extends MockedPulsarServiceBaseTest {
         LoadManagerReport report = new LoadReport(brokerUrl.toString(), brokerUrlTls.toString(), null, null);
         doReturn(report).when(discoveryProvider).nextBroker();
 
+        // PIP-478: overridable, no-op by default — lets a subclass select an alternate broker-client TLS path
+        // (e.g. the new PIP-478 factory) without altering this test's behavior.
+        customizeProxyConfiguration(proxyConfig);
+
         ServletHolder servletHolder =
                 new ServletHolder(new AdminProxyHandler(proxyConfig, discoveryProvider, proxyClientAuthentication));
         webServer.addServlet("/admin", servletHolder);
@@ -117,6 +121,15 @@ public class AuthedAdminProxyHandlerTest extends MockedPulsarServiceBaseTest {
 
         // start web-service
         webServer.start();
+    }
+
+    /**
+     * Hook for subclasses to select an alternate broker-client TLS path before the {@link AdminProxyHandler}
+     * is constructed. No-op by default, so this test runs the legacy path unchanged.
+     *
+     * @param proxyConfig the proxy configuration to customize
+     */
+    protected void customizeProxyConfiguration(ProxyConfiguration proxyConfig) {
     }
 
     @AfterMethod(alwaysRun = true)

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyTest.java
@@ -527,9 +527,7 @@ public class ProxyTest extends MockedPulsarServiceBaseTest {
                 return new ClientCnx(InstrumentProvider.NOOP, conf, eventLoopGroup) {
 
                     @Override
-                    protected ByteBuf newConnectCommand() throws Exception {
-                        authenticationDataProvider = authentication.getAuthData(remoteHostName);
-                        AuthData authData = authenticationDataProvider.authenticate(AuthData.INIT_AUTH_DATA);
+                    protected ByteBuf buildConnectCommand(AuthData authData) throws Exception {
                         BaseCommand cmd =
                                 Commands.newConnectWithoutSerialize(authentication.getAuthMethodName(), authData,
                                         this.protocolVersion, clientVersion, proxyToTargetBrokerAddress,

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyTlsFactoryMetricsTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyTlsFactoryMetricsTest.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.proxy.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import com.google.common.io.Resources;
+import io.netty.handler.ssl.SslContext;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.data.LongPointData;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import java.io.File;
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import org.apache.pulsar.broker.tls.TlsFactorySupport;
+import org.apache.pulsar.common.tls.PulsarTlsFactory;
+import org.apache.pulsar.common.tls.TlsPurpose;
+import org.apache.pulsar.proxy.stats.PulsarProxyOpenTelemetry;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * PIP-478 stage 4b: the proxy threads its OpenTelemetry root into the PROXY-purpose
+ * {@code TlsFactoryInitContext}, so the default file-based TLS factory's {@code pulsar.tls.reload} /
+ * {@code pulsar.tls.last_reload_success} instruments emit for real instead of being no-ops. The 4a
+ * in-memory-reader metrics pattern applied to a server component (the proxy).
+ */
+public class ProxyTlsFactoryMetricsTest {
+
+    private static final String CA_CERT = resource("certificate-authority/certs/ca.cert.pem");
+    private static final String PROXY_CERT = resource("certificate-authority/server-keys/proxy.cert.pem");
+    private static final String PROXY_KEY = resource("certificate-authority/server-keys/proxy.key-pk8.pem");
+
+    private static final String RELOAD_COUNTER = "pulsar.tls.reload";
+    private static final String LAST_RELOAD_SUCCESS_GAUGE = "pulsar.tls.last_reload_success";
+    private static final AttributeKey<String> PURPOSE = AttributeKey.stringKey("purpose");
+    private static final AttributeKey<String> RESULT = AttributeKey.stringKey("result");
+
+    private ScheduledExecutorService scheduler;
+    private final Executor directExecutor = Runnable::run;
+    private InMemoryMetricReader metricReader;
+    private OpenTelemetry openTelemetry;
+
+    @BeforeMethod
+    public void setUp() {
+        scheduler = Executors.newSingleThreadScheduledExecutor();
+        metricReader = InMemoryMetricReader.create();
+        openTelemetry = OpenTelemetrySdk.builder()
+                .setMeterProvider(SdkMeterProvider.builder().registerMetricReader(metricReader).build())
+                .build();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void tearDown() {
+        scheduler.shutdownNow();
+    }
+
+    @Test
+    public void proxyOpenTelemetryExposesRealRoot() {
+        ProxyConfiguration config = new ProxyConfiguration();
+        config.setClusterName("test");
+        try (PulsarProxyOpenTelemetry proxyOtel = new PulsarProxyOpenTelemetry(config)) {
+            assertThat(proxyOtel.getOpenTelemetry())
+                    .as("the proxy exposes a real OpenTelemetry root (not OpenTelemetry.noop()) to feed its "
+                            + "TlsFactoryInitContext")
+                    .isNotNull()
+                    .isNotSameAs(OpenTelemetry.noop());
+        }
+    }
+
+    @Test
+    public void proxyServerFactoryEmitsTlsReloadThroughWiredRoot() throws Exception {
+        ProxyConfiguration config = new ProxyConfiguration();
+        config.setTlsCertificateFilePath(PROXY_CERT);
+        config.setTlsKeyFilePath(PROXY_KEY);
+        config.setTlsTrustCertsFilePath(CA_CERT);
+
+        // Exactly the proxy's default PROXY-purpose factory, initialized with a real OpenTelemetry root — the
+        // wiring ServiceChannelInitializer performs via proxyService.getOpenTelemetry().getOpenTelemetry().
+        PulsarTlsFactory factory = ProxyTlsFactories.serverFactory(config, TlsPurpose.PROXY,
+                config.getTlsCiphers(), config.getTlsProtocols());
+        factory.initialize(TlsFactorySupport.initContext(Map.of(), scheduler, directExecutor, openTelemetry)).join();
+        // The initial material load of the PROXY purpose records one successful reload.
+        factory.createInstance(TlsPurpose.PROXY, SslContext.class).join().get().dispose();
+
+        Collection<MetricData> metrics = metricReader.collectAllMetrics();
+        // TlsPurpose.PROXY.name() is the lowercase wire label "proxy".
+        assertThat(counter(metrics, "proxy", "success"))
+                .as("the proxy TLS factory records a successful pulsar.tls.reload through the wired root")
+                .isEqualTo(1L);
+        assertThat(counter(metrics, "proxy", "failure")).isEqualTo(0L);
+        assertThat(gauge(metrics, "proxy")).as("last_reload_success gauge is set on success").isPositive();
+        factory.close();
+    }
+
+    private long counter(Collection<MetricData> metrics, String purpose, String result) {
+        return metrics.stream()
+                .filter(m -> m.getName().equals(RELOAD_COUNTER))
+                .flatMap(m -> m.getLongSumData().getPoints().stream())
+                .filter(p -> purpose.equals(p.getAttributes().get(PURPOSE))
+                        && result.equals(p.getAttributes().get(RESULT)))
+                .mapToLong(LongPointData::getValue)
+                .findFirst()
+                .orElse(0L);
+    }
+
+    private long gauge(Collection<MetricData> metrics, String purpose) {
+        return metrics.stream()
+                .filter(m -> m.getName().equals(LAST_RELOAD_SUCCESS_GAUGE))
+                .flatMap(m -> m.getLongGaugeData().getPoints().stream())
+                .filter(p -> purpose.equals(p.getAttributes().get(PURPOSE)))
+                .mapToLong(LongPointData::getValue)
+                .findFirst()
+                .orElse(-1L);
+    }
+
+    private static String resource(String name) {
+        return new File(Resources.getResource(name).getPath()).getAbsolutePath();
+    }
+}

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyTlsFactoryTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyTlsFactoryTest.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.proxy.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+import java.util.Optional;
+import lombok.Cleanup;
+import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
+import org.apache.pulsar.broker.authentication.AuthenticationService;
+import org.apache.pulsar.client.api.Authentication;
+import org.apache.pulsar.client.api.AuthenticationFactory;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.common.configuration.PulsarConfigurationLoader;
+import org.apache.pulsar.metadata.impl.ZKMetadataStore;
+import org.mockito.Mockito;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ * PIP-478 stage 2b: verifies the proxy serves TLS on the new {@code PulsarTlsFactory} path
+ * (selected by {@code tlsFactoryClassName=default}) for the binary front-end (purpose PROXY) and, by
+ * starting the TLS web server, the WEB purpose. The legacy PIP-337 path is exercised by
+ * {@link ProxyTlsTest}, which must remain green.
+ */
+public class ProxyTlsFactoryTest extends MockedPulsarServiceBaseTest {
+
+    private ProxyService proxyService;
+    private final ProxyConfiguration proxyConfig = new ProxyConfiguration();
+    private Authentication proxyClientAuthentication;
+
+    @Override
+    @BeforeClass
+    protected void setup() throws Exception {
+        internalSetup();
+        setupDefaultTenantAndNamespace();
+
+        proxyConfig.setServicePort(Optional.of(0));
+        proxyConfig.setBrokerProxyAllowedTargetPorts("*");
+        proxyConfig.setServicePortTls(Optional.of(0));
+        proxyConfig.setWebServicePort(Optional.of(0));
+        proxyConfig.setWebServicePortTls(Optional.of(0));
+        proxyConfig.setTlsEnabledWithBroker(false);
+        proxyConfig.setTlsCertificateFilePath(PROXY_CERT_FILE_PATH);
+        proxyConfig.setTlsKeyFilePath(PROXY_KEY_FILE_PATH);
+        // Select the new PIP-478 TLS SPI (built-in file-based factory) for the proxy server purposes.
+        proxyConfig.setTlsFactoryClassName("default");
+        proxyConfig.setMetadataStoreUrl(DUMMY_VALUE);
+        proxyConfig.setConfigurationMetadataStoreUrl(GLOBAL_DUMMY_VALUE);
+        proxyConfig.setClusterName(configClusterName);
+
+        proxyClientAuthentication = AuthenticationFactory.create(proxyConfig.getBrokerClientAuthenticationPlugin(),
+                proxyConfig.getBrokerClientAuthenticationParameters());
+        proxyClientAuthentication.start();
+
+        proxyService = Mockito.spy(new ProxyService(proxyConfig, new AuthenticationService(
+                PulsarConfigurationLoader.convertFrom(proxyConfig)), proxyClientAuthentication));
+        doReturn(registerCloseable(new ZKMetadataStore(mockZooKeeper)))
+                .when(proxyService).createLocalMetadataStore();
+        doReturn(registerCloseable(new ZKMetadataStore(mockZooKeeperGlobal))).when(proxyService)
+                .createConfigurationMetadataStore();
+
+        proxyService.start();
+    }
+
+    @Override
+    @AfterClass(alwaysRun = true)
+    protected void cleanup() throws Exception {
+        internalCleanup();
+        if (proxyService != null) {
+            proxyService.close();
+        }
+        if (proxyClientAuthentication != null) {
+            proxyClientAuthentication.close();
+        }
+    }
+
+    @Test
+    public void testProducerOverProxyTlsFactory() throws Exception {
+        @Cleanup
+        PulsarClient client = PulsarClient.builder()
+                .serviceUrl(proxyService.getServiceUrlTls())
+                .allowTlsInsecureConnection(false)
+                .tlsTrustCertsFilePath(CA_CERT_FILE_PATH).build();
+
+        @Cleanup
+        Producer<byte[]> producer = client.newProducer(Schema.BYTES)
+                .topic("persistent://public/default/tls-factory-topic").create();
+
+        for (int i = 0; i < 10; i++) {
+            producer.send("test".getBytes());
+        }
+        assertThat(producer.isConnected()).isTrue();
+    }
+}

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/SslContextFallbackSynthesisTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/SslContextFallbackSynthesisTest.java
@@ -1,0 +1,224 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.proxy.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.handler.ssl.SslContext;
+import java.time.Duration;
+import java.util.Optional;
+import lombok.Cleanup;
+import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
+import org.apache.pulsar.broker.authentication.AuthenticationService;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.api.Authentication;
+import org.apache.pulsar.client.api.AuthenticationFactory;
+import org.apache.pulsar.client.api.v5.Message;
+import org.apache.pulsar.client.api.v5.Producer;
+import org.apache.pulsar.client.api.v5.PulsarClient;
+import org.apache.pulsar.client.api.v5.QueueConsumer;
+import org.apache.pulsar.client.api.v5.schema.Schema;
+import org.apache.pulsar.common.configuration.PulsarConfigurationLoader;
+import org.apache.pulsar.metadata.impl.ZKMetadataStore;
+import org.mockito.Mockito;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ * PIP-478 (F1): a custom {@link org.apache.pulsar.common.tls.PulsarTlsFactory} that supplies <em>only</em>
+ * the JDK {@code SSLContext} (returning {@code empty()} for the Netty class) drives the framework's
+ * {@code SSLContext}-fallback synthesis across the binary and HTTP consumers. One broker and one proxy are
+ * wired to {@link SslContextOnlyTlsFactory}, and the scenarios verify that the broker binary listener, the
+ * client binary transport, the broker admin client, and the proxy's server + broker-client contexts all use
+ * the framework-synthesized Netty contexts.
+ *
+ * <p><b>Coverage note.</b> The proxy&rarr;broker <em>lookup</em> data path (client&rarr;proxy&rarr;broker
+ * produce/consume) is <em>not</em> asserted here: the proxy's lookup {@code ConnectionPool} does not resolve
+ * a client TLS factory for its broker-facing config, so that path fails with a null-factory NPE
+ * independently of this change (reproduced by {@code ProxyKeyStoreTlsTransportTest.testProducer} on this
+ * branch). Instead the proxy's server (PROXY) and broker-client (BROKER_CLIENT) synthesized contexts are
+ * verified at proxy startup and via {@link ProxyService#getBrokerClientSslContext()}.
+ */
+public class SslContextFallbackSynthesisTest extends MockedPulsarServiceBaseTest {
+
+    private static final String FACTORY = SslContextOnlyTlsFactory.class.getName();
+
+    private ProxyService proxyService;
+    private final ProxyConfiguration proxyConfig = new ProxyConfiguration();
+    private Authentication proxyClientAuthentication;
+
+    @Override
+    @BeforeClass
+    protected void setup() throws Exception {
+        SslContextOnlyTlsFactory.resetNettyRequestCount();
+
+        // Broker: BROKER (binary) + WEB purposes served by the SSLContext-only factory; the broker's own
+        // admin client (CLIENT_DEFAULT) too via brokerClientTlsFactoryClassName.
+        conf.setWebServicePortTls(Optional.of(0));
+        conf.setBrokerServicePortTls(Optional.of(0));
+        conf.setTlsAllowInsecureConnection(true);
+        conf.setTlsRequireTrustedClientCertOnConnect(false);
+        conf.setTlsFactoryClassName(FACTORY);
+        conf.setTlsFactoryConfig(pemParams(BROKER_CERT_FILE_PATH, BROKER_KEY_FILE_PATH));
+        conf.setBrokerClientTlsEnabled(true);
+        conf.setBrokerClientTlsFactoryClassName(FACTORY);
+        conf.setBrokerClientTlsFactoryConfig(pemParams(BROKER_CERT_FILE_PATH, BROKER_KEY_FILE_PATH));
+
+        internalSetup();
+        setupDefaultTenantAndNamespace();
+
+        // Proxy: PROXY (binary) + WEB served by the factory; proxy->broker (BROKER_CLIENT) too. Starting the
+        // proxy exercises the PROXY and BROKER_CLIENT synthesis paths (their subscriptions are established at
+        // startup, so a failed synthesis would fail start()).
+        proxyConfig.setServicePort(Optional.of(0));
+        proxyConfig.setServicePortTls(Optional.of(0));
+        proxyConfig.setWebServicePort(Optional.of(0));
+        proxyConfig.setWebServicePortTls(Optional.of(0));
+        proxyConfig.setBrokerProxyAllowedTargetPorts("*");
+        proxyConfig.setTlsAllowInsecureConnection(true);
+        proxyConfig.setTlsHostnameVerificationEnabled(false);
+        proxyConfig.setTlsFactoryClassName(FACTORY);
+        proxyConfig.setTlsFactoryConfig(pemParams(PROXY_CERT_FILE_PATH, PROXY_KEY_FILE_PATH));
+        proxyConfig.setTlsEnabledWithBroker(true);
+        proxyConfig.setBrokerClientTlsFactoryClassName(FACTORY);
+        proxyConfig.setBrokerClientTlsFactoryConfig(pemParams(BROKER_CERT_FILE_PATH, BROKER_KEY_FILE_PATH));
+        proxyConfig.setMetadataStoreUrl(DUMMY_VALUE);
+        proxyConfig.setConfigurationMetadataStoreUrl(GLOBAL_DUMMY_VALUE);
+        proxyConfig.setClusterName(configClusterName);
+
+        proxyClientAuthentication = AuthenticationFactory.create(proxyConfig.getBrokerClientAuthenticationPlugin(),
+                proxyConfig.getBrokerClientAuthenticationParameters());
+        proxyClientAuthentication.start();
+
+        proxyService = Mockito.spy(new ProxyService(proxyConfig, new AuthenticationService(
+                PulsarConfigurationLoader.convertFrom(proxyConfig)), proxyClientAuthentication));
+        doReturn(registerCloseable(new ZKMetadataStore(mockZooKeeper)))
+                .when(proxyService).createLocalMetadataStore();
+        doReturn(registerCloseable(new ZKMetadataStore(mockZooKeeperGlobal))).when(proxyService)
+                .createConfigurationMetadataStore();
+        proxyService.start();
+    }
+
+    @Override
+    @AfterClass(alwaysRun = true)
+    protected void cleanup() throws Exception {
+        internalCleanup();
+        if (proxyService != null) {
+            proxyService.close();
+        }
+        if (proxyClientAuthentication != null) {
+            proxyClientAuthentication.close();
+        }
+    }
+
+    /**
+     * Client binary transport (CLIENT_DEFAULT, one-shot endpoint form) directly to the broker binary listener
+     * (BROKER): two synthesized Netty contexts in a single produce/consume flow.
+     */
+    @Test
+    public void brokerAndClientBinaryOverSynthesizedContexts() throws Exception {
+        @Cleanup
+        PulsarClient client = PulsarClient.builder()
+                .serviceUrl(pulsar.getBrokerServiceUrlTls())
+                .tlsFactory(new SslContextOnlyTlsFactory(CA_CERT_FILE_PATH, null, null, false))
+                .build();
+
+        assertProduceConsume(client, "persistent://public/default/f1-binary-topic", "binary-direct");
+        assertThat(SslContextOnlyTlsFactory.nettyRequestCount())
+                .as("the framework requested the Netty SslContext and fell back to SSLContext synthesis")
+                .isPositive();
+    }
+
+    /**
+     * The broker's own admin client (AsyncHttpConnector, CLIENT_DEFAULT) over HTTPS against the broker web
+     * listener (WEB) — a synthesized context on the client-side HTTP path, proven by a read round-trip. This
+     * is the same {@link org.apache.pulsar.common.tls.impl.TlsContextAcquisition} subscribing-synthesis path
+     * the client HTTP-lookup {@code HttpClient} uses (the v5 client rejects an {@code https} service URL, so
+     * HttpClient cannot be driven directly here).
+     */
+    @Test
+    public void brokerAdminClientOverSynthesizedContext() throws Exception {
+        PulsarAdmin admin = pulsar.getAdminClient();
+        assertThat(admin.getServiceUrl()).startsWith("https://");
+        assertThat(admin.clusters().getClusters()).contains(configClusterName);
+    }
+
+    /**
+     * T2: a full client&rarr;proxy&rarr;broker produce/consume over TLS with the SSLContext-only factory on
+     * every synthesized leg. The client's binary transport, the proxy's PROXY server listener, and the
+     * proxy's BROKER_CLIENT data connection to the broker (via {@code DirectProxyHandler}) are all
+     * framework-synthesized Netty contexts; a successful round trip proves the SSLContext-fallback synthesis
+     * end-to-end on the proxy data path — not just at context construction.
+     *
+     * <p>(The proxy's binary-<em>lookup</em> {@code ConnectionPool} is wired to a default file-based factory
+     * built from the same broker-client PEM material rather than the custom class — by design, see
+     * {@link ProxyService#start()} — so it connects over TLS with a default context; that does not affect the
+     * synthesis proven on the client and proxy-data legs.)
+     */
+    @Test
+    public void clientThroughProxyToBrokerOverSynthesizedContexts() throws Exception {
+        int before = SslContextOnlyTlsFactory.nettyRequestCount();
+        @Cleanup
+        PulsarClient client = PulsarClient.builder()
+                .serviceUrl(proxyService.getServiceUrlTls())
+                .tlsFactory(new SslContextOnlyTlsFactory(CA_CERT_FILE_PATH, null, null, false))
+                .build();
+
+        assertProduceConsume(client, "persistent://public/default/f1-proxy-topic", "proxy-synth");
+        assertThat(SslContextOnlyTlsFactory.nettyRequestCount())
+                .as("the client's produce/consume through the proxy fell back to SSLContext synthesis")
+                .isGreaterThan(before);
+    }
+
+    /**
+     * The proxy's broker-client context (BROKER_CLIENT, subscribing form used by {@code DirectProxyHandler})
+     * is a usable framework-synthesized Netty context, and the proxy started with the SSLContext-only factory
+     * (proving the PROXY-purpose synthesis at startup).
+     */
+    @Test
+    public void proxyBrokerClientContextIsSynthesized() throws Exception {
+        SslContext brokerClientContext = proxyService.getBrokerClientSslContext();
+        assertThat(brokerClientContext).as("proxy BROKER_CLIENT context synthesized from the JDK SSLContext")
+                .isNotNull();
+        assertThat(brokerClientContext.isClient()).isTrue();
+        // Building an SslHandler proves the synthesized context is a functional client context.
+        assertThat(brokerClientContext.newHandler(ByteBufAllocator.DEFAULT, "localhost", 6651)).isNotNull();
+    }
+
+    private static void assertProduceConsume(PulsarClient client, String topic, String payload) throws Exception {
+        @Cleanup
+        Producer<String> producer = client.newProducer(Schema.string()).topic(topic).create();
+
+        @Cleanup
+        QueueConsumer<String> consumer = client.newQueueConsumer(Schema.string())
+                .topic(topic).subscriptionName("f1-sub").subscribe();
+
+        producer.newMessage().value(payload).send();
+
+        Message<String> received = consumer.receive(Duration.ofSeconds(10));
+        assertThat(received).isNotNull();
+        assertThat(received.value()).isEqualTo(payload);
+    }
+
+    private static String pemParams(String cert, String key) {
+        return "trust=" + CA_CERT_FILE_PATH + ",cert=" + cert + ",key=" + key + ",insecure=true";
+    }
+}

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/SslContextOnlyTlsFactory.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/SslContextOnlyTlsFactory.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.proxy.server;
+
+import io.netty.handler.ssl.SslContext;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.pulsar.common.tls.PulsarTlsFactory;
+import org.apache.pulsar.common.tls.TlsEndpoint;
+import org.apache.pulsar.common.tls.TlsFactoryInitContext;
+import org.apache.pulsar.common.tls.TlsHandle;
+import org.apache.pulsar.common.tls.TlsPolicy;
+import org.apache.pulsar.common.tls.TlsPurpose;
+import org.apache.pulsar.common.tls.impl.FileBasedTlsFactory;
+import org.apache.pulsar.common.tls.impl.FileBasedTlsFactorySettings;
+
+/**
+ * A PIP-478 test factory that supplies <em>only</em> the JDK {@code javax.net.ssl.SSLContext} for every
+ * purpose — it always returns {@link Optional#empty()} for the Netty {@code io.netty.handler.ssl.SslContext}
+ * — forcing the framework's {@code SSLContext}-fallback synthesis (F1). It delegates the actual material
+ * loading to a {@link FileBasedTlsFactory} so it exercises the real (rotating) load path.
+ *
+ * <p>Reflectively instantiable via the no-arg constructor (selected by {@code tlsFactoryClassName} /
+ * {@code brokerClientTlsFactoryClassName}, reading {@code trust}/{@code cert}/{@code key}/{@code insecure}
+ * from the factory config params), and directly constructible for adoption through the v5 client builder's
+ * {@code tlsFactory(...)}.
+ *
+ * <p>{@link #nettyRequestCount()} counts the {@code SslContext} requests it refused, so a test can assert the
+ * synthesis path was actually taken rather than silently skipped.
+ */
+public class SslContextOnlyTlsFactory implements PulsarTlsFactory {
+
+    private static final List<TlsPurpose> ALL_PURPOSES = List.of(
+            TlsPurpose.BROKER, TlsPurpose.PROXY, TlsPurpose.WEB,
+            TlsPurpose.BROKER_CLIENT, TlsPurpose.CLIENT_DEFAULT, TlsPurpose.CLIENT_OAUTH2);
+
+    private static final AtomicInteger NETTY_REQUESTS = new AtomicInteger();
+
+    private volatile String trustCertsFilePath;
+    private volatile String certificateFilePath;
+    private volatile String keyFilePath;
+    private volatile boolean allowInsecureConnection;
+    private volatile FileBasedTlsFactory delegate;
+
+    /** Reflective (class-name) constructor: material comes from the factory config params. */
+    public SslContextOnlyTlsFactory() {
+    }
+
+    /** Direct constructor for v5 client adoption: material is supplied explicitly. */
+    public SslContextOnlyTlsFactory(String trustCertsFilePath, String certificateFilePath, String keyFilePath,
+                                    boolean allowInsecureConnection) {
+        this.trustCertsFilePath = trustCertsFilePath;
+        this.certificateFilePath = certificateFilePath;
+        this.keyFilePath = keyFilePath;
+        this.allowInsecureConnection = allowInsecureConnection;
+    }
+
+    /** Total number of Netty {@code SslContext} requests this factory refused (across all instances). */
+    public static int nettyRequestCount() {
+        return NETTY_REQUESTS.get();
+    }
+
+    public static void resetNettyRequestCount() {
+        NETTY_REQUESTS.set(0);
+    }
+
+    @Override
+    public CompletableFuture<Void> initialize(TlsFactoryInitContext context) {
+        Map<String, String> params = context.params();
+        if (trustCertsFilePath == null) {
+            trustCertsFilePath = StringUtils.trimToNull(params.get("trust"));
+        }
+        if (certificateFilePath == null) {
+            certificateFilePath = StringUtils.trimToNull(params.get("cert"));
+        }
+        if (keyFilePath == null) {
+            keyFilePath = StringUtils.trimToNull(params.get("key"));
+        }
+        if (params.containsKey("insecure")) {
+            allowInsecureConnection = Boolean.parseBoolean(params.get("insecure"));
+        }
+        TlsPolicy policy = TlsPolicy.builder()
+                .format(TlsPolicy.Format.PEM)
+                .trustCertsFilePath(trustCertsFilePath)
+                .certificateFilePath(certificateFilePath)
+                .keyFilePath(keyFilePath)
+                .allowInsecureConnection(allowInsecureConnection)
+                .enableHostnameVerification(false)
+                .build();
+        Map<TlsPurpose, TlsPolicy> policies = new LinkedHashMap<>();
+        for (TlsPurpose purpose : ALL_PURPOSES) {
+            policies.put(purpose, policy);
+        }
+        this.delegate = new FileBasedTlsFactory(policies, FileBasedTlsFactorySettings.builder().build());
+        return delegate.initialize(context);
+    }
+
+    @Override
+    public <T> CompletableFuture<Optional<TlsHandle<T>>> createInstance(TlsPurpose purpose, Class<T> instanceClass) {
+        if (instanceClass == SslContext.class) {
+            NETTY_REQUESTS.incrementAndGet();
+            return CompletableFuture.completedFuture(Optional.empty());
+        }
+        return delegate.createInstance(purpose, instanceClass);
+    }
+
+    @Override
+    public <T> CompletableFuture<Optional<TlsHandle<T>>> createInstance(
+            TlsPurpose purpose, TlsEndpoint endpoint, Class<T> instanceClass) {
+        if (instanceClass == SslContext.class) {
+            NETTY_REQUESTS.incrementAndGet();
+            return CompletableFuture.completedFuture(Optional.empty());
+        }
+        return delegate.createInstance(purpose, endpoint, instanceClass);
+    }
+
+    @Override
+    public <T> CompletableFuture<Optional<TlsHandle<T>>> createInstance(
+            TlsPurpose purpose, Class<T> instanceClass, Consumer<T> onLoadOrReload) {
+        if (instanceClass == SslContext.class) {
+            NETTY_REQUESTS.incrementAndGet();
+            return CompletableFuture.completedFuture(Optional.empty());
+        }
+        return delegate.createInstance(purpose, instanceClass, onLoadOrReload);
+    }
+
+    @Override
+    public void close() {
+        if (delegate != null) {
+            delegate.close();
+        }
+    }
+}

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/service/ProxyServer.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/service/ProxyServer.java
@@ -22,24 +22,29 @@ import java.net.MalformedURLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import javax.servlet.Servlet;
 import javax.servlet.ServletException;
 import lombok.CustomLog;
 import org.apache.pulsar.broker.PulsarServerException;
+import org.apache.pulsar.broker.tls.TlsFactorySupport;
 import org.apache.pulsar.broker.web.JettyRequestLogFactory;
 import org.apache.pulsar.broker.web.JsonMapperProvider;
 import org.apache.pulsar.broker.web.WebExecutorThreadPool;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.util.ExecutorProvider;
-import org.apache.pulsar.common.util.DefaultPulsarSslFactory;
-import org.apache.pulsar.common.util.PulsarSslConfiguration;
-import org.apache.pulsar.common.util.PulsarSslFactory;
-import org.apache.pulsar.jetty.tls.JettySslContextFactory;
+import org.apache.pulsar.common.tls.PulsarTlsFactory;
+import org.apache.pulsar.common.tls.TlsFactoryInitContext;
+import org.apache.pulsar.common.tls.TlsPolicy;
+import org.apache.pulsar.common.tls.TlsPurpose;
+import org.apache.pulsar.common.tls.impl.FileBasedTlsFactory;
+import org.apache.pulsar.common.tls.impl.FileBasedTlsFactorySettings;
+import org.apache.pulsar.jetty.tls.JettyTlsFactory;
 import org.eclipse.jetty.ee8.servlet.ServletContextHandler;
 import org.eclipse.jetty.ee8.servlet.ServletHolder;
 import org.eclipse.jetty.ee8.websocket.server.config.JettyWebSocketServletContainerInitializer;
@@ -71,8 +76,10 @@ public class ProxyServer {
 
     private ServerConnector connector;
     private ServerConnector connectorTls;
-    private PulsarSslFactory sslFactory;
     private ScheduledExecutorService scheduledExecutorService;
+    // PIP-478 TLS SPI factory (the only server TLS path since the PIP-337 removal).
+    private PulsarTlsFactory tlsFactory;
+    private JettyTlsFactory.ReloadableServerTls reloadableServerTls;
 
     public ProxyServer(WebSocketProxyConfiguration config)
             throws PulsarClientException, MalformedURLException, PulsarServerException {
@@ -106,23 +113,12 @@ public class ProxyServer {
         // TLS enabled connector
         if (config.getWebServicePortTls().isPresent()) {
             try {
-                PulsarSslConfiguration sslConfiguration = buildSslConfiguration(config);
-                this.sslFactory = new DefaultPulsarSslFactory();
-                this.sslFactory.initialize(sslConfiguration);
-                this.sslFactory.createInternalSslContext();
                 this.scheduledExecutorService = Executors
                         .newSingleThreadScheduledExecutor(new ExecutorProvider
                                 .ExtendedThreadFactory("proxy-websocket-ssl-refresh"));
-                if (config.getTlsCertRefreshCheckDurationSec() > 0) {
-                    this.scheduledExecutorService.scheduleWithFixedDelay(this::refreshSslContext,
-                            config.getTlsCertRefreshCheckDurationSec(),
-                            config.getTlsCertRefreshCheckDurationSec(),
-                            TimeUnit.SECONDS);
-                }
-                SslContextFactory.Server sslCtxFactory =
-                        JettySslContextFactory.createSslContextFactory(config.getTlsProvider(),
-                                sslFactory, config.isTlsRequireTrustedClientCertOnConnect(),
-                                config.getWebServiceTlsCiphers(), config.getWebServiceTlsProtocols());
+                // PIP-478: the websocket proxy web listener uses the PulsarTlsFactory SPI (the built-in
+                // file-based factory by default, or a custom tlsFactoryClassName).
+                SslContextFactory.Server sslCtxFactory = createTlsFactoryWebServer(config);
                 List<ConnectionFactory> connectionFactories = new ArrayList<>();
                 if (config.isWebServiceHaProxyProtocolEnabled()) {
                     connectionFactories.add(new ProxyConnectionFactory());
@@ -209,6 +205,15 @@ public class ProxyServer {
         if (scheduledExecutorService != null) {
             scheduledExecutorService.shutdownNow();
         }
+        // PIP-478: dispose the TLS factory subscription and close the factory, if the new path was used.
+        if (this.reloadableServerTls != null) {
+            this.reloadableServerTls.subscription().dispose();
+            this.reloadableServerTls = null;
+        }
+        if (this.tlsFactory != null) {
+            this.tlsFactory.close();
+            this.tlsFactory = null;
+        }
     }
 
     public Optional<Integer> getListenPortHTTP() {
@@ -227,32 +232,60 @@ public class ProxyServer {
         }
     }
 
-    protected PulsarSslConfiguration buildSslConfiguration(WebSocketProxyConfiguration config) {
-        return PulsarSslConfiguration.builder()
-                .tlsKeyStoreType(config.getTlsKeyStoreType())
-                .tlsKeyStorePath(config.getTlsKeyStore())
-                .tlsKeyStorePassword(config.getTlsKeyStorePassword())
-                .tlsTrustStoreType(config.getTlsTrustStoreType())
-                .tlsTrustStorePath(config.getTlsTrustStore())
-                .tlsTrustStorePassword(config.getTlsTrustStorePassword())
-                .tlsCiphers(config.getWebServiceTlsCiphers())
-                .tlsProtocols(config.getWebServiceTlsProtocols())
-                .tlsTrustCertsFilePath(config.getTlsTrustCertsFilePath())
-                .tlsCertificateFilePath(config.getTlsCertificateFilePath())
-                .tlsKeyFilePath(config.getTlsKeyFilePath())
-                .allowInsecureConnection(config.isTlsAllowInsecureConnection())
-                .requireTrustedClientCertOnConnect(config.isTlsRequireTrustedClientCertOnConnect())
-                .tlsEnabledWithKeystore(config.isTlsEnabledWithKeyStore())
-                .serverMode(true)
-                .isHttps(true)
-                .build();
+    // PIP-478: build the PulsarTlsFactory for the WEB purpose and drive a vanilla Jetty
+    // SslContextFactory.Server via the SSLContext subscription (no cert refresh task).
+    private SslContextFactory.Server createTlsFactoryWebServer(WebSocketProxyConfiguration config) throws Exception {
+        this.tlsFactory = TlsFactorySupport.createFactory(config.getTlsFactoryClassName(), null,
+                () -> buildDefaultWebTlsFactory(config));
+        // PIP-478: the standalone WebSocket proxy has no OpenTelemetry infrastructure (no
+        // OpenTelemetryService / metrics root on its classpath), so the TLS-reload instruments stay no-ops
+        // here — unlike the proxy / functions-worker, which now thread their real OpenTelemetry root. (When
+        // the WebSocket service runs embedded in a broker, the broker's own listeners already emit the
+        // metrics.)
+        TlsFactoryInitContext initContext = TlsFactorySupport.initContext(
+                TlsFactorySupport.parseFactoryConfig(config.getTlsFactoryConfig()),
+                scheduledExecutorService, scheduledExecutorService);
+        TlsFactorySupport.initializeBlocking(this.tlsFactory, initContext);
+        this.reloadableServerTls = JettyTlsFactory.createReloadingServerFactory(this.tlsFactory, TlsPurpose.WEB,
+                config.getTlsProvider(), config.isTlsRequireTrustedClientCertOnConnect(),
+                config.isTlsAllowInsecureConnection(), config.getWebServiceTlsCiphers(),
+                config.getWebServiceTlsProtocols());
+        return this.reloadableServerTls.sslContextFactory();
     }
 
-    protected void refreshSslContext() {
-        try {
-            this.sslFactory.update();
-        } catch (Exception e) {
-            log.error().exception(e).log("Failed to refresh SSL context");
+    private static PulsarTlsFactory buildDefaultWebTlsFactory(WebSocketProxyConfiguration config) {
+        TlsPolicy.Builder policyBuilder = TlsPolicy.builder()
+                .allowInsecureConnection(config.isTlsAllowInsecureConnection())
+                .protocols(toList(config.getWebServiceTlsProtocols()))
+                .ciphers(toList(config.getWebServiceTlsCiphers()));
+        if (config.isTlsEnabledWithKeyStore()) {
+            policyBuilder.format(TlsPolicy.Format.KEYSTORE)
+                    .keyStoreType(config.getTlsKeyStoreType())
+                    .trustStoreType(config.getTlsTrustStoreType())
+                    .keyStorePath(config.getTlsKeyStore())
+                    .keyStorePassword(config.getTlsKeyStorePassword())
+                    .trustStorePath(config.getTlsTrustStore())
+                    .trustStorePassword(config.getTlsTrustStorePassword());
+        } else {
+            policyBuilder.format(TlsPolicy.Format.PEM)
+                    .trustCertsFilePath(config.getTlsTrustCertsFilePath())
+                    .certificateFilePath(config.getTlsCertificateFilePath())
+                    .keyFilePath(config.getTlsKeyFilePath());
         }
+        Map<TlsPurpose, TlsPolicy> policies = Map.of(TlsPurpose.WEB, policyBuilder.build());
+        long refresh = config.getTlsCertRefreshCheckDurationSec();
+        // The Jetty web path uses a JDK SSLContext, so the Netty engine selection is irrelevant here; the
+        // FileBasedTlsFactorySettings default (JDK engine) applies and keeps netty-handler off this module's
+        // compile classpath.
+        FileBasedTlsFactorySettings settings = FileBasedTlsFactorySettings.builder()
+                .requireTrustedClientCert(config.isTlsRequireTrustedClientCertOnConnect())
+                .refreshIntervalSeconds(refresh <= 0 ? FileBasedTlsFactorySettings.DEFAULT_REFRESH_INTERVAL_SECONDS
+                        : (int) Math.min(refresh, Integer.MAX_VALUE))
+                .build();
+        return new FileBasedTlsFactory(policies, settings);
+    }
+
+    private static List<String> toList(Set<String> values) {
+        return values == null ? List.of() : List.copyOf(values);
     }
 }

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/service/WebSocketProxyConfiguration.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/service/WebSocketProxyConfiguration.java
@@ -217,6 +217,16 @@ public class WebSocketProxyConfiguration implements PulsarConfiguration {
     @FieldContext(doc = "TLS cert refresh duration (in seconds). 0 means checking every new connection.")
     private long tlsCertRefreshCheckDurationSec = 300;
 
+    @FieldContext(doc = "PIP-478 TLS factory (PulsarTlsFactory) class name for the WebSocket proxy's web "
+            + "server TLS (purpose WEB). When set, the new PIP-478 TLS SPI is used instead of the built-in "
+            + "file-based TLS loading: an empty value or the literal 'default' selects the built-in default "
+            + "factory composed from these tls* settings, otherwise the named class is instantiated via its "
+            + "public no-arg constructor. This is the WebSocket proxy's first TLS-factory pluggability.")
+    private String tlsFactoryClassName = "";
+    @FieldContext(doc = "PIP-478 configuration parameters for tlsFactoryClassName. Accepts a JSON object or "
+            + "a comma-separated key=value list.")
+    private String tlsFactoryConfig = "";
+
     /**** --- KeyStore TLS config variables. --- ****/
     @FieldContext(
             doc = "Enable TLS with KeyStore type configuration for WebSocket"


### PR DESCRIPTION
### Motivation

PR 5 of the PIP-478 stacked series. With the neutral SPI (chunk 2), the default
file-based TLS factory (chunk 3), and the async v5 client auth engine (chunk 4 /
#238) in place, the server side still runs on the PIP-337 `sslFactoryPlugin`
path. This PR wires the server components onto the new `PulsarTlsFactory` SPI and
flips the default.

### Modifications

- Wires the broker, proxy, websocket, and functions-worker listeners plus their
  outbound clients (broker-as-client, proxy→broker, admin) onto the
  `PulsarTlsFactory` SPI via `DefaultBrokerTlsFactory` and the Jetty reload
  driver.
- Adds the `tlsFactory*` config keys (`tlsFactoryClassName`/`tlsFactoryConfig`
  and the `brokerClient` equivalents) across `ServiceConfiguration`,
  `ProxyConfiguration`, `WebSocketProxyConfiguration`, and `WorkerConfig`, plus
  the matching `conf/{broker,standalone,proxy,websocket,functions_worker}`
  entries. A blank value selects the built-in `DefaultBrokerTlsFactory` composed
  from the base `tls*` settings.
- Flips the server default from the PIP-337 `sslFactoryPlugin` path to the new
  SPI path for all server components and their internal clients.
- The deprecated PIP-337 `sslFactoryPlugin*` keys are rejected loudly at broker
  startup (string-literal FQCN comparison in `TlsFactorySupport`); they are
  retained only to detect and fail on a stale configuration.

The physical removal of the old PIP-337 SSL factory classes
(`PulsarSslFactory`/`DefaultPulsarSslFactory`/`JettySslContextFactory` and the
`SecurityUtility` decomposition) is deferred to the final PR (chunk 6), so this
change is forward-reference-free and compiles standalone on top of #238.

Stacks on #238.

### Verification

- `:pulsar-broker-common`, `:pulsar-broker`, `:pulsar-proxy`, `:pulsar-websocket`,
  and `:pulsar-functions:pulsar-functions-worker` compile (main + test).
- Scoped broker TLS suites: 12 tests (1 skipped), 0 failures —
  `TlsFactoryProducerConsumerTest`, `V5TlsProducerConsumerTest`,
  `ReplicatorTlsFactoryTest`, `BrokerAdminClientTlsFactoryTest`,
  `WorkerServerTlsFactoryTest`, `WebSocketProxyTlsFactoryTest`,
  `AdminOnlyOAuth2AuthTest`.
- Scoped proxy TLS suites: 14 tests, 0 failures — `ProxyTlsFactoryTest`,
  `ProxyTlsFactoryMetricsTest`, `SslContextFallbackSynthesisTest`,
  `AuthedAdminProxyHandler*Test`.
